### PR TITLE
fix: make fake Codex runtime work on Windows

### DIFF
--- a/src/tools/codex/codex_tool.py
+++ b/src/tools/codex/codex_tool.py
@@ -192,8 +192,13 @@ class CodexExecRunner:
             )
 
         metadata["exit_code"] = completed.returncode
-        output = _extract_output(completed.stdout)
-        logs = completed.stderr.strip()
+
+        stdout = _coerce_str(completed.stdout)
+        stderr = _coerce_str(completed.stderr)
+
+        output = _extract_output(stdout)
+        logs = stderr
+
         if completed.returncode != 0:
             logger.warning(
                 "Local codex exec failed with exit_code=%s: cwd=%s",
@@ -205,7 +210,7 @@ class CodexExecRunner:
                 f"codex exec exited with code {completed.returncode}",
                 start,
                 output=output,
-                logs=logs or completed.stdout.strip(),
+                logs=logs or stdout,
                 metadata=metadata,
             )
 
@@ -311,7 +316,8 @@ def _run_checked(command: list[str], *, timeout: int, cwd: Path) -> dict[str, An
         return {"returncode": 1, "stdout": "", "stderr": str(exc)}
 
 
-def _extract_output(stdout: str) -> str:
+def _extract_output(stdout: Any) -> str:
+    stdout = _coerce_str(stdout)
     last_text = ""
     raw_lines: list[str] = []
     for line in stdout.splitlines():
@@ -387,10 +393,11 @@ def _truncate_output(output: str, max_chars: int) -> tuple[str, bool]:
     return output[:max_chars], True
 
 
-def _summarize_success(output: str) -> str:
-    if not output.strip():
+def _summarize_success(output: Any) -> str:
+    output = _coerce_str(output)
+    if not output:
         return "Codex execution completed with no output"
-    first_line = output.strip().splitlines()[0]
+    first_line = output.splitlines()[0]
     return first_line[:160]
 
 

--- a/src/tools/codex/codex_tool.py
+++ b/src/tools/codex/codex_tool.py
@@ -192,13 +192,8 @@ class CodexExecRunner:
             )
 
         metadata["exit_code"] = completed.returncode
-
-        stdout = _coerce_str(completed.stdout)
-        stderr = _coerce_str(completed.stderr)
-
-        output = _extract_output(stdout)
-        logs = stderr
-
+        output = _extract_output(completed.stdout)
+        logs = completed.stderr.strip()
         if completed.returncode != 0:
             logger.warning(
                 "Local codex exec failed with exit_code=%s: cwd=%s",
@@ -210,7 +205,7 @@ class CodexExecRunner:
                 f"codex exec exited with code {completed.returncode}",
                 start,
                 output=output,
-                logs=logs or stdout,
+                logs=logs or completed.stdout.strip(),
                 metadata=metadata,
             )
 
@@ -316,8 +311,7 @@ def _run_checked(command: list[str], *, timeout: int, cwd: Path) -> dict[str, An
         return {"returncode": 1, "stdout": "", "stderr": str(exc)}
 
 
-def _extract_output(stdout: Any) -> str:
-    stdout = _coerce_str(stdout)
+def _extract_output(stdout: str) -> str:
     last_text = ""
     raw_lines: list[str] = []
     for line in stdout.splitlines():
@@ -393,11 +387,10 @@ def _truncate_output(output: str, max_chars: int) -> tuple[str, bool]:
     return output[:max_chars], True
 
 
-def _summarize_success(output: Any) -> str:
-    output = _coerce_str(output)
-    if not output:
+def _summarize_success(output: str) -> str:
+    if not output.strip():
         return "Codex execution completed with no output"
-    first_line = output.splitlines()[0]
+    first_line = output.strip().splitlines()[0]
     return first_line[:160]
 
 

--- a/tests/tools_test/codex/test_codex_tool.py
+++ b/tests/tools_test/codex/test_codex_tool.py
@@ -57,6 +57,68 @@ exit 2
         encoding="utf-8",
     )
     fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+
+    if os.name == "nt":
+        fake_py = bin_dir / "codex_fake.py"
+        fake_py.write_text(
+            f"""import json
+import os
+import sys
+import time
+from pathlib import Path
+
+args_file = Path(r"{args_file}")
+stdin_file = Path(r"{stdin_file}")
+args = sys.argv[1:]
+
+with args_file.open("a", encoding="utf-8") as f:
+    f.write("CALL:" + " ".join(args) + "\\n")
+
+if args and args[0] == "--version":
+    print("codex-cli 9.9.9")
+    sys.exit(0)
+
+if len(args) >= 2 and args[0] == "login" and args[1] == "status":
+    if os.environ.get("FAKE_CODEX_LOGIN_FAIL") == "1":
+        print("not logged in", file=sys.stderr)
+        sys.exit(1)
+    print("Logged in")
+    sys.exit(0)
+
+if args and args[0] == "--search":
+    args = args[1:]
+
+if args and args[0] == "exec":
+    stdin_file.write_text(sys.stdin.read(), encoding="utf-8")
+
+    if os.environ.get("FAKE_CODEX_SLEEP"):
+        time.sleep(float(os.environ["FAKE_CODEX_SLEEP"]))
+
+    if os.environ.get("FAKE_CODEX_EXIT"):
+        print("codex failed", file=sys.stderr)
+        sys.exit(int(os.environ["FAKE_CODEX_EXIT"]))
+
+    if os.environ.get("FAKE_CODEX_BIG") == "1":
+        print(json.dumps({{"type": "agent_message", "message": "X" * 50}}))
+        sys.exit(0)
+
+    print('{{"type":"agent_message","message":"Codex final output"}}')
+    sys.exit(0)
+
+print("unexpected invocation: " + " ".join(args), file=sys.stderr)
+sys.exit(2)
+""",
+            encoding="utf-8",
+        )
+
+        fake_cmd = bin_dir / "codex.cmd"
+        fake_cmd.write_text(
+            f"""@echo off
+python "{fake_py}" %*
+""",
+            encoding="utf-8",
+        )
+
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
     return fake, args_file, stdin_file
 


### PR DESCRIPTION
## Summary

Related to #9.

This PR fixes the Windows fake Codex runtime issue found while validating the Codex Exec Demo.

The previous test helper only created a bash-based `bin/codex` script, which is unreliable on Windows. This PR adds a Windows `codex.cmd` wrapper and a Python fake runner so Codex Tool tests can run reliably on Windows without depending on bash.

## Changes

1. Fix Windows fake Codex runtime in tests

   - Keep the existing bash-based fake `bin/codex` for non-Windows platforms
   - Add a Windows `codex.cmd` wrapper
   - Add a Python fake runner for Windows
   - Simulate `codex --version`, `codex login status`, and `codex exec`
   - Avoid relying on bash in Windows test environments

## Verification

```powershell
python -m py_compile tests/tools_test/codex/test_codex_tool.py
uv run pytest tests/tools_test/codex/test_codex_tool.py
```

Result:

```text
15 passed, 2 warnings
```

Also manually verified the Codex Exec Demo:

```powershell
uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
```

Result:

- `codex1` succeeded and returned project name/version
- `codex2` succeeded and returned top-level directory summaries

## Notes

- The warnings are from dependency-related Pydantic deprecation messages and are not introduced by this change.
- This PR does not implement the full `loom check` command yet.
- This PR keeps `src/tools/codex/codex_tool.py` unchanged and focuses only on the confirmed Windows fake runtime issue.