### PR TITLE
fix: context_cache and system_prompt_boundary not inheriting from common

### DIFF
--- a/config/llm.example.yaml
+++ b/config/llm.example.yaml
@@ -1,60 +1,96 @@
-# AI Agents LLM 配置文件
+# ============================================================
+# AgentLoom LLM 模型配置文件（示例模板）
+# ============================================================
+#
+# 继承优先级（从高到低）：
+#   模型类型自己的值  >  common 的值  >  代码默认值
+#
+# 也就是说：只要模型类型里显式写了某个字段，就用它自己的值，
+# 不会去继承 common。只有「没写」的字段才会从 common 继承。
+#
+# 举例：
+#   common.base_url = "http://shared/v1"
+#
+#   powerful:
+#     base_url: "http://dedicated/v1"   ← 显式写了，用自己的
+#   summary:
+#     # base_url 没写                   ← 没写，继承 common 的
+#
+# 支持继承的字段：
+#   base_url, api_key, temperature, max_tokens, timeout,
+#   num_retries, retry_delay, max_retry_delay, extra_headers,
+#   requests_per_minute, context_cache, system_prompt_boundary,
+#   supports_native_tool_calls
+#
+# 注意：model（模型 ID）和 description 不参与继承，每个类型必须自己指定。
+#
+# 模型 ID 格式：{provider}/{model-name}
+# 常见 provider：openai, anthropic, gemini, ollama 等
+# 完整列表见 LiteLLM 官方文档
 
-# ============================================
-# 模型配置
-# ============================================
 model:
-  # 默认模型类型
+  # 全局默认模型类型（Agent 未指定 model_type 时使用）
   default_model_type: powerful
 
-  # 通用配置（作为默认值，当 powerful/fast/summary 未设置时使用）
-  # 平台名称可以选择: gemini, anthropic, openai。其他平台请查litellm 官方手册
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # common — 共享配置（其他类型未设置的字段从此继承）
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   common:
     model: "gemini/gemini-3_1-pro-preview"
     base_url: "xxxxxxx"
     api_key: "xxxxxxx"
-    # 速率限制：每分钟最大请求数（用于 smolagents，防止超出 API 限制）
     requests_per_minute: 10
-  
-  # 强大模型配置（用于复杂任务，如代码生成、复杂推理）
+
+    # --- 以下为可选参数（在 common 中设置后，所有类型自动继承）---
+    #
+    # temperature: 0.2          # 温度参数 (0.0~2.0)，越高越随机
+    # max_tokens: 128000        # 最大输出 token 数
+    # timeout: 300              # 请求超时（秒）
+    # num_retries: 5            # 失败重试次数
+    # retry_delay: 15.0         # 重试间隔（秒）
+    # max_retry_delay: 100.0    # 重试最大间隔（秒）
+    #
+    # context_cache: true       # 启用 prompt 缓存（LiteLLM 自动适配各平台）
+    #
+    # system_prompt_boundary: "<!-- DYNAMIC_BOUNDARY -->"
+    #   将 system prompt 拆分为静态（可缓存）和动态两部分，
+    #   提高缓存命中率。标记之后的内容视为动态部分。
+    #
+    # supports_native_tool_calls: "auto"
+    #   三态开关："auto" 运行时检测 / "true" 强制原生 / "false" 文本解析
+    #
+    # extra_headers:            # 自定义 HTTP 请求头
+    #   X-Custom-Header: "value"
+
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # powerful — 强大模型（复杂推理、代码生成）
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   powerful:
-    base_url: "xxxxxxx"
     model: "openai/azure-gpt-5_2"
-    # base_url 和 api_key 未设置时，使用 common 的配置
+    base_url: "xxxxxxx"           # 显式设置，不继承 common
     temperature: 0.2
     max_tokens: 128000
     timeout: 300
-    # context_cache: true enables automatic prompt caching for ALL models.
-    # litellm handles per-provider behavior (Anthropic preserves, OpenAI strips, etc.)
     context_cache: true
