### PR TITLE
test: wait for stall watchdog one-shot stop

### DIFF
--- a/tests/tools_test/shell/test_stall_watchdog.py
+++ b/tests/tools_test/shell/test_stall_watchdog.py
@@ -173,10 +173,10 @@ class TestStallWatchdog:
         )
         sw.start()
 
-        # Wait for detection.
+        # Wait for detection and for the one-shot watchdog to stop.
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:
-            if sw.stall_message is not None:
+            if sw.stall_message is not None and sw._stopped:
                 break
             time.sleep(0.2)
 


### PR DESCRIPTION
## Summary

This PR fixes a flaky `StallWatchdog` one-shot detection test observed in GitHub Actions.

The test previously waited only for `stall_message` to become non-`None`. Since the watchdog runs on a background thread, CI can observe `stall_message` before the one-shot watchdog has fully stopped. This PR makes the test wait for both the detected stall message and the stopped state.

## Changes

1. Make `test_one_shot_detection` wait for the final one-shot state

   - Wait until `sw.stall_message is not None`
   - Also wait until `sw._stopped` is true
   - Keep the production `StallWatchdog` implementation unchanged
   - Reduce timing-related flakiness in CI

## Verification

```powershell
python -m py_compile tests/tools_test/shell/test_stall_watchdog.py
uv run pytest tests/tools_test/shell/test_stall_watchdog.py::TestStallWatchdog::test_one_shot_detection -vv
uv run pytest tests/tools_test/shell/test_stall_watchdog.py
```

Result:

```text
27 passed, 2 warnings
```

## Notes

- The warnings are dependency-related Pydantic deprecation warnings from `litellm`.
- This PR only adjusts the test timing behavior.
- It does not change the `StallWatchdog` runtime implementation.