### PR TITLE
fix: _replace_security_section regex fails on Python-stripped docstring

### DIFF
--- a/src/lib/permissions/policy_summary.py
+++ b/src/lib/permissions/policy_summary.py
@@ -210,8 +210,10 @@ def _replace_security_section(description: str, new_section: str) -> str:
     marker_pos = description.index(_SHELL_SECURITY_SECTION_MARKER)
 
     # Find the start of the next section after Security:
+    # Use \s* (not \s{4}) because Python strips common docstring indentation
+    # when storing __doc__, so section headers may have no leading whitespace.
     next_section_pattern = re.compile(
-        r'^\s{4}(?:Args|Returns|Raises|Examples):',
+        r'^\s*(?:Args|Returns|Raises|Examples):',
         re.MULTILINE,
     )
     after_marker = description[marker_pos:]
@@ -224,14 +226,7 @@ def _replace_security_section(description: str, new_section: str) -> str:
     else:
         end_pos = len(description)
 
-    # Build replacement: indent the new section to match docstring indentation
-    indented_lines = []
-    for line in new_section.splitlines():
-        if line.strip():
-            indented_lines.append(f"    {line}")
-        else:
-            indented_lines.append("")
-    replacement = "\n".join(indented_lines) + "\n\n"
+    replacement = new_section + "\n\n"
 
     return description[:marker_pos] + replacement + description[end_pos:]
 


### PR DESCRIPTION
## Problem

Running workflows with `shell_tool` fails with:

```
Cannot generate JSON schema for shell_tool because the docstring has no description for the argument 'command'
```

## Root Cause

`_replace_security_section()` in `src/lib/permissions/policy_summary.py` uses regex `r'^\s{4}(?:Args|Returns|Raises|Examples):'` to find the end of the `Security:` section.

However, Python automatically strips common indentation from `func.__doc__`. While the source code has `    Args:` (4 spaces), `__doc__` stores `Args:` with zero leading spaces. The regex never matches — the entire `Args:` section gets eaten → `get_json_schema()` can't find argument descriptions.

## Fix

Two changes in `_replace_security_section()`:

1. **Regex**: `\s{4}` → `\s*` — matches zero or more whitespace, compatible with Python's stripped docstrings
2. **Indentation**: Removed forced `"    "` prefix on replacement lines — the docstring already has no common indentation, adding 4 spaces creates inconsistent formatting

## Verification

```python
from src.tools.shell.shell_tool import shell_tool
from src.lib.permissions.policy_summary import _replace_security_section, build_shell_security_section
from smolagents.tools import get_json_schema

patched = _replace_security_section(shell_tool.__doc__, build_shell_security_section())
shell_tool.__doc__ = patched
get_json_schema(shell_tool)  # ✅ succeeds now
```

All existing tests pass (`test_policy_summary.py`: 19/19, `test_agent_function_schema_generation.py`: 3/3).
```