-    # system_prompt_boundary: optional marker to split system prompt into
-    # static (cached) and dynamic (uncached) segments for higher cache hit rates.
-    # Example: system_prompt_boundary: "<!-- DYNAMIC_BOUNDARY -->"
-    # supports_native_tool_calls: three-state flag for tool calling capability.
-    #   "auto" (default): detect at runtime from first API response
-    #   "true": always use native tool_calls (skip detection)
-    #   "false": always use multi-strategy text parsing fallback
-    # supports_native_tool_calls: "auto"
 
-  # 快速模型配置（用于简单任务，如意图识别、分类）
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # fast — 快速模型（意图识别、简单分类）
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   fast:
-    # 使用 openai/ 前缀让 LiteLLM 识别这是 OpenAI 兼容端点
-    base_url: "xxxxxxx"
     model: "gemini/gemini-3_1-pro-preview"
-    # api_key 未设置时，使用 common 的配置
-    # 注意：LiteLLM 对 gpt-5 模型要求 temperature=1.0
+    base_url: "xxxxxxx"           # 显式设置，不继承 common
     temperature: 1.0
     max_tokens: 50000
     timeout: 300
     context_cache: true
-  
-  # 摘要模型配置（用于文本摘要、内容提取）
+
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # summary — 摘要模型（上下文压缩、内容提取）
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   summary:
-    # Use Fast model config to avoid 401 Auth errors on the other endpoint
     model: "anthropic/claude-sonnet-4-5"
-    # api_key 未设置时，使用 common 的配置
-    # 注意：LiteLLM 对 gpt-5 模型要求 temperature=1.0
     temperature: 0.3
     max_tokens: 50000
     timeout: 300
     context_cache: true
+    # base_url 和 api_key 未设置，自动从 common 继承

--- a/src/lib/config/llm_config.py
+++ b/src/lib/config/llm_config.py
@@ -149,8 +149,13 @@ class LLMConfig(BaseModel):
                 retry_delay=float(resolved_retry_delay),
                 max_retry_delay=float(resolved_max_retry_delay),
                 extra_headers=resolved_extra_headers,
-                context_cache=BoolParser.parse(v.get("context_cache", DEFAULT_MODEL_CONTEXT_CACHE), default=DEFAULT_MODEL_CONTEXT_CACHE),
-                system_prompt_boundary=v.get("system_prompt_boundary", None),
+                context_cache=BoolParser.parse(
+                    v.get("context_cache", common_raw.get("context_cache", DEFAULT_MODEL_CONTEXT_CACHE)),
+                    default=DEFAULT_MODEL_CONTEXT_CACHE,
+                ),
+                system_prompt_boundary=v.get(
+                    "system_prompt_boundary", common_raw.get("system_prompt_boundary")
+                ),
                 description=str(v.get("description", f"Model type '{k}' loaded from YAML config")),
                 requests_per_minute=int(resolved_rpm),
                 supports_native_tool_calls=resolved_tool_calls,


### PR DESCRIPTION
## Problem

`llm.yaml` 文档声称模型类型未设置的字段会自动从 `common` 继承，但 `context_cache` 和 `system_prompt_boundary` 没有走 common fallback：

| 字段 | 实际行为 | 期望行为 |
|---|---|---|
| `context_cache` | 直接使用代码默认值 | 继承 common |
| `system_prompt_boundary` | 硬编码 `None` | 继承 common |

其余字段（`base_url`、`api_key`、`temperature`、`max_tokens`、`timeout`、`num_retries`、`retry_delay`、`max_retry_delay`、`extra_headers`、`requests_per_minute`、`supports_native_tool_calls`）的继承是正常的。

## Root Cause

`src/lib/config/llm_config.py` 的 `from_dict()` 中，这两个字段在构造 `LlmModelTypeSettings` 时只查了 `v.get(...)`，没有像其他字段那样加上 `common_raw.get(...)` 作为 fallback。

