### PR TITLE
fix: use replace for atomic file writes on Windows

### DIFF
--- a/src/lib/checkpoint/checkpoint_manager.py
+++ b/src/lib/checkpoint/checkpoint_manager.py
@@ -324,7 +324,7 @@ class CheckpointManager:
         tid = threading.get_ident()
         tmp = path.with_suffix(f".{os.getpid()}.{tid}.tmp")
         tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
-        tmp.rename(path)
+        tmp.replace(path)
 
     @staticmethod
     def _read_json(path: Path) -> dict | None:

--- a/src/lib/heartbeat/_base.py
+++ b/src/lib/heartbeat/_base.py
@@ -95,6 +95,6 @@ class BaseHeartbeatWriter:
             self._path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self._path.with_suffix(".tmp")
             tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-            tmp.rename(self._path)
+            tmp.replace(self._path)
         except Exception:
             pass  # heartbeat must never crash the host process


### PR DESCRIPTION
This PR fixes Windows file write failures caused by `Path.rename()` when the target JSON file already exists.

On Windows, `Path.rename()` may fail with `WinError 183` if the destination file already exists. This affected checkpoint and heartbeat persistence.

Changes:
- Replace `tmp.rename(path)` with `tmp.replace(path)`
- Replace `tmp.rename(self._path)` with `tmp.replace(self._path)`

Verified by running:

```powershell
uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml