### PR TITLE
fix: support process kill signal on Windows

### DIFF
--- a/src/tools/shell/tree_kill.py
+++ b/src/tools/shell/tree_kill.py
@@ -23,8 +23,8 @@ logger = get_logger(__name__)
 # Grace period between SIGTERM and SIGKILL (milliseconds).
 _KILL_GRACE_MS = 200
 
-
-def tree_kill(pid: int, sig: int = signal.SIGKILL) -> bool:
+DEFAULT_KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
+def tree_kill(pid: int, sig: int = DEFAULT_KILL_SIGNAL) -> bool:
     """Kill a process tree rooted at *pid*.
 
     Strategy:


### PR DESCRIPTION
## Summary

This PR fixes a Windows compatibility issue where `signal.SIGKILL` is unavailable and causes the `loom` CLI to fail during startup.

## Problem

On Windows, running the CLI fails with:

```text
AttributeError: module 'signal' has no attribute 'SIGKILL'
## Changes

- Added a fallback kill signal for platforms without `SIGKILL`
- Uses `SIGTERM` when `SIGKILL` is not available

## Test

```powershell
py -3.12 -m uv sync
py -3.12 -m uv run loom --help
## Test Result

- `uv sync` completed successfully
- `loom --help` starts successfully on Windows

## Environment

- OS: Windows
- Python: 3.12.10
- uv: 0.11.11
- Node.js: 24.15.0
- npm: 11.12.1