## Fix

```python
# 修复前
context_cache=BoolParser.parse(v.get("context_cache", DEFAULT_MODEL_CONTEXT_CACHE), ...)
system_prompt_boundary=v.get("system_prompt_boundary", None)

# 修复后
context_cache=BoolParser.parse(
    v.get("context_cache", common_raw.get("context_cache", DEFAULT_MODEL_CONTEXT_CACHE)), ...
)
system_prompt_boundary=v.get(
    "system_prompt_boundary", common_raw.get("system_prompt_boundary")
)
```

## Why these two should inherit, but `description` should not

| 字段 | 是否继承 | 理由 |
|---|---|---|
| `context_cache` | ✅ 继承 | 行为开关，和 `temperature`、`timeout` 同类。在 common 里设了 `context_cache: true`，显然是希望所有类型都开启缓存。 |
| `system_prompt_boundary` | ✅ 继承 | 框架级配置（system prompt 拆分标记），不跟具体模型绑定。所有类型应该用同一个标记来拆分。 |
| `description` | ❌ 不继承 | 每个模型类型的自我介绍，应该各不一样。如果继承 common 的描述，`powerful`、`fast`、`summary` 全显示一样的文字，反而失去区分意义。当前自动生成 `"Model type 'xxx' loaded from YAML config"` 虽不优雅，但至少能区分类型。 |
| `model` | ❌ 不继承 | 模型 ID，每个类型必须用不同的模型，继承没有意义。 |
---

## 可视化概览 (配置继承逻辑)

```mermaid
graph TD
    subgraph "配置文件 (llm.example.yaml)"
        A["model 配置块"]
        B["common 共享配置"]
        C["powerful 类型"]
        D["fast 类型"]
        E["summary 类型"]
        
        A --> B
        A --> C
        A --> D
        A --> E
    end
    
    subgraph "配置加载逻辑 (llm_config.py)"
        F["LLMConfig 解析器"]
        G["获取当前类型配置"]
        H["获取 common 配置"]
        I["代码默认值"]
        J["最终配置对象"]
    end
    
    B -.继承.-> C
    B -.继承.-> D
    B -.继承.-> E
    
    F --> G
    F --> H
    F --> I
    
    G -->|优先级 1: 显式设置| J
    H -->|优先级 2: common 继承| J
    I -->|优先级 3: 代码默认| J
    
    style B fill:#fff3e0,color:#e65100,stroke:#e65100,stroke-width:2px
    style H fill:#fff3e0,color:#e65100,stroke:#e65100,stroke-width:2px
    style J fill:#c8e6c9,color:#1a5e20,stroke:#1a5e20,stroke-width:2px
```

**继承优先级说明：**
1.  **最高优先级：** 模型类型自己显式设置的值（如 `powerful.base_url`）
2.  **次优先级：** `common` 部分的值（当模型类型未设置时继承）
3.  **最低优先级：** Python 代码中的默认值

---
## Documentation

同步更新了 `config/llm.example.yaml`：
- 明确继承优先级：**模型自己的值 > common > 代码默认值**
- 列出所有支持继承的字段
- 标注 `model` 和 `description` 不参与继承
- 在显式设置了值的字段旁标注"不继承 common"，避免用户误解

## Verification

```python
from src.lib.config.llm_config import LLMConfig

raw = {
    'model': {
        'common': {
            'model': 'openai/test',
            'context_cache': True,
            'system_prompt_boundary': '<!-- DYNAMIC -->',
        },
        'summary': {'model': 'openai/summary-model'},
    }
}
cfg = LLMConfig.from_dict(raw)
s = cfg.for_type('summary')
assert s.context_cache == True
assert s.system_prompt_boundary == '<!-- DYNAMIC -->'
```

现有测试全部通过（`test_llm_readonly_members.py`、`test_model_cfg_passthrough.py`、`test_llm_config_only_from_llm_yaml.py`：13/13）。
````
