### PR TITLE
fix: remove implicit common model fallback

### DIFF
--- a/config/llm.example.yaml
+++ b/config/llm.example.yaml
@@ -4,26 +4,19 @@
 # 模型配置
 # ============================================
 model:
-  # 默认模型类型
+  # 全局默认模型类型；Agent 未指定 model_type 时必须配置这里
   default_model_type: powerful
 
-  # 通用配置（作为默认值，当 powerful/fast/summary 未设置时使用）
-  # 平台名称可以选择: gemini, anthropic, openai。其他平台请查litellm 官方手册
-  common:
-    model: "gemini/gemini-3_1-pro-preview"
-    base_url: "xxxxxxx"
-    api_key: "xxxxxxx"
-    # 速率限制：每分钟最大请求数（用于 smolagents，防止超出 API 限制）
-    requests_per_minute: 10
-  
   # 强大模型配置（用于复杂任务，如代码生成、复杂推理）
   powerful:
     base_url: "xxxxxxx"
-    model: "openai/azure-gpt-5_2"
-    # base_url 和 api_key 未设置时，使用 common 的配置
+    api_key: "xxxxxxx"
+    model: "openai/gpt-5_5"
     temperature: 0.2
     max_tokens: 128000
     timeout: 300
+    # 速率限制：每分钟最大请求数（用于 smolagents，防止超出 API 限制）
+    requests_per_minute: 10
     # context_cache: true enables automatic prompt caching for ALL models.
     # litellm handles per-provider behavior (Anthropic preserves, OpenAI strips, etc.)
     context_cache: true
@@ -40,8 +33,8 @@ model:
   fast:
     # 使用 openai/ 前缀让 LiteLLM 识别这是 OpenAI 兼容端点
     base_url: "xxxxxxx"
+    api_key: "xxxxxxx"
     model: "gemini/gemini-3_1-pro-preview"
-    # api_key 未设置时，使用 common 的配置
     # 注意：LiteLLM 对 gpt-5 模型要求 temperature=1.0
     temperature: 1.0
     max_tokens: 50000
@@ -51,8 +44,9 @@ model:
   # 摘要模型配置（用于文本摘要、内容提取）
   summary:
     # Use Fast model config to avoid 401 Auth errors on the other endpoint
-    model: "anthropic/claude-sonnet-4-5"
-    # api_key 未设置时，使用 common 的配置
+    model: "anthropic/claude-sonnet-4-6"
+    base_url: "xxxxxxx"
+    api_key: "xxxxxxx"
     # 注意：LiteLLM 对 gpt-5 模型要求 temperature=1.0
     temperature: 0.3
     max_tokens: 50000

--- a/docs/cn/agent_config.md
+++ b/docs/cn/agent_config.md
@@ -374,7 +374,7 @@ workflow: |
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `tools` | `list[dict]` | `[]` | 工具列表。详见 [第 4 节](#4-工具配置详解) |
-| `model_type` | `str` | 全局 `default_model_type` | 模型选择。详见 [3.7](#37-model_type--模型选择) |
+| `model_type` | `str` | 已配置的全局 `default_model_type` | 模型选择。详见 [3.7](#37-model_type--模型选择) |
 | `tool_call_type` | `str` | `"code_act"` | Agent 交互模式。详见 [3.6](#36-tool_call_type--交互模式) |
 | `execution_env` | `dict` | `{type: "local"}` | 执行环境配置。详见 [3.5](#35-execution_env--执行环境) |
 | `prompt` | `str` 或 `dict` | 框架内置 | 自定义 System Prompt 模板。详见 [3.9](#39-prompt--自定义-prompt) |
@@ -488,7 +488,7 @@ Agent YAML 不能直接修改 LLM 参数，但可以通过 `model_type` **选择
 
 **解析逻辑**：
 1. Agent YAML 指定了 `model_type` → 使用该值，如果该类型不存在，**直接报错 (`ValueError`)，不会静默回退**。
-2. 未指定 → 使用 `config/llm.yaml` 的 `model.default_model_type`（默认是 `"common"`）。如果 `default_model_type` 指向的类型也不存在，**同样直接报错**。
+2. 未指定 → 使用全局 `config/llm.yaml` 的 `model.default_model_type`。如果 `default_model_type` 未配置，或最终解析出的类型不存在，**同样直接报错**。
 
 ---
 
@@ -1581,7 +1581,7 @@ workflow: |
 ```yaml
 name: "text_analyzer"
 description: "纯文本分析 Agent，不需要 Shell"
-model_type: "common"
+model_type: "fast"
 tool_call_type: "code_act"
 
 # 不声明 shell_tool，Agent 无法执行任何 Shell 命令
@@ -1723,7 +1723,7 @@ grep -r 'SECURITY_BLOCK\|WHITELIST_REJECT\|PATH_VIOLATION' .logs/my_agent/
 | `description` | ✅ | ✅ | ✅ | `str` | — |
 | `workflow` | ✅ | ✅ | ✅ | `str`/`list[str]` | — |
 | `tools` | ❌ | ✅ | ✅ | `list[dict]` | `[]` |
-| `model_type` | ❌ | ✅ | ✅ | `str` | `"common" (依赖 llm.yaml)` |
+| `model_type` | ❌ | ✅ | ✅ | `str` | `config/llm.yaml` 中的 `model.default_model_type`；无隐式默认值 |
 | `tool_call_type` | ❌ | ✅ | ✅ | `str` | `"code_act"` |
 | `execution_env` | ❌ | ✅ | ✅ | `dict` | `{type: "local"}` |
 | `prompt` | ❌ | ✅ | ✅ | `str`/`dict` | 框架内置 |

--- a/docs/cn/config-overview.md
+++ b/docs/cn/config-overview.md
@@ -59,9 +59,10 @@ flowchart TD
 ### 隔离机制
 1. **拦截写入**：在加载 `system.yaml` 或 Agent YAML 时，系统会主动过滤掉 `model`, `llm`, `langfuse` 这三个顶级字段，并打印警告。
 2. **通过 `model_type` 关联**：Agent 在配置中只指定 `model_type: "powerful"`（模型分类标签）。
-3. **回退链 (Fallback)**：
-   当请求某个 `model_type` 的参数时，查找顺序为：
-   `models[model_type].参数` → `models.common.参数` → `代码内置默认值`。
+3. **参数读取链**：
+   当 `model_type` 已经解析完成后，参数查找顺序为：
+   `models[model_type].参数` → `代码内置默认值`。
+   如果 Agent YAML 和 `model.default_model_type` 都没有提供模型类型，模型调用会直接以 `ValueError` 失败。
 
 ## 4. 全局 C 单例 (Unified Access)
 
@@ -75,7 +76,7 @@ tools_list = C.get_nested("tools", "default", default=[])
 is_summary_enabled = C.get("smart_summary")
 
 # 2. 访问 LLM 配置
-api_key = C.llm_api_key                # 自动解析 common.api_key
+api_key = C.llm_api_key                # 读取默认模型类型的 api_key
 temp = C.get_model_config("powerful", "temperature")  # 获取 specific 模型的参数
 
 # 3. 访问原始合并字典

--- a/docs/cn/llm_config.md
+++ b/docs/cn/llm_config.md
@@ -15,9 +15,9 @@
 
 - [快速参考：完整 YAML 结构](#快速参考完整-yaml-结构)
 - [1. model.default_model_type — 全局默认模型类型](#1-modeldefault_model_type--全局默认模型类型)
-- [2. model.common — 通用后备配置](#2-modelcommon--通用后备配置)
+- [2. 模型类型命名规则](#2-模型类型命名规则)
 - [3. model.\<type\> — 模型类型配置](#3-modeltype--模型类型配置)
-- [4. 参数继承链](#4-参数继承链)
+- [4. 参数默认值](#4-参数默认值)
 - [5. langfuse — 可观测性配置（后续支持）](#5-langfuse--可观测性配置后续支持)
 - [6. 重试机制详解](#6-重试机制详解)
 - [7. Provider 前缀与特定行为](#7-provider-前缀与特定行为)
@@ -36,24 +36,14 @@
 # 模型配置
 # ============================================
 model:
-  # 全局默认模型类型（可选，默认为 "common"）
+  # 全局默认模型类型；若省略，未写 model_type 的 Agent 会直接报错
   default_model_type: "powerful"
-
-  # ━━━ 必填：通用共享配置（也是一个普通模型类型） ━━━
-  # 其他模型类型缺少的字段会自动从 common 继承
-  # Agent 也可以直接 model_type: "common" 使用它
-  common:
-    model: "openai/gpt-4o"            # ❗ 必填：LiteLLM 模型 ID
-    base_url: "https://llm-gateway-proxy.inner.chj.cloud/llm-gateway/v1"
-    api_key: "your-api-key"
-    requests_per_minute: 10
-    num_retries: 5
-    retry_delay: 15.0
-    max_retry_delay: 100.0
 
   # ━━━ 必填：摘要模型（上下文压缩 smart_summary 功能依赖） ━━━
   summary:
     model: "openai/azure-gpt-5-chat"
+    base_url: "https://llm-gateway.example.com/v1"
+    api_key: "your-api-key"
     description: "摘要模型，适合总结和提取"
     temperature: 1.0
     max_tokens: 2048
@@ -65,6 +55,7 @@ model:
   powerful:
     model: "anthropic/aws-claude-opus-4-5"
     base_url: "https://llm-gateway-proxy.inner.chj.cloud/llm-gateway"
+    api_key: "your-api-key"
     description: "高质量推理模型，适合复杂分析/代码任务"
     temperature: 0.2
     max_tokens: 8192
@@ -74,6 +65,8 @@ model:
   # 快速模型（意图识别、分类）
   fast:
     model: "anthropic/aws-claude-sonnet-4-5"
+    base_url: "https://llm-gateway.example.com/v1"
+    api_key: "your-api-key"
     description: "低延迟模型，适合简单任务"
     temperature: 1.0
     max_tokens: 1024
@@ -94,9 +87,9 @@ model:
 
 | 参数 | 类型 | 默认值 | 必选 | 说明 |
 |------|------|--------|------|------|
-| `model.default_model_type` | `str` | `"common"` | ❌ 否 | 全局默认模型类型。值必须是 `model` 块下定义的某个类型 key（如 `powerful`、`fast`、`summary`，或自定义类型名）。未配置时默认为 `"common"`，即使用 common 共享配置作为兜底 |
+| `model.default_model_type` | `str` | `""` | ❌ 否 | 全局默认模型类型。值必须是 `model` 块下定义的某个类型 key（如 `powerful`、`fast`、`summary`，或自定义类型名）。未配置时，未指定 `model_type` 的 Agent 会直接抛出 `ValueError` |
 
-### 1.1 完整 Fallback 链
+### 1.1 解析规则
 
 当 Agent 需要获取模型配置时，按以下优先级解析：
 
@@ -104,11 +97,11 @@ model:
 Agent YAML 中的 model_type（如 model_type: "fast"）
        ↓ (未指定时)
 config/llm.yaml 中的 default_model_type（如 default_model_type: "powerful"）
-       ↓ (也未配置时)
-common 共享配置作为兜底
+       ↓ (default_model_type 未配置时)
+ValueError
 ```
 
-> ⚠️ **注意**：如果 Agent YAML 明确指定了 `model_type` 但该类型在 `llm.yaml` 中不存在，框架会**直接报错**（`ValueError`），不会静默回退。这是为了尽早暴露配置错误。
+> ⚠️ **注意**：最终解析出的模型类型必须存在于 `llm.yaml`。如果 Agent YAML 明确指定了不存在的 `model_type`，全局默认类型指向不存在的类型，或 Agent 与全局配置都没有提供模型类型，框架都会**直接报错**（`ValueError`）。
 
 **示例**：
 
@@ -117,59 +110,48 @@ model:
   default_model_type: "powerful"   # 所有 Agent 默认使用 powerful 类型
   # default_model_type: "fast"     # 如果默认用快速模型
 
-  common:
-    base_url: "https://your-gateway.com/v1"
-    api_key: "your-key"
-
   powerful:
     model: "anthropic/claude-3-5-sonnet"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "your-key"
     temperature: 0.2
 ```
 
 ```yaml
 # Agent YAML 示例
 name: "my_agent"
-model_type: "powerful"    # 使用 powerful 类型，如果不写则使用 default_model_type
+model_type: "powerful"    # 使用 powerful 类型；如果不写，则使用已配置的 default_model_type
 ```
 
 ---
 
-## 2. model.common — 通用共享配置（必填）
+## 2. 模型类型命名规则
 
-`common` 是一个**必须配置的模型类型**，它有双重角色：
+`model` 块下除 `default_model_type` 外，所有值为 dict 的 key 都是模型类型名。框架不会对类型名做特殊语义处理，`powerful`、`fast`、`summary` 只是示例命名。
 
-1. **普通模型类型**：Agent 可以通过 `model_type: "common"` 直接使用它，和 `powerful`/`fast` 完全一样
-2. **共享参数池**：其他模型类型缺少的字段（如 `base_url`、`api_key`）会自动从 `common` 继承
+- `summary` 是上下文压缩（`smart_summary`）依赖的必需类型。
+- `default_model_type` 是保留 key，不是模型类型。
 
-> `common` 和其他模型类型**完全一样**，拥有相同的字段列表（见 [3.1 完整参数列表](#31-完整参数列表)）。`model` 字段也是必填的。
-
-**示例**：
+**示例：**
 
 ```yaml
 model:
-  common:
-    model: "openai/gpt-4o"              # ❗ 必填：LiteLLM 模型 ID
-    base_url: "https://your-gateway.com/v1"
-    api_key: "sk-your-api-key"
-    requests_per_minute: 10
-    num_retries: 5
-    retry_delay: 15.0
-    max_retry_delay: 100.0
-```
-
-**参数继承示例**：
-
-```yaml
-model:
-  common:
-    model: "openai/gpt-4o"              # 默认模型
-    base_url: "https://your-gateway.com/v1"
-    api_key: "sk-your-key"
+  default_model_type: "powerful"
 
   powerful:
-    model: "anthropic/claude-3-5-sonnet"  # 覆盖 common 的 model
-    temperature: 0.2                      # 覆盖 common 的 temperature
-    # base_url 和 api_key 未设置 → 自动继承 common 的值
+    model: "openai/gpt-4o"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "sk-your-api-key"
+
+  fast:
+    model: "openai/gpt-4o-mini"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "sk-your-api-key"
+
+  summary:
+    model: "openai/gpt-4o-mini"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "sk-your-api-key"
 ```
 
 ---
@@ -180,35 +162,34 @@ model:
 
 | Key | 是否必填 | 说明 |
 |-----|---------|------|
-| `common` | ❗ **必填** | 普通模型类型 + 其他类型的参数继承源，`default_model_type` 默认指向它 |
 | `summary` | ❗ **必填** | 上下文压缩（`smart_summary`）功能硬依赖此类型 |
-| `default_model_type` | ❌ 可选 | 保留 key，默认 `"common"` |
+| `default_model_type` | ❌ 可选 | 保留 key。没有隐式默认值；仅当所有 Agent 都显式指定 `model_type` 时才可省略 |
 | 其他任意 key | ❌ 可选 | 自由定义、删除、改名，如 `powerful`、`fast`、`code_review` 等 |
 
-除 `default_model_type` 外，`model` 块下的**所有 key 都会被解析为模型类型**（包括 `common`）。框架对类型名没有任何限制——`powerful`、`fast` 只是示例命名，你可以自由删除、重命名或新增。每个模型类型（包括 `common`）的 `model` 字段都是必填的。
+除 `default_model_type` 外，`model` 块下**所有值为 dict 的 key 都会被解析为模型类型**。框架对类型名没有任何限制——`powerful`、`fast` 只是示例命名，你可以自由删除、重命名或新增。每个模型类型的 `model` 字段都是必填的。
 
 **YAML 路径**：`model.<你的类型名>.*`（如 `model.powerful.*`、`model.my_llm.*`）
 **Pydantic 模型**：`LlmModelTypeSettings`
 
 ### 3.1 完整参数列表
 
-| 参数 | 类型 | 默认值 | 必选 | 继承自 common | 说明 |
-|------|------|--------|------|--------------|------|
-| `model` | `str` | — | ❗ **必填** | ❌ 不继承 | **LiteLLM 模型 ID**，必须带 Provider 前缀。格式：`{provider}/{model-name}`。例如：`openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `gemini/gemini-1.5-pro`。**未配置会在加载时直接报错。** |
-| `base_url` | `str` | `""` | ❌ 否 | ✅ 继承 | API 网关地址。未设置时继承 `common.base_url`。**注意：字段名是 `base_url`，不是 `api_base`** |
-| `api_key` | `str` | `""` | ❌ 否 | ✅ 继承 | API 认证密钥。未设置时继承 `common.api_key` |
-| `description` | `str` | `"Model type '{k}' loaded from YAML config"` | ❌ 否 | ❌ 不继承 | 模型的人类可读描述。用于日志和文档 |
-| `temperature` | `float` | `0.1` | ❌ 否 | ✅ 继承 | 创造力/随机性控制 (0.0 - 2.0)。详见 [3.2 temperature 建议](#32-temperature-配置建议) |
-| `max_tokens` | `int` \| `str` | `150000` | ❌ 否 | ✅ 继承 | 模型单次生成的最大 Token 数。特殊值 `"max"` 表示使用模型原生最大值 |
-| `timeout` | `int` | `60` | ❌ 否 | ✅ 继承 | 单次 HTTP 请求超时（秒）。超过此时间未响应则中断 |
-| `num_retries` | `int` | `5` | ❌ 否 | ✅ 继承 | API 调用失败重试次数 |
-| `retry_delay` | `float` | `15.0` | ❌ 否 | ✅ 继承 | 重试初始延迟（秒）。详见 [第 6 节](#6-重试机制详解) |
-| `max_retry_delay` | `float` | `100.0` | ❌ 否 | ✅ 继承 | 重试最大延迟（秒）。指数退避的上限 |
-| `extra_headers` | `dict` \| `null` | `null` | ❌ 否 | ✅ 继承（但不 merge） | 自定义 HTTP 请求头。**⚠️ 模型级别的 `extra_headers` 会完全覆盖 `common.extra_headers`，不做合并** |
-| `context_cache` | `bool` | `false` | ❌ 否 | ❌ 不继承 | 通用 Prompt 缓存优化。`true` 时框架对**所有模型**统一注入 `cache_control: {"type": "ephemeral"}`，litellm 根据 Provider 自动处理（Anthropic 保留、OpenAI 剥离、Vertex AI 转换为 Gemini 格式） |
-| `system_prompt_boundary` | `str` \| `null` | `null` | ❌ 否 | ❌ 不继承 | 系统提示词分割标记。设置后，系统提示词以此标记分割为 **静态（缓存）** + **动态（不缓存）** 两段，提升缓存命中率。例如：`"<!-- DYNAMIC_BOUNDARY -->"` |
-| `requests_per_minute` | `int` | `60` | ❌ 否 | ✅ 继承 | 该模型类型的速率限制 |
-| `supports_native_tool_calls` | `str` | `"auto"` | ❌ 否 | ✅ 继承 | 原生 tool_calls 能力标记。三态值：`"auto"` 运行时首次调用自动探测，`"true"` 强制使用原生路径，`"false"` 强制走文本解析兜底。详见 [3.6 supports_native_tool_calls 行为](#36-supports_native_tool_calls-行为) |
+| 参数 | 类型 | 默认值 | 必选 | 说明 |
+|------|------|--------|------|------|
+| `model` | `str` | — | ❗ **必填** | **LiteLLM 模型 ID**，必须带 Provider 前缀。格式：`{provider}/{model-name}`。例如：`openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `gemini/gemini-1.5-pro`。**未配置会在加载时直接报错。** |
+| `base_url` | `str` | `""` | ❌ 否 | API 网关地址。每个模型类型独立配置。**注意：字段名是 `base_url`，不是 `api_base`** |
+| `api_key` | `str` | `""` | ❌ 否 | API 认证密钥。每个模型类型独立配置 |
+| `description` | `str` | `"Model type '{k}' loaded from YAML config"` | ❌ 否 | 模型的人类可读描述。用于日志和文档 |
+| `temperature` | `float` | `0.1` | ❌ 否 | 创造力/随机性控制 (0.0 - 2.0)。详见 [3.2 temperature 建议](#32-temperature-配置建议) |
+| `max_tokens` | `int` \| `str` | `150000` | ❌ 否 | 模型单次生成的最大 Token 数。特殊值 `"max"` 表示使用模型原生最大值 |
+| `timeout` | `int` | `60` | ❌ 否 | 单次 HTTP 请求超时（秒）。超过此时间未响应则中断 |
+| `num_retries` | `int` | `5` | ❌ 否 | API 调用失败重试次数 |
+| `retry_delay` | `float` | `15.0` | ❌ 否 | 重试初始延迟（秒）。详见 [第 6 节](#6-重试机制详解) |
+| `max_retry_delay` | `float` | `100.0` | ❌ 否 | 重试最大延迟（秒）。指数退避的上限 |
+| `extra_headers` | `dict` \| `null` | `null` | ❌ 否 | 自定义 HTTP 请求头。每个模型类型独立配置，不做跨类型合并 |
+| `context_cache` | `bool` | `false` | ❌ 否 | 通用 Prompt 缓存优化。`true` 时框架对**所有模型**统一注入 `cache_control: {"type": "ephemeral"}`，litellm 根据 Provider 自动处理（Anthropic 保留、OpenAI 剥离、Vertex AI 转换为 Gemini 格式） |
+| `system_prompt_boundary` | `str` \| `null` | `null` | ❌ 否 | 系统提示词分割标记。设置后，系统提示词以此标记分割为 **静态（缓存）** + **动态（不缓存）** 两段，提升缓存命中率。例如：`"<!-- DYNAMIC_BOUNDARY -->"` |
+| `requests_per_minute` | `int` | `60` | ❌ 否 | 该模型类型的速率限制 |
+| `supports_native_tool_calls` | `str` | `"auto"` | ❌ 否 | 原生 tool_calls 能力标记。三态值：`"auto"` 运行时首次调用自动探测，`"true"` 强制使用原生路径，`"false"` 强制走文本解析兜底。详见 [3.6 supports_native_tool_calls 行为](#36-supports_native_tool_calls-行为) |
 
 ### 3.2 temperature 配置建议
 
@@ -233,20 +214,14 @@ model:
 
 ```yaml
 model:
-  common:
-    extra_headers:
-      X-Project: "AgentLoom"
-      X-Env: "dev"
-
   powerful:
-    extra_headers:          # ⚠️ 完全覆盖 common 的 extra_headers
+    extra_headers:
       X-Model-Tier: "powerful"
       X-Biz-Tag: "demo"
-    # 最终 powerful 的 headers = {X-Model-Tier: "powerful", X-Biz-Tag: "demo"}
-    # common 的 {X-Project, X-Env} 不会被合并进来
 
   fast:
-    # 未设置 extra_headers → 继承 common 的 {X-Project: "AgentLoom", X-Env: "dev"}
+    extra_headers:
+      X-Model-Tier: "fast"
 ```
 
 > 也可通过**环境变量**覆盖（JSON 字符串格式）：
@@ -344,27 +319,31 @@ Agent YAML 通过 `model_type` 字段引用你定义的类型名。
 model:
   default_model_type: "main"
 
-  common:
-    base_url: "https://your-gateway.com/v1"
-    api_key: "your-key"
-
   main:                          # ✅ 自定义名称，替代 powerful
     model: "anthropic/claude-3-5-sonnet"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "your-key"
     temperature: 0.2
 
   code_review:                   # ✅ 自定义类型
     model: "anthropic/claude-3-5-sonnet"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "your-key"
     temperature: 0.1
     max_tokens: 16384
     timeout: 600
 
   translation:                   # ✅ 自定义类型
     model: "openai/gpt-4o"
+    base_url: "https://api.openai.com/v1"
+    api_key: "your-openai-key"
     temperature: 0.3
     max_tokens: 4096
 
   summary:                       # 保留 summary 以支持 smart_summary 功能
     model: "openai/gpt-4o-mini"
+    base_url: "https://api.openai.com/v1"
+    api_key: "your-openai-key"
     temperature: 0.3
 ```
 
@@ -381,16 +360,14 @@ model_type: "code_review"        # 引用 llm.yaml 中定义的 code_review
 model:
   default_model_type: "default"
 
-  common:
-    base_url: "https://your-gateway.com/v1"
-    api_key: "your-key"
-
   default:
     model: "openai/gpt-4o"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "your-key"
     temperature: 0.3
 ```
 
-> 所有自定义类型与框架示例中的 `powerful`/`fast`/`summary` **完全等价**，享有同样的 common 继承机制。
+> 所有自定义类型与框架示例中的 `powerful`/`fast`/`summary` **完全等价**。每个类型独立声明自己的模型和参数。
 
 **示例**：
 
@@ -412,15 +389,17 @@ model:
 
   fast:
     model: "gemini/gemini-3_1-pro-preview"
+    base_url: "https://generativelanguage.googleapis.com/v1"
+    api_key: "gemini-key"
     temperature: 1.0
     max_tokens: 1024
     timeout: 60
     context_cache: true
-    # base_url 和 api_key 未设置，继承 common
 
   summary:
     model: "openai/azure-gpt-5-chat"
     base_url: "https://portal-k8s-prod.ep.chehejia.com/api/copilot/v3/openai/azure-gpt-5-chat/v1"
+    api_key: "summary-key"
     temperature: 1.0
     max_tokens: 2048
     timeout: 300
@@ -428,35 +407,33 @@ model:
 
 ---
 
-## 4. 参数继承链
+## 4. 参数默认值
 
-模型参数的最终值按以下优先级链从高到低解析：
+模型参数的最终值按以下规则解析：
 
 ```
 模型类型设置 (model.powerful.xxx)
-       ↓ (未设置时 fallback)
-通用设置 (model.common.xxx)
-       ↓ (未设置时 fallback)
+      ↓ (未设置时)
 代码默认值 (defaults.py)
 ```
 
-**具体继承规则**：
+**具体默认规则**：
 
-| 字段 | 继承行为 |
+| 字段 | 默认行为 |
 |------|----------|
-| `base_url` | model type → common → `""` |
-| `api_key` | model type → common → `""` |
-| `temperature` | model type → common → `0.1` |
-| `max_tokens` | model type → common → `150000` |
-| `timeout` | model type → common → `60` |
-| `num_retries` | model type → common → `5` |
-| `retry_delay` | model type → common → `15.0` |
-| `max_retry_delay` | model type → common → `100.0` |
-| `extra_headers` | model type → common → `null`（**覆盖，不 merge**） |
-| `requests_per_minute` | model type → common → `60` |
-| `model` | ❌ **不继承**，各类型独立设置 |
-| `description` | ❌ **不继承**，各类型独立设置 |
-| `context_cache` | ❌ **不继承**，默认 `false` |
+| `base_url` | 未设置时为 `""` |
+| `api_key` | 未设置时为 `""` |
+| `temperature` | 未设置时为 `0.1` |
+| `max_tokens` | 未设置时为 `150000` |
+| `timeout` | 未设置时为 `60` |
+| `num_retries` | 未设置时为 `5` |
+| `retry_delay` | 未设置时为 `15.0` |
+| `max_retry_delay` | 未设置时为 `100.0` |
+| `extra_headers` | 未设置时为 `null` |
+| `requests_per_minute` | 未设置时为 `60` |
+| `model` | ❗ 必填，不存在默认值 |
+| `description` | 未设置时自动生成 |
+| `context_cache` | 未设置时为 `false` |
 
 ---
 
@@ -571,17 +548,6 @@ litellm.completion failed (attempt 2/5): RateLimitError: Rate limit exceeded. Re
 
 ## 附录 A：完整 Pydantic 模型
 
-### LlmCommonSettings
-
-```python
-class LlmCommonSettings(BaseModel):
-    base_url: str = ""
-    api_key: str = ""
-    requests_per_minute: int = 60  # DEFAULT_MODEL_REQUESTS_PER_MINUTE
-```
-
-> **注**：尽管上述 Pydantic 模型仅显式声明了这三个字段，但在实际解析逻辑（`LLMConfig.from_dict`）中，框架会直接读取 YAML 中的 `common` 原始字典，从而为其他模型提供 `temperature`、`timeout`、`extra_headers` 等更多参数的默认值继承（Fallback）能力。
-
 ### LlmModelTypeSettings
 
 ```python
@@ -619,9 +585,8 @@ class LangfuseSettings(BaseModel):
 ```python
 class LLMConfig(BaseModel):
     langfuse: LangfuseSettings           # 预留，后续启用
-    common: LlmCommonSettings
-    default_model_type: str = "common"   # 未配置时默认为 "common"
-    models: dict[str, LlmModelTypeSettings]  # {"common": ..., "powerful": ..., "summary": ..., 或自定义类型}
+    default_model_type: str = ""         # 没有隐式模型类型默认值
+    models: dict[str, LlmModelTypeSettings]  # {"powerful": ..., "summary": ..., 或自定义类型}
 ```
 
 **运行时访问方式**：
@@ -661,17 +626,16 @@ model:
 
 ```yaml
 model:
-  common:
-    base_url: "http://localhost:11434"
-
   powerful:
     model: "ollama/llama3"
+    base_url: "http://localhost:11434"
     temperature: 0.3
     max_tokens: 4096
     timeout: 120
 
   fast:
     model: "ollama/phi3"
+    base_url: "http://localhost:11434"
     temperature: 0.7
     max_tokens: 1024
     timeout: 30
@@ -683,14 +647,11 @@ model:
 model:
   default_model_type: "powerful"
 
-  common:
-    api_key: "default-key"
-    requests_per_minute: 30
-
   powerful:
     model: "anthropic/aws-claude-opus-4-5"
     base_url: "https://your-anthropic-gateway.com"
     api_key: "anthropic-specific-key"
+    requests_per_minute: 30
     temperature: 0.2
     max_tokens: 8192
 
@@ -698,6 +659,7 @@ model:
     model: "openai/gpt-4o-mini"
     base_url: "https://api.openai.com/v1"
     api_key: "openai-specific-key"
+    requests_per_minute: 30
     temperature: 0.7
     max_tokens: 1024
 
@@ -705,6 +667,7 @@ model:
     model: "gemini/gemini-1.5-flash"
     base_url: "https://generativelanguage.googleapis.com/v1"
     api_key: "gemini-specific-key"
+    requests_per_minute: 30
     temperature: 0.3
     max_tokens: 2048
 ```
@@ -713,19 +676,21 @@ model:
 
 ```yaml
 model:
-  common:
-    base_url: "https://your-openai-proxy.com/v1"
-    api_key: "sk-your-key"
-
   powerful:
     model: "openai/gpt-4o"
+    base_url: "https://your-openai-proxy.com/v1"
+    api_key: "sk-your-key"
     temperature: 0.2
 
   fast:
     model: "openai/gpt-4o-mini"
+    base_url: "https://your-openai-proxy.com/v1"
+    api_key: "sk-your-key"
     temperature: 0.7
 
   summary:
     model: "openai/gpt-4o-mini"
+    base_url: "https://your-openai-proxy.com/v1"
+    api_key: "sk-your-key"
     temperature: 0.3
 ```

--- a/docs/en/agent_config.md
+++ b/docs/en/agent_config.md
@@ -372,7 +372,7 @@ workflow: |
 | Field | Type | Default | Description |
 |------|------|--------|------|
 | `tools` | `list[dict]` | `[]` | Tool list. See [Section 4](#4-tool-configuration-details) |
-| `model_type` | `str` | Global `default_model_type` | Model selection. See [3.7](#37-model_type--model-selection) |
+| `model_type` | `str` | Configured global `default_model_type` | Model selection. See [3.7](#37-model_type--model-selection) |
 | `tool_call_type` | `str` | `"code_act"` | Agent interaction mode. See [3.6](#36-tool_call_type--interaction-mode) |
 | `execution_env` | `dict` | `{type: "local"}` | Execution environment configuration. See [3.5](#35-execution_env--execution-environment) |
 | `prompt` | `str` or `dict` | Framework built-in | Custom System Prompt template. See [3.9](#39-prompt--custom-prompt) |
@@ -486,7 +486,7 @@ Custom type names from `llm.yaml` are also supported (e.g., `"code_review"`).
 
 **Resolution logic**:
 1. Agent YAML specifies `model_type` → Uses that value; if the type doesn't exist, **raises an error (`ValueError`) directly, no silent fallback**.
-2. Not specified → Uses `config/llm.yaml`'s `model.default_model_type` (defaults to `"common"`). If `default_model_type` points to a non-existent type, **also raises an error directly**.
+2. Not specified → Uses the global `config/llm.yaml` `model.default_model_type`. If `default_model_type` is omitted or the resolved type does not exist, **also raises an error directly**.
 
 ---
 
@@ -1546,7 +1546,7 @@ workflow: |
 ```yaml
 name: "text_analyzer"
 description: "Pure text analysis agent, no shell needed"
-model_type: "common"
+model_type: "fast"
 tool_call_type: "code_act"
 
 # No shell_tool declared — agent cannot execute any shell commands
@@ -1685,7 +1685,7 @@ These tolerance mechanisms significantly reduce wasted retries caused by LLM out
 | `description` | ✅ | ✅ | ✅ | `str` | — |
 | `workflow` | ✅ | ✅ | ✅ | `str`/`list[str]` | — |
 | `tools` | ❌ | ✅ | ✅ | `list[dict]` | `[]` |
-| `model_type` | ❌ | ✅ | ✅ | `str` | `"common" (depends on llm.yaml)` |
+| `model_type` | ❌ | ✅ | ✅ | `str` | `model.default_model_type` from `config/llm.yaml`; no implicit default |
 | `tool_call_type` | ❌ | ✅ | ✅ | `str` | `"code_act"` |
 | `execution_env` | ❌ | ✅ | ✅ | `dict` | `{type: "local"}` |
 | `prompt` | ❌ | ✅ | ✅ | `str`/`dict` | Framework built-in |

--- a/docs/en/config-overview.md
+++ b/docs/en/config-overview.md
@@ -59,9 +59,10 @@ In AgentLoom, **LLM configuration (`llm.yaml`) is physically isolated from syste
 ### Isolation Mechanism
 1. **Write interception**: When loading `system.yaml` or Agent YAML, the system actively filters out three top-level fields: `model`, `llm`, `langfuse`, and prints a warning.
 2. **Association via `model_type`**: An Agent only specifies `model_type: "powerful"` (model classification label) in its configuration.
-3. **Fallback chain**:
-   When requesting parameters for a specific `model_type`, the lookup order is:
-   `models[model_type].parameter` → `models.common.parameter` → `built-in code default values`.
+3. **Parameter lookup chain**:
+   After `model_type` has been resolved, parameter lookup order is:
+   `models[model_type].parameter` → `built-in code default values`.
+   If neither the Agent YAML nor `model.default_model_type` provides a model type, the model call fails fast with `ValueError`.
 
 ## 4. Global C Singleton (Unified Access)
 
@@ -75,7 +76,7 @@ tools_list = C.get_nested("tools", "default", default=[])
 is_summary_enabled = C.get("smart_summary")
 
 # 2. Access LLM configuration
-api_key = C.llm_api_key                # Automatically resolves common.api_key
+api_key = C.llm_api_key                # Reads api_key from the default model type
 temp = C.get_model_config("powerful", "temperature")  # Get parameters for specific model
 
 # 3. Access raw merged dictionary

--- a/docs/en/llm_config.md
+++ b/docs/en/llm_config.md
@@ -15,15 +15,15 @@
 
 - [Quick Reference: Complete YAML Structure](#quick-reference-complete-yaml-structure)
 - [1. model.default_model_type — Global Default Model Type](#1-modeldefault_model_type--global-default-model-type)
-- [2. model.common — Common Fallback Configuration](#2-modelcommon--common-fallback-configuration)
+- [2. Model Type Naming Rules](#2-model-type-naming-rules)
 - [3. model.\<type\> — Model Type Configuration](#3-modeltype--model-type-configuration)
-- [4. Parameter Inheritance Chain](#4-parameter-inheritance-chain)
+- [4. Parameter Defaults](#4-parameter-defaults)
 - [5. langfuse — Observability Configuration (Future Support)](#5-langfuse--observability-configuration-future-support)
 - [6. Retry Mechanism Details](#6-retry-mechanism-details)
 - [7. Provider Prefixes and Specific Behaviors](#7-provider-prefixes-and-specific-behaviors)
 - [8. Default Value Constants Reference Table](#8-default-value-constants-reference-table)
 - [Appendix A: Complete Pydantic Models](#appendix-a-complete-pydantic-models)
-- [Appendix B: Common Configuration Scenarios](#appendix-b-common-configuration-scenarios)
+- [Appendix B: Typical Configuration Scenarios](#appendix-b-typical-configuration-scenarios)
 
 ---
 
@@ -36,24 +36,14 @@ The following shows the **complete structure** of `config/llm.yaml`, with all fi
 # Model Configuration
 # ============================================
 model:
-  # Global default model type (optional, defaults to "common")
+  # Global default model type. If omitted, Agents without model_type fail fast.
   default_model_type: "powerful"
-
-  # ━━━ Required: Common shared configuration (also a regular model type) ━━━
-  # Fields missing from other model types are automatically inherited from common
-  # Agents can also directly use model_type: "common"
-  common:
-    model: "openai/gpt-4o"            # ❗ Required: LiteLLM model ID
-    base_url: "https://llm-gateway-proxy.inner.chj.cloud/llm-gateway/v1"
-    api_key: "your-api-key"
-    requests_per_minute: 10
-    num_retries: 5
-    retry_delay: 15.0
-    max_retry_delay: 100.0
 
   # ━━━ Required: Summary model (smart_summary context compression depends on this) ━━━
   summary:
     model: "openai/azure-gpt-5-chat"
+    base_url: "https://llm-gateway.example.com/v1"
+    api_key: "your-api-key"
     description: "Summary model, suitable for summarization and extraction"
     temperature: 1.0
     max_tokens: 2048
@@ -65,6 +55,7 @@ model:
   powerful:
     model: "anthropic/aws-claude-opus-4-5"
     base_url: "https://llm-gateway-proxy.inner.chj.cloud/llm-gateway"
+    api_key: "your-api-key"
     description: "High-quality reasoning model, suitable for complex analysis/code tasks"
     temperature: 0.2
     max_tokens: 8192
@@ -74,6 +65,8 @@ model:
   # Fast model (intent recognition, classification)
   fast:
     model: "anthropic/aws-claude-sonnet-4-5"
+    base_url: "https://llm-gateway.example.com/v1"
+    api_key: "your-api-key"
     description: "Low-latency model, suitable for simple tasks"
     temperature: 1.0
     max_tokens: 1024
@@ -94,9 +87,9 @@ Controls which model type the entire Agent system uses when an Agent YAML does n
 
 | Parameter | Type | Default | Required | Description |
 |------|------|--------|------|------|
-| `model.default_model_type` | `str` | `"common"` | ❌ No | Global default model type. Must be a type key defined under the `model` block (e.g., `powerful`, `fast`, `summary`, or a custom type name). Defaults to `"common"` when not configured, using the common shared configuration as fallback |
+| `model.default_model_type` | `str` | `""` | ❌ No | Global default model type. Must be a type key defined under the `model` block (e.g., `powerful`, `fast`, `summary`, or a custom type name). If omitted, Agents that do not specify `model_type` raise `ValueError` directly |
 
-### 1.1 Complete Fallback Chain
+### 1.1 Resolution Rules
 
 When an Agent needs to obtain model configuration, resolution follows this priority:
 
@@ -104,11 +97,11 @@ When an Agent needs to obtain model configuration, resolution follows this prior
 model_type in Agent YAML (e.g., model_type: "fast")
        ↓ (when not specified)
 default_model_type in config/llm.yaml (e.g., default_model_type: "powerful")
-       ↓ (when also not configured)
-common shared configuration as fallback
+       ↓ (when default_model_type is not configured)
+ValueError
 ```
 
-> ⚠️ **Note**: If an Agent YAML explicitly specifies `model_type` but that type does not exist in `llm.yaml`, the framework will **raise an error** (`ValueError`) directly, without silently falling back. This is to expose configuration errors as early as possible.
+> ⚠️ **Note**: The resolved model type must exist in `llm.yaml`. If an Agent YAML explicitly specifies a missing `model_type`, the global default points to a missing type, or neither Agent nor global config provides a model type, the framework will **raise an error** (`ValueError`) directly.
 
 **Example**:
 
@@ -117,59 +110,48 @@ model:
   default_model_type: "powerful"   # All Agents default to the powerful type
   # default_model_type: "fast"     # If defaulting to the fast model
 
-  common:
-    base_url: "https://your-gateway.com/v1"
-    api_key: "your-key"
-
   powerful:
     model: "anthropic/claude-3-5-sonnet"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "your-key"
     temperature: 0.2
 ```
 
 ```yaml
 # Agent YAML example
 name: "my_agent"
-model_type: "powerful"    # Uses the powerful type; if omitted, uses default_model_type
+model_type: "powerful"    # Uses the powerful type; if omitted, uses configured default_model_type
 ```
 
 ---
 
-## 2. model.common — Common Shared Configuration (Required)
+## 2. Model Type Naming Rules
 
-`common` is a **required model type** with a dual role:
+Under the `model` block, every dict-valued key except `default_model_type` is a model type name. The framework does not assign special semantics to type names; `powerful`, `fast`, and `summary` are examples.
 
-1. **Regular model type**: Agents can use it directly via `model_type: "common"`, just like `powerful`/`fast`
-2. **Shared parameter pool**: Fields missing from other model types (e.g., `base_url`, `api_key`) are automatically inherited from `common`
+- `summary` is required by context compression (`smart_summary`).
+- `default_model_type` is a reserved key, not a model type.
 
-> `common` is **exactly the same** as other model types, with the same field list (see [3.1 Complete Parameter List](#31-complete-parameter-list)). The `model` field is also required.
-
-**Example**:
+**Example:**
 
 ```yaml
 model:
-  common:
-    model: "openai/gpt-4o"              # ❗ Required: LiteLLM model ID
-    base_url: "https://your-gateway.com/v1"
-    api_key: "sk-your-api-key"
-    requests_per_minute: 10
-    num_retries: 5
-    retry_delay: 15.0
-    max_retry_delay: 100.0
-```
-
-**Parameter inheritance example**:
-
-```yaml
-model:
-  common:
-    model: "openai/gpt-4o"              # Default model
-    base_url: "https://your-gateway.com/v1"
-    api_key: "sk-your-key"
+  default_model_type: "powerful"
 
   powerful:
-    model: "anthropic/claude-3-5-sonnet"  # Overrides common's model
-    temperature: 0.2                      # Overrides common's temperature
-    # base_url and api_key not set → automatically inherited from common
+    model: "openai/gpt-4o"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "sk-your-api-key"
+
+  fast:
+    model: "openai/gpt-4o-mini"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "sk-your-api-key"
+
+  summary:
+    model: "openai/gpt-4o-mini"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "sk-your-api-key"
 ```
 
 ---
@@ -180,35 +162,34 @@ model:
 
 | Key | Required | Description |
 |-----|---------|------|
-| `common` | ❗ **Required** | Regular model type + parameter inheritance source for other types; `default_model_type` points to it by default |
 | `summary` | ❗ **Required** | Context compression (`smart_summary`) feature has a hard dependency on this type |
-| `default_model_type` | ❌ Optional | Reserved key, defaults to `"common"` |
+| `default_model_type` | ❌ Optional | Reserved key. No implicit default; omit only when every Agent specifies `model_type` |
 | Any other key | ❌ Optional | Freely define, delete, or rename, e.g., `powerful`, `fast`, `code_review`, etc. |
 
-Except for `default_model_type`, **all keys under the `model` block are parsed as model types** (including `common`). The framework has no restrictions on type names — `powerful` and `fast` are just example names. You can freely delete, rename, or add new ones. The `model` field for each model type (including `common`) is required.
+Except for `default_model_type`, **all dict-valued keys under the `model` block are parsed as model types**. The framework has no restrictions on type names — `powerful` and `fast` are just example names. You can freely delete, rename, or add new ones. The `model` field for each model type is required.
 
 **YAML path**: `model.<your-type-name>.*` (e.g., `model.powerful.*`, `model.my_llm.*`)
 **Pydantic model**: `LlmModelTypeSettings`
 
 ### 3.1 Complete Parameter List
 
-| Parameter | Type | Default | Required | Inherited from common | Description |
-|------|------|--------|------|--------------|------|
-| `model` | `str` | — | ❗ **Required** | ❌ Not inherited | **LiteLLM model ID**, must include Provider prefix. Format: `{provider}/{model-name}`. Examples: `openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `gemini/gemini-1.5-pro`. **Raises an error if not configured.** |
-| `base_url` | `str` | `""` | ❌ No | ✅ Inherited | API gateway address. Inherits `common.base_url` when not set. **Note: field name is `base_url`, not `api_base`** |
-| `api_key` | `str` | `""` | ❌ No | ✅ Inherited | API authentication key. Inherits `common.api_key` when not set |
-| `description` | `str` | `"Model type '{k}' loaded from YAML config"` | ❌ No | ❌ Not inherited | Human-readable model description. Used in logs and documentation |
-| `temperature` | `float` | `0.1` | ❌ No | ✅ Inherited | Creativity/randomness control (0.0 - 2.0). See [3.2 temperature Recommendations](#32-temperature-configuration-recommendations) |
-| `max_tokens` | `int` \| `str` | `150000` | ❌ No | ✅ Inherited | Maximum tokens per single model generation. Special value `"max"` uses the model's native maximum |
-| `timeout` | `int` | `60` | ❌ No | ✅ Inherited | Single HTTP request timeout (seconds). Interrupted if no response within this time |
-| `num_retries` | `int` | `5` | ❌ No | ✅ Inherited | Number of retries on API call failure |
-| `retry_delay` | `float` | `15.0` | ❌ No | ✅ Inherited | Initial retry delay (seconds). See [Section 6](#6-retry-mechanism-details) |
-| `max_retry_delay` | `float` | `100.0` | ❌ No | ✅ Inherited | Maximum retry delay (seconds). Upper limit for exponential backoff |
-| `extra_headers` | `dict` \| `null` | `null` | ❌ No | ✅ Inherited (no merge) | Custom HTTP request headers. **⚠️ Model-level `extra_headers` completely overrides `common.extra_headers`, no merging** |
-| `context_cache` | `bool` | `false` | ❌ No | ❌ Not inherited | Universal Prompt cache optimization. When `true`, the framework injects `cache_control: {"type": "ephemeral"}` for **ALL models** universally. litellm handles per-provider behavior automatically (Anthropic preserves, OpenAI strips, Vertex AI converts to Gemini format) |
-| `system_prompt_boundary` | `str` \| `null` | `null` | ❌ No | ❌ Not inherited | System prompt split marker. When set, the system prompt is split into **static (cached)** + **dynamic (uncached)** segments at this marker, improving cache hit rates. Example: `"<!-- DYNAMIC_BOUNDARY -->"` |
-| `requests_per_minute` | `int` | `60` | ❌ No | ✅ Inherited | Rate limit for this model type |
-| `supports_native_tool_calls` | `str` | `"auto"` | ❌ No | ✅ Inherited | Native tool_calls capability flag. Tri-state: `"auto"` auto-detects on first call, `"true"` always uses native path, `"false"` always uses text parsing fallback. See [3.6 supports_native_tool_calls Behavior](#36-supports_native_tool_calls-behavior) |
+| Parameter | Type | Default | Required | Description |
+|------|------|--------|------|------|
+| `model` | `str` | — | ❗ **Required** | **LiteLLM model ID**, must include Provider prefix. Format: `{provider}/{model-name}`. Examples: `openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `gemini/gemini-1.5-pro`. **Raises an error if not configured.** |
+| `base_url` | `str` | `""` | ❌ No | API gateway address. Configure independently for each model type. **Note: field name is `base_url`, not `api_base`** |
+| `api_key` | `str` | `""` | ❌ No | API authentication key. Configure independently for each model type |
+| `description` | `str` | `"Model type '{k}' loaded from YAML config"` | ❌ No | Human-readable model description. Used in logs and documentation |
+| `temperature` | `float` | `0.1` | ❌ No | Creativity/randomness control (0.0 - 2.0). See [3.2 temperature Recommendations](#32-temperature-configuration-recommendations) |
+| `max_tokens` | `int` \| `str` | `150000` | ❌ No | Maximum tokens per single model generation. Special value `"max"` uses the model's native maximum |
+| `timeout` | `int` | `60` | ❌ No | Single HTTP request timeout (seconds). Interrupted if no response within this time |
+| `num_retries` | `int` | `5` | ❌ No | Number of retries on API call failure |
+| `retry_delay` | `float` | `15.0` | ❌ No | Initial retry delay (seconds). See [Section 6](#6-retry-mechanism-details) |
+| `max_retry_delay` | `float` | `100.0` | ❌ No | Maximum retry delay (seconds). Upper limit for exponential backoff |
+| `extra_headers` | `dict` \| `null` | `null` | ❌ No | Custom HTTP request headers. Configure independently for each model type; no cross-type merge is performed |
+| `context_cache` | `bool` | `false` | ❌ No | Universal Prompt cache optimization. When `true`, the framework injects `cache_control: {"type": "ephemeral"}` for **ALL models** universally. litellm handles per-provider behavior automatically (Anthropic preserves, OpenAI strips, Vertex AI converts to Gemini format) |
+| `system_prompt_boundary` | `str` \| `null` | `null` | ❌ No | System prompt split marker. When set, the system prompt is split into **static (cached)** + **dynamic (uncached)** segments at this marker, improving cache hit rates. Example: `"<!-- DYNAMIC_BOUNDARY -->"` |
+| `requests_per_minute` | `int` | `60` | ❌ No | Rate limit for this model type |
+| `supports_native_tool_calls` | `str` | `"auto"` | ❌ No | Native tool_calls capability flag. Tri-state: `"auto"` auto-detects on first call, `"true"` always uses native path, `"false"` always uses text parsing fallback. See [3.6 supports_native_tool_calls Behavior](#36-supports_native_tool_calls-behavior) |
 
 ### 3.2 temperature Configuration Recommendations
 
@@ -233,20 +214,14 @@ Except for `default_model_type`, **all keys under the `model` block are parsed a
 
 ```yaml
 model:
-  common:
-    extra_headers:
-      X-Project: "AgentLoom"
-      X-Env: "dev"
-
   powerful:
-    extra_headers:          # ⚠️ Completely overrides common's extra_headers
+    extra_headers:
       X-Model-Tier: "powerful"
       X-Biz-Tag: "demo"
-    # Final powerful headers = {X-Model-Tier: "powerful", X-Biz-Tag: "demo"}
-    # common's {X-Project, X-Env} are NOT merged in
 
   fast:
-    # extra_headers not set → inherits common's {X-Project: "AgentLoom", X-Env: "dev"}
+    extra_headers:
+      X-Model-Tier: "fast"
 ```
 
 > You can also override via **environment variables** (JSON string format):
@@ -344,27 +319,31 @@ Agent YAML references your defined type names through the `model_type` field.
 model:
   default_model_type: "main"
 
-  common:
-    base_url: "https://your-gateway.com/v1"
-    api_key: "your-key"
-
   main:                          # ✅ Custom name, replaces powerful
     model: "anthropic/claude-3-5-sonnet"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "your-key"
     temperature: 0.2
 
   code_review:                   # ✅ Custom type
     model: "anthropic/claude-3-5-sonnet"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "your-key"
     temperature: 0.1
     max_tokens: 16384
     timeout: 600
 
   translation:                   # ✅ Custom type
     model: "openai/gpt-4o"
+    base_url: "https://api.openai.com/v1"
+    api_key: "your-openai-key"
     temperature: 0.3
     max_tokens: 4096
 
   summary:                       # Keep summary to support smart_summary feature
     model: "openai/gpt-4o-mini"
+    base_url: "https://api.openai.com/v1"
+    api_key: "your-openai-key"
     temperature: 0.3
 ```
 
@@ -381,16 +360,14 @@ model_type: "code_review"        # References code_review defined in llm.yaml
 model:
   default_model_type: "default"
 
-  common:
-    base_url: "https://your-gateway.com/v1"
-    api_key: "your-key"
-
   default:
     model: "openai/gpt-4o"
+    base_url: "https://your-gateway.com/v1"
+    api_key: "your-key"
     temperature: 0.3
 ```
 
-> All custom types are **fully equivalent** to the framework examples' `powerful`/`fast`/`summary`, with the same common inheritance mechanism.
+> All custom types are **fully equivalent** to the framework examples' `powerful`/`fast`/`summary`. Each type declares its own model and parameters independently.
 
 **Example**:
 
@@ -412,15 +389,17 @@ model:
 
   fast:
     model: "gemini/gemini-3_1-pro-preview"
+    base_url: "https://generativelanguage.googleapis.com/v1"
+    api_key: "gemini-key"
     temperature: 1.0
     max_tokens: 1024
     timeout: 60
     context_cache: true
-    # base_url and api_key not set, inherited from common
 
   summary:
     model: "openai/azure-gpt-5-chat"
     base_url: "https://portal-k8s-prod.ep.chehejia.com/api/copilot/v3/openai/azure-gpt-5-chat/v1"
+    api_key: "summary-key"
     temperature: 1.0
     max_tokens: 2048
     timeout: 300
@@ -428,35 +407,33 @@ model:
 
 ---
 
-## 4. Parameter Inheritance Chain
+## 4. Parameter Defaults
 
-The final value of model parameters is resolved in the following priority chain from high to low:
+The final value of model parameters is resolved as follows:
 
 ```
 Model type settings (model.powerful.xxx)
-       ↓ (fallback when not set)
-Common settings (model.common.xxx)
-       ↓ (fallback when not set)
+      ↓ (when not set)
 Code default values (defaults.py)
 ```
 
-**Specific inheritance rules**:
+**Specific default rules**:
 
-| Field | Inheritance Behavior |
+| Field | Default Behavior |
 |------|----------|
-| `base_url` | model type → common → `""` |
-| `api_key` | model type → common → `""` |
-| `temperature` | model type → common → `0.1` |
-| `max_tokens` | model type → common → `150000` |
-| `timeout` | model type → common → `60` |
-| `num_retries` | model type → common → `5` |
-| `retry_delay` | model type → common → `15.0` |
-| `max_retry_delay` | model type → common → `100.0` |
-| `extra_headers` | model type → common → `null` (**overrides, no merge**) |
-| `requests_per_minute` | model type → common → `60` |
-| `model` | ❌ **Not inherited**, set independently per type |
-| `description` | ❌ **Not inherited**, set independently per type |
-| `context_cache` | ❌ **Not inherited**, defaults to `false` |
+| `base_url` | `""` when unset |
+| `api_key` | `""` when unset |
+| `temperature` | `0.1` when unset |
+| `max_tokens` | `150000` when unset |
+| `timeout` | `60` when unset |
+| `num_retries` | `5` when unset |
+| `retry_delay` | `15.0` when unset |
+| `max_retry_delay` | `100.0` when unset |
+| `extra_headers` | `null` when unset |
+| `requests_per_minute` | `60` when unset |
+| `model` | ❗ Required; no default |
+| `description` | Auto-generated when unset |
+| `context_cache` | `false` when unset |
 
 ---
 
@@ -571,17 +548,6 @@ The following constants are defined in `src/lib/config/defaults.py` and serve as
 
 ## Appendix A: Complete Pydantic Models
 
-### LlmCommonSettings
-
-```python
-class LlmCommonSettings(BaseModel):
-    base_url: str = ""
-    api_key: str = ""
-    requests_per_minute: int = 60  # DEFAULT_MODEL_REQUESTS_PER_MINUTE
-```
-
-> **Note**: Although the Pydantic model above only explicitly declares these three fields, the actual parsing logic (`LLMConfig.from_dict`) reads the raw `common` dictionary from YAML directly, providing fallback inheritance for additional parameters like `temperature`, `timeout`, `extra_headers`, etc.
-
 ### LlmModelTypeSettings
 
 ```python
@@ -618,9 +584,8 @@ class LangfuseSettings(BaseModel):
 ```python
 class LLMConfig(BaseModel):
     langfuse: LangfuseSettings           # Reserved, future activation
-    common: LlmCommonSettings
-    default_model_type: str = "common"   # Defaults to "common" when not configured
-    models: dict[str, LlmModelTypeSettings]  # {"common": ..., "powerful": ..., "summary": ..., or custom types}
+    default_model_type: str = ""         # No implicit model-type default
+    models: dict[str, LlmModelTypeSettings]  # {"powerful": ..., "summary": ..., or custom types}
 ```
 
 **Runtime access**:
@@ -641,7 +606,7 @@ available = C.llm.available_types              # → ["powerful", "fast", "summa
 
 ---
 
-## Appendix B: Common Configuration Scenarios
+## Appendix B: Typical Configuration Scenarios
 
 ### B.1 Switching to OpenAI GPT-4o
 
@@ -660,17 +625,16 @@ model:
 
 ```yaml
 model:
-  common:
-    base_url: "http://localhost:11434"
-
   powerful:
     model: "ollama/llama3"
+    base_url: "http://localhost:11434"
     temperature: 0.3
     max_tokens: 4096
     timeout: 120
 
   fast:
     model: "ollama/phi3"
+    base_url: "http://localhost:11434"
     temperature: 0.7
     max_tokens: 1024
     timeout: 30
@@ -682,14 +646,11 @@ model:
 model:
   default_model_type: "powerful"
 
-  common:
-    api_key: "default-key"
-    requests_per_minute: 30
-
   powerful:
     model: "anthropic/aws-claude-opus-4-5"
     base_url: "https://your-anthropic-gateway.com"
     api_key: "anthropic-specific-key"
+    requests_per_minute: 30
     temperature: 0.2
     max_tokens: 8192
 
@@ -697,6 +658,7 @@ model:
     model: "openai/gpt-4o-mini"
     base_url: "https://api.openai.com/v1"
     api_key: "openai-specific-key"
+    requests_per_minute: 30
     temperature: 0.7
     max_tokens: 1024
 
@@ -704,6 +666,7 @@ model:
     model: "gemini/gemini-1.5-flash"
     base_url: "https://generativelanguage.googleapis.com/v1"
     api_key: "gemini-specific-key"
+    requests_per_minute: 30
     temperature: 0.3
     max_tokens: 2048
 ```
@@ -712,19 +675,21 @@ model:
 
 ```yaml
 model:
-  common:
-    base_url: "https://your-openai-proxy.com/v1"
-    api_key: "sk-your-key"
-
   powerful:
     model: "openai/gpt-4o"
+    base_url: "https://your-openai-proxy.com/v1"
+    api_key: "sk-your-key"
     temperature: 0.2
 
   fast:
     model: "openai/gpt-4o-mini"
+    base_url: "https://your-openai-proxy.com/v1"
+    api_key: "sk-your-key"
     temperature: 0.7
 
   summary:
     model: "openai/gpt-4o-mini"
+    base_url: "https://your-openai-proxy.com/v1"
+    api_key: "sk-your-key"
     temperature: 0.3
 ```

--- a/src/lib/config/config.py
+++ b/src/lib/config/config.py
@@ -24,6 +24,7 @@ from .config_validation import (
     raise_project_key_error,
     validate_system_snapshot,
 )
+from .defaults import DEFAULT_MODEL_REQUESTS_PER_MINUTE
 from .layered_builder import LayeredConfigBuilder
 from .llm_config import LLMConfig
 
@@ -215,10 +216,6 @@ class UnifiedConfig:
             val = getattr(specific, key)
             if val is not None and val != "":
                 return val
-        if hasattr(self._llm_config.common, key):
-            val = getattr(self._llm_config.common, key)
-            if val is not None and val != "":
-                return val
         return default
 
     @property
@@ -239,15 +236,24 @@ class UnifiedConfig:
 
     @property
     def requests_per_minute(self) -> int:
-        return self._llm_config.common.requests_per_minute
+        try:
+            return self._llm_config.for_type(None).requests_per_minute
+        except ValueError:
+            return DEFAULT_MODEL_REQUESTS_PER_MINUTE
 
     @property
     def llm_base_url(self) -> str:
-        return self._llm_config.common.base_url
+        try:
+            return self._llm_config.for_type(None).base_url
+        except ValueError:
+            return ""
 
     @property
     def llm_api_key(self) -> str:
-        api_key = self._llm_config.common.api_key
+        try:
+            api_key = self._llm_config.for_type(None).api_key
+        except ValueError:
+            api_key = ""
         return api_key if api_key else "not_provided"
 
     @property

--- a/src/lib/config/llm_config.py
+++ b/src/lib/config/llm_config.py
@@ -21,7 +21,43 @@ from src.lib.config.defaults import (
     DEFAULT_MODEL_TIMEOUT,
 )
 
-_RESERVED_MODEL_KEYS = {"default_model_type"}
+_RESERVED_MODEL_KEYS = {"default_model_type", "common"}
+
+
+def _available_types_text(models: Dict[str, Any]) -> str:
+    available = list(models.keys())
+    return ", ".join(available) if available else "(none)"
+
+
+def _missing_default_model_type_error(models: Dict[str, Any]) -> str:
+    return (
+        "No model_type was provided and config/llm.yaml does not set "
+        "`model.default_model_type`; the model call was not started. "
+        "Fix: add `model_type: <type>` to the Agent YAML, or set "
+        "`model.default_model_type: <type>` in config/llm.yaml. "
+        f"Available model types: {_available_types_text(models)}."
+    )
+
+
+def _unknown_model_type_error(model_type: Any, models: Dict[str, Any]) -> str:
+    return (
+        f"Model type '{model_type}' is not defined in config/llm.yaml; "
+        "the model call was not started. "
+        f"Available model types: {_available_types_text(models)}. "
+        "Fix: set Agent YAML `model_type` to one of the available types, "
+        f"or add `model.{model_type}.model: <provider/model>` in config/llm.yaml."
+    )
+
+
+def _missing_default_target_error(default_type: str, models: Dict[str, Any]) -> str:
+    return (
+        f"config/llm.yaml sets `model.default_model_type: {default_type}`, "
+        "but that model type is not defined; the model call was not started. "
+        f"Available model types: {_available_types_text(models)}. "
+        f"Fix: change `model.default_model_type` to an available type, "
+        f"or add `model.{default_type}.model: <provider/model>`."
+    )
+
 
 class LangfuseSettings(BaseModel):
     model_config = ConfigDict(extra="allow", frozen=True)
@@ -43,12 +79,6 @@ class LangfuseSettings(BaseModel):
 
     def get_actual_private_key(self) -> str:
         return self.private_key or self.secret_key or ""
-
-class LlmCommonSettings(BaseModel):
-    model_config = ConfigDict(extra="allow", frozen=True)
-    base_url: str = ""
-    api_key: str = ""
-    requests_per_minute: int = DEFAULT_MODEL_REQUESTS_PER_MINUTE
 
 class LlmModelTypeSettings(BaseModel):
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True, frozen=True)
@@ -76,8 +106,7 @@ class LLMConfig(BaseModel):
     # Internal representation from yaml
     langfuse: LangfuseSettings = Field(default_factory=LangfuseSettings)
     # the entire "model" block gets split into its pieces
-    common: LlmCommonSettings = Field(default_factory=LlmCommonSettings)
-    default_model_type: str = "common"
+    default_model_type: str = ""
     models: Dict[str, LlmModelTypeSettings] = Field(default_factory=dict)
     
     @classmethod
@@ -93,33 +122,24 @@ class LLMConfig(BaseModel):
     def from_dict(cls, raw: Dict[str, Any]) -> "LLMConfig":
         langfuse_raw = raw.get("langfuse", {})
         model_raw = raw.get("model", {})
-        
-        common_raw = model_raw.get("common", {})
-        default_type = model_raw.get("default_model_type", "common")
+        default_type = model_raw.get("default_model_type", "")
         
         # Build models dict
         models: Dict[str, LlmModelTypeSettings] = {}
         for k, v in model_raw.items():
             if k in _RESERVED_MODEL_KEYS or not isinstance(v, dict):
                 continue
-                
-            # Merge common defaults explicitly when parsing model types
-            resolved_base_url = v.get("base_url") or common_raw.get("base_url") or ""
-            resolved_api_key = v.get("api_key") or common_raw.get("api_key") or ""
-            
-            resolved_rpm = v.get("requests_per_minute")
-            if resolved_rpm is None:
-                 resolved_rpm = common_raw.get("requests_per_minute", DEFAULT_MODEL_REQUESTS_PER_MINUTE)
-                 
-            resolved_temp = v.get("temperature", common_raw.get("temperature", DEFAULT_MODEL_TEMPERATURE))
-            resolved_max_tokens = v.get("max_tokens", common_raw.get("max_tokens", DEFAULT_MAX_TOKENS))
-            resolved_timeout = v.get("timeout", common_raw.get("timeout", DEFAULT_MODEL_TIMEOUT))
-            resolved_num_retries = v.get("num_retries", common_raw.get("num_retries", DEFAULT_MODEL_NUM_RETRIES))
-            resolved_retry_delay = v.get("retry_delay", common_raw.get("retry_delay", DEFAULT_MODEL_RETRY_DELAY))
-            resolved_max_retry_delay = v.get("max_retry_delay", common_raw.get("max_retry_delay", DEFAULT_MODEL_MAX_RETRY_DELAY))
+
+            resolved_base_url = v.get("base_url") or ""
+            resolved_api_key = v.get("api_key") or ""
+            resolved_rpm = v.get("requests_per_minute", DEFAULT_MODEL_REQUESTS_PER_MINUTE)
+            resolved_temp = v.get("temperature", DEFAULT_MODEL_TEMPERATURE)
+            resolved_max_tokens = v.get("max_tokens", DEFAULT_MAX_TOKENS)
+            resolved_timeout = v.get("timeout", DEFAULT_MODEL_TIMEOUT)
+            resolved_num_retries = v.get("num_retries", DEFAULT_MODEL_NUM_RETRIES)
+            resolved_retry_delay = v.get("retry_delay", DEFAULT_MODEL_RETRY_DELAY)
+            resolved_max_retry_delay = v.get("max_retry_delay", DEFAULT_MODEL_MAX_RETRY_DELAY)
             resolved_extra_headers = v.get("extra_headers")
-            if resolved_extra_headers is None:
-                resolved_extra_headers = common_raw.get("extra_headers")
 
             model_id = v.get("model", "")
             if not model_id:
@@ -132,7 +152,7 @@ class LLMConfig(BaseModel):
             # Resolve supports_native_tool_calls (three-state: auto/true/false)
             raw_tool_calls = v.get(
                 "supports_native_tool_calls",
-                common_raw.get("supports_native_tool_calls", "auto"),
+                "auto",
             )
             resolved_tool_calls = str(raw_tool_calls).strip().lower()
             if resolved_tool_calls not in ("auto", "true", "false"):
@@ -157,10 +177,9 @@ class LLMConfig(BaseModel):
             )
 
         # Validate required model types:
-        # - 'common': default model type + shared parameter pool
         # - 'summary': context compression (smart_summary) depends on it
         if models:
-            for required in ("common", "summary"):
+            for required in ("summary",):
                 if required not in models:
                     raise ValueError(
                         f"Model type '{required}' is required in llm.yaml but not found. "
@@ -169,8 +188,7 @@ class LLMConfig(BaseModel):
 
         return cls(
             langfuse=LangfuseSettings(**langfuse_raw),
-            common=LlmCommonSettings(**common_raw),
-            default_model_type=default_type,
+            default_model_type=str(default_type or ""),
             models=models
         )
         
@@ -180,7 +198,6 @@ class LLMConfig(BaseModel):
         if arbitrary code tries to read C.raw['model'] or C.raw['langfuse'].
         """
         model_dict = {
-            "common": self.common.model_dump(),
             "default_model_type": self.default_model_type
         }
         for k, v in self.models.items():
@@ -193,28 +210,24 @@ class LLMConfig(BaseModel):
 
     def for_type(self, model_type: Optional[str]) -> LlmModelTypeSettings:
         desired = (model_type or "").strip().lower()
-        
+
         # If user explicitly requested a type and it exists, return it.
         if desired and desired in self.models:
             return self.models[desired]
-            
-        # If user explicitly requested a type but it DOES NOT exist, raise error immediately (do not fallback).
+
+        # If user explicitly requested a type but it DOES NOT exist, raise error immediately.
         if desired:
-             raise ValueError(
-                f"Model type '{model_type}' requested by Agent is not defined in llm.yaml. "
-                f"Available types: {list(self.models.keys())}"
-            )
-            
-        # If user did not request a type (empty/None), fallback to default_model_type
+            raise ValueError(_unknown_model_type_error(model_type, self.models))
+
+        # If user did not request a type (empty/None), use global default_model_type.
         default_type = self.default_model_type.strip().lower()
         if default_type and default_type in self.models:
             return self.models[default_type]
-            
-        raise ValueError(
-            f"No model type found for '{model_type}' and default "
-            f"'{self.default_model_type}' is also not available. "
-            f"Available types: {list(self.models.keys())}"
-        )
+
+        if not default_type:
+            raise ValueError(_missing_default_model_type_error(self.models))
+
+        raise ValueError(_missing_default_target_error(self.default_model_type, self.models))
 
     @property
     def available_types(self) -> list[str]:

--- a/src/lib/smolagents/models/model_types.py
+++ b/src/lib/smolagents/models/model_types.py
@@ -22,6 +22,30 @@ from src.lib.config.defaults import (
 logger = get_logger(__name__)
 
 
+def _available_types_text(available: list[str]) -> str:
+    return ", ".join(available) if available else "(none)"
+
+
+def _missing_default_model_type_error(available: list[str]) -> str:
+    return (
+        "No model_type was provided and config/llm.yaml does not set "
+        "`model.default_model_type`; the model call was not started. "
+        "Fix: add `model_type: <type>` to the Agent YAML, or set "
+        "`model.default_model_type: <type>` in config/llm.yaml. "
+        f"Available model types: {_available_types_text(available)}."
+    )
+
+
+def _unknown_model_type_error(model_type: str, available: list[str]) -> str:
+    return (
+        f"Model type '{model_type}' is not defined in config/llm.yaml; "
+        "the model call was not started. "
+        f"Available model types: {_available_types_text(available)}. "
+        "Fix: set Agent YAML `model_type` to one of the available types, "
+        f"or add `model.{model_type}.model: <provider/model>` in config/llm.yaml."
+    )
+
+
 def _parse_extra_headers(value: Any, source: str) -> Optional[dict]:
     """
     Parse extra_headers from dict or JSON string.
@@ -118,7 +142,7 @@ def _build_model_config_from_yaml(type_name: str) -> ModelConfig:
     resolved = C.llm.for_type(type_name)
     extra_headers = _parse_extra_headers(
         resolved.extra_headers,
-        f"model.{type_name}.extra_headers/model.common.extra_headers",
+        f"model.{type_name}.extra_headers",
     )
 
     return ModelConfig(
@@ -146,7 +170,7 @@ class ModelTypeManager:
     def _get_available_types(cls) -> list[str]:
         """
         Return all model type names defined in config under 'model:',
-        excluding reserved keys like 'common' and 'default_model_type'.
+        excluding reserved keys like 'default_model_type'.
         """
         return list(C.llm.available_types)
 
@@ -166,10 +190,7 @@ class ModelTypeManager:
         """
         available = cls._get_available_types()
         if model_type.value not in available:
-            raise ValueError(
-                f"Unsupported model type: '{model_type.value}'. "
-                f"Available types from YAML: {available}"
-            )
+            raise ValueError(_unknown_model_type_error(model_type.value, available))
         return _build_model_config_from_yaml(model_type.value)
 
     @classmethod
@@ -190,9 +211,9 @@ class ModelTypeManager:
         """
         Resolve a model type string to a ModelType instance.
 
-        If `model_type` is None or empty, uses the default model type from
-        YAML (model.default_model_type).  If that is also unset, the
-        framework falls back to common shared settings (via ``for_type``).
+        If `model_type` is None or empty, uses the global default model type
+        from YAML (model.default_model_type). If that key is unset, the
+        framework raises ``ValueError`` immediately.
 
         If `model_type` is explicitly specified but not defined in
         llm.yaml, a ``ValueError`` is raised to surface configuration
@@ -210,7 +231,10 @@ class ModelTypeManager:
                 defined in llm.yaml.
         """
         if not model_type:
-            return ModelType(C.default_model_type or "common")
+            default_type = (C.default_model_type or "").strip()
+            if not default_type:
+                raise ValueError(_missing_default_model_type_error(cls._get_available_types()))
+            return ModelType(default_type)
 
         type_name = model_type.lower().strip()
         available = cls._get_available_types()
@@ -218,7 +242,4 @@ class ModelTypeManager:
         if type_name in available:
             return ModelType(type_name)
 
-        raise ValueError(
-            f"Model type '{model_type}' is not defined in llm.yaml. "
-            f"Available types: {available}"
-        )
+        raise ValueError(_unknown_model_type_error(model_type, available))

--- a/tests/agent_test/llm_cfg_test/test_llm_api_and_langfuse_members.py
+++ b/tests/agent_test/llm_cfg_test/test_llm_api_and_langfuse_members.py
@@ -30,13 +30,12 @@ def test_langfuse_app_override_and_defaults(tmp_path):
         {
             "model": {
                 "default_model_type": "powerful",
-                "common": {
-                    "model": "openai/test-common",
-                    "base_url": "https://common.example/v1",
-                    "api_key": "common-key",
+                "powerful": {
+                    "model": "openai/powerful",
+                    "base_url": "https://powerful.example/v1",
+                    "api_key": "powerful-key",
                     "requests_per_minute": 5,
                 },
-                "powerful": {"model": "openai/powerful"},
                 "summary": {"model": "openai/test-summary"},
             },
         },

--- a/tests/agent_test/llm_cfg_test/test_llm_layering_and_app_override.py
+++ b/tests/agent_test/llm_cfg_test/test_llm_layering_and_app_override.py
@@ -58,22 +58,21 @@ def test_layering_precedence_with_application_override(tmp_path):
             "prompt": {"path": "prompts/system_prompt.yaml"},
             "model": {
                 "default_model_type": "powerful",
-                "common": {"model": "openai/test-common", "base_url": "https://system.example/v1", "api_key": "system-key", "requests_per_minute": 3},
-                "powerful": {"model": "openai/system-powerful", "timeout": 50},
+                "powerful": {"model": "openai/system-powerful", "base_url": "https://system.example/v1", "api_key": "system-key", "requests_per_minute": 3, "timeout": 50},
                 "summary": {"model": "openai/test-summary"},
             },
         },
         llm_data={
             "model": {
-                "common": {"model": "openai/test-common", "base_url": "https://llm.example/v1", "api_key": "llm-key", "requests_per_minute": 9},
-                "powerful": {"model": "openai/llm-powerful", "timeout": 60},
+                "default_model_type": "powerful",
+                "powerful": {"model": "openai/llm-powerful", "base_url": "https://llm.example/v1", "api_key": "llm-key", "requests_per_minute": 9, "timeout": 60},
                 "summary": {"model": "openai/test-summary"},
             }
         },
         app_data={
             "tool_access_control": {"exclude_paths": ["Tools", ".git"]},
             "prompt": {"path": "prompts/app_prompt.yaml"},
-            "model": {"common": {"model": "openai/test-common", "api_key": "app-key"}, "powerful": {"model": "openai/app-powerful"}},
+            "model": {"powerful": {"model": "openai/app-powerful", "api_key": "app-key"}},
             "summary": {"model": "openai/test-summary"},
             "langfuse": {"host": "https://app-langfuse.example"},
         },
@@ -96,8 +95,8 @@ def test_non_application_path_does_not_load_app_override(tmp_path):
     _write_yaml(config_dir / "system.yaml", {"prompt": {"path": "prompts/system_prompt.yaml"}})
     _write_yaml(config_dir / "llm.yaml", {
         "model": {
-            "common": {"model": "openai/test-common", "base_url": "https://llm.example/v1"},
-            "powerful": {"model": "openai/llm-powerful"},
+            "default_model_type": "powerful",
+            "powerful": {"model": "openai/llm-powerful", "base_url": "https://llm.example/v1"},
             "summary": {"model": "openai/test-summary"},
         }
     })
@@ -122,13 +121,13 @@ def test_max_tokens_uses_llm_yaml_only_and_ignores_system_layers(tmp_path):
     config_dir, yaml_file = _setup_layered(
         tmp_path,
         system_data={
-            "model": {"default_model_type": "powerful", "common": {"model": "openai/test-common", "max_tokens": 11111}, "powerful": {"model": "openai/system-powerful", "max_tokens": 22222}, "summary": {"model": "openai/test-summary"}},
+            "model": {"default_model_type": "powerful", "powerful": {"model": "openai/system-powerful", "max_tokens": 22222}, "summary": {"model": "openai/test-summary"}},
         },
         llm_data={
-            "model": {"common": {"model": "openai/test-common", "max_tokens": 33333}, "powerful": {"model": "openai/llm-powerful", "max_tokens": 44444}, "summary": {"model": "openai/test-summary"}},
+            "model": {"default_model_type": "powerful", "powerful": {"model": "openai/llm-powerful", "max_tokens": 44444}, "summary": {"model": "openai/test-summary"}},
         },
         app_data={
-            "model": {"common": {"model": "openai/test-common", "max_tokens": 55555}, "powerful": {"max_tokens": 66666}, "summary": {"model": "openai/test-summary"}},
+            "model": {"powerful": {"max_tokens": 66666}, "summary": {"model": "openai/test-summary"}},
         },
     )
     _build_effective(config_dir, yaml_file)
@@ -140,13 +139,13 @@ def test_max_tokens_falls_back_to_builtin_when_llm_yaml_omits_it(tmp_path):
     config_dir, yaml_file = _setup_layered(
         tmp_path,
         system_data={
-            "model": {"default_model_type": "powerful", "common": {"model": "openai/test-common", "max_tokens": 22222}, "powerful": {"model": "openai/system-powerful", "max_tokens": 33333}, "summary": {"model": "openai/test-summary"}},
+            "model": {"default_model_type": "powerful", "powerful": {"model": "openai/system-powerful", "max_tokens": 33333}, "summary": {"model": "openai/test-summary"}},
         },
         llm_data={
-            "model": {"common": {"model": "openai/test-common"}, "powerful": {"model": "openai/llm-powerful"}, "summary": {"model": "openai/test-summary"}},
+            "model": {"default_model_type": "powerful", "powerful": {"model": "openai/llm-powerful"}, "summary": {"model": "openai/test-summary"}},
         },
         app_data={
-            "model": {"common": {"model": "openai/test-common", "max_tokens": 44444}, "powerful": {"max_tokens": 55555}, "summary": {"model": "openai/test-summary"}},
+            "model": {"powerful": {"max_tokens": 55555}, "summary": {"model": "openai/test-summary"}},
         },
     )
     _build_effective(config_dir, yaml_file)

--- a/tests/agent_test/llm_cfg_test/test_llm_readonly_members.py
+++ b/tests/agent_test/llm_cfg_test/test_llm_readonly_members.py
@@ -19,18 +19,14 @@ def test_llm_readonly_members_basic(monkeypatch):
     raw = {
         "model": {
             "default_model_type": "powerful",
-            "common": {
-                "model": "openai/test-common",
-                "base_url": "https://common.example/v1",
-                "api_key": "common-key",
-                "requests_per_minute": 12,
-                "temperature": 0.4,
-                "max_tokens": 1024,
-                "timeout": 31,
-            },
             "powerful": {
                 "model": "openai/powerful",
+                "base_url": "https://powerful.example/v1",
+                "api_key": "powerful-key",
+                "requests_per_minute": 12,
                 "temperature": 0.2,
+                "max_tokens": 1024,
+                "timeout": 31,
                 "description": "powerful model",
             },
             "fast": {
@@ -46,32 +42,23 @@ def test_llm_readonly_members_basic(monkeypatch):
     llm = config_module.C.llm
 
     assert llm.default_model_type == "powerful"
-    assert set(llm.available_types) == {"common", "powerful", "fast", "summary"}
-
-    assert llm.common.base_url == "https://common.example/v1"
-    assert llm.common.api_key == "common-key"
-    assert llm.common.requests_per_minute == 12
+    assert set(llm.available_types) == {"powerful", "fast", "summary"}
 
     powerful = llm.for_type("powerful")
     assert powerful.model == "openai/powerful"
-    assert powerful.base_url == "https://common.example/v1"
-    assert powerful.api_key == "common-key"
+    assert powerful.base_url == "https://powerful.example/v1"
+    assert powerful.api_key == "powerful-key"
     assert powerful.temperature == 0.2
     assert powerful.max_tokens == 1024
     assert powerful.timeout == 31
     assert powerful.description == "powerful model"
 
 
-def test_llm_unknown_type_falls_back_to_default(monkeypatch):
-    """for_type() with unknown type should fall back to default_model_type."""
+def test_llm_unknown_type_raises(monkeypatch):
+    """Explicit unknown model types should raise instead of falling back."""
     raw = {
         "model": {
             "default_model_type": "fast",
-            "common": {
-                "model": "openai/test-common",
-                "base_url": "https://common.example/v1",
-                "api_key": "common-key",
-            },
             "fast": {
                 "model": "openai/fast",
                 "temperature": 0.6,
@@ -81,22 +68,19 @@ def test_llm_unknown_type_falls_back_to_default(monkeypatch):
     }
     _patch_active_config(monkeypatch, raw)
 
-    # for_type() falls back to default_model_type when type not found
-    import pytest
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         config_module.C.llm.for_type("non_existing")
+    message = str(exc_info.value)
+    assert "config/llm.yaml" in message
+    assert "the model call was not started" in message
+    assert "Available model types: fast, summary" in message
+    assert "model.non_existing.model" in message
 
 
-def test_llm_no_default_model_type_falls_back_to_common(monkeypatch):
-    """When default_model_type is not set, it defaults to 'common'."""
+def test_llm_no_default_model_type_raises_for_implicit_request(monkeypatch):
+    """When default_model_type is not set, implicit model selection fails fast."""
     raw = {
         "model": {
-            "common": {
-                "model": "openai/test-common",
-                "base_url": "https://common.example/v1",
-                "api_key": "common-key",
-                "requests_per_minute": 20,
-            },
             "powerful": {
                 "model": "openai/powerful",
             },
@@ -105,23 +89,96 @@ def test_llm_no_default_model_type_falls_back_to_common(monkeypatch):
     }
     _patch_active_config(monkeypatch, raw)
 
-    # default_model_type defaults to "common", so unknown type falls back to common
-    assert config_module.C.llm.default_model_type == "common"
-    import pytest
+    assert config_module.C.llm.default_model_type == ""
+    with pytest.raises(ValueError) as exc_info:
+        config_module.C.llm.for_type(None)
+    message = str(exc_info.value)
+    assert "model.default_model_type" in message
+    assert "the model call was not started" in message
+    assert "Agent YAML" in message
+
+    from src.lib.smolagents.models.model_types import ModelTypeManager
+
+    with pytest.raises(ValueError) as exc_info:
+        ModelTypeManager.resolve_model_type(None)
+    assert "model.default_model_type" in str(exc_info.value)
+    assert "the model call was not started" in str(exc_info.value)
+
     with pytest.raises(ValueError):
         config_module.C.llm.for_type("non_existing")
+
+
+def test_llm_does_not_require_common(monkeypatch):
+    """Model config works without any common type."""
+    raw = {
+        "model": {
+            "default_model_type": "powerful",
+            "powerful": {
+                "model": "openai/powerful",
+                "api_key": "powerful-key",
+            },
+            "summary": {"model": "openai/test-summary"},
+        }
+    }
+    _patch_active_config(monkeypatch, raw)
+
+    assert set(config_module.C.llm.available_types) == {"powerful", "summary"}
+    assert config_module.C.llm.for_type(None).model == "openai/powerful"
+
+
+def test_llm_common_block_is_ignored(monkeypatch):
+    """common is ignored instead of becoming a model type or fallback source."""
+    raw = {
+        "model": {
+            "default_model_type": "powerful",
+            "common": {
+                "model": "openai/common",
+            },
+            "powerful": {
+                "model": "openai/powerful",
+                "base_url": "https://powerful.example/v1",
+                "api_key": "powerful-key",
+                "requests_per_minute": 12,
+                "temperature": 0.4,
+            },
+            "summary": {"model": "openai/test-summary"},
+        }
+    }
+    _patch_active_config(monkeypatch, raw)
+
+    assert set(config_module.C.llm.available_types) == {"powerful", "summary"}
+    powerful = config_module.C.llm.for_type(None)
+    assert powerful.base_url == "https://powerful.example/v1"
+    assert powerful.api_key == "powerful-key"
+    assert powerful.requests_per_minute == 12
+    assert powerful.temperature == 0.4
+
+    exported = config_module.C.llm.to_legacy_dict()
+    assert "common" not in exported["model"]
+    assert config_module.LLMConfig.from_dict(exported).for_type(None).base_url == "https://powerful.example/v1"
+
+
+def test_llm_legacy_export_does_not_invent_common(monkeypatch):
+    """Export should not create a common model type when config did not define it."""
+    raw = {
+        "model": {
+            "default_model_type": "powerful",
+            "powerful": {"model": "openai/powerful"},
+            "summary": {"model": "openai/test-summary"},
+        }
+    }
+    cfg = config_module.LLMConfig.from_dict(raw)
+
+    exported = cfg.to_legacy_dict()
+
+    assert "common" not in exported["model"]
+    assert config_module.LLMConfig.from_dict(exported).for_type(None).model == "openai/powerful"
 
 
 def test_llm_views_are_readonly(monkeypatch):
     raw = {
         "model": {
             "default_model_type": "powerful",
-            "common": {
-                "model": "openai/test-common",
-                "base_url": "https://common.example/v1",
-                "api_key": "common-key",
-                "requests_per_minute": 10,
-            },
             "powerful": {
                 "model": "openai/powerful",
             },
@@ -129,9 +186,6 @@ def test_llm_views_are_readonly(monkeypatch):
         }
     }
     _patch_active_config(monkeypatch, raw)
-
-    with pytest.raises((ValidationError, AttributeError, TypeError)):
-        config_module.C.llm.common.base_url = "https://new.example/v1"
 
     with pytest.raises((ValidationError, AttributeError, TypeError)):
         config_module.C.llm.for_type("powerful").model = "openai/other"
@@ -141,9 +195,6 @@ def test_llm_max_tokens_default_is_150000(monkeypatch):
     raw = {
         "model": {
             "default_model_type": "powerful",
-            "common": {
-                "model": "openai/test-common",
-            },
             "powerful": {
                 "model": "openai/powerful",
             },

--- a/tests/agent_test/llm_cfg_test/test_model_cfg_passthrough.py
+++ b/tests/agent_test/llm_cfg_test/test_model_cfg_passthrough.py
@@ -27,23 +27,19 @@ def _base_model_config() -> dict:
         },
         "model": {
             "default_model_type": "powerful",
-            "common": {
-                "model": "openai/test-common",
+            "powerful": {
+                "model": "openai/test-model",
                 "base_url": "https://example.test/v1",
-                "api_key": "key-common",
+                "api_key": "key-powerful",
                 "temperature": 0.2,
                 "max_tokens": 1024,
-                "timeout": 30,
+                "timeout": 60,
                 "num_retries": 7,
                 "retry_delay": 2.5,
                 "max_retry_delay": 20.0,
-                "extra_headers": {"X-Common": "1"},
+                "extra_headers": {"X-Model": "powerful"},
                 "requests_per_minute": 11,
-            },
-            "powerful": {
-                "model": "openai/test-model",
                 "description": "Powerful model for complex tasks",
-                "timeout": 60,
             },
             "fast": {
                 "model": "openai/fast-model",
@@ -62,23 +58,21 @@ def test_llm_member_access_and_model_config_fields(monkeypatch):
     cfg = model_types.ModelTypeManager.get_llm_config(model_types.ModelType("powerful"))
 
     assert llm.default_model_type == "powerful"
-    assert set(llm.available_types) == {"common", "powerful", "fast", "summary"}
-    assert llm.common.base_url == "https://example.test/v1"
-    assert llm.common.requests_per_minute == 11
+    assert set(llm.available_types) == {"powerful", "fast", "summary"}
     assert llm.for_type("powerful").model == "openai/test-model"
 
     assert cfg.model_id == "openai/test-model"
     assert cfg.base_url == "https://example.test/v1"
-    assert cfg.api_key == "key-common"
+    assert cfg.api_key == "key-powerful"
     assert cfg.timeout == 60
     assert cfg.num_retries == 7
     assert cfg.retry_delay == 2.5
     assert cfg.max_retry_delay == 20.0
     assert cfg.description == "Powerful model for complex tasks"
-    assert cfg.extra_headers == {"X-Common": "1"}
+    assert cfg.extra_headers == {"X-Model": "powerful"}
 
 
-def test_model_config_specific_extra_headers_override_common(monkeypatch):
+def test_model_config_specific_extra_headers_are_preserved(monkeypatch):
     config = _base_model_config()
     config["model"]["powerful"]["extra_headers"] = {"X-Specific": "yes"}
     _patch_yaml_config(monkeypatch, config)
@@ -103,9 +97,9 @@ def test_model_manager_litellm_config_contains_passthrough_fields(monkeypatch):
     assert params["num_retries"] == 7
     assert params["retry_delay"] == 2.5
     assert params["max_retry_delay"] == 20.0
-    assert params["extra_headers"] == {"X-Common": "1"}
+    assert params["extra_headers"] == {"X-Model": "powerful"}
     assert params["api_base"] == "https://example.test/v1"
-    assert params["api_key"] == "key-common"
+    assert params["api_key"] == "key-powerful"
 
 
 def test_langfuse_private_key_fallback(monkeypatch):

--- a/tests/agent_test/sys_config/test_code_agent_and_tools_override.py
+++ b/tests/agent_test/sys_config/test_code_agent_and_tools_override.py
@@ -24,9 +24,12 @@ default_loaded_tools:
   - shell_tool
     """)
     (system_config_dir / "llm.yaml").write_text("""
-common:
-  provider: "openai"
-  model: "gpt-4o"
+model:
+  default_model_type: powerful
+  powerful:
+    model: "openai/gpt-4o"
+  summary:
+    model: "openai/gpt-4o-mini"
 """)
     
     (config_dir / "system.yaml").write_text("""
@@ -80,4 +83,3 @@ def test_code_agent_and_tools_inherits_from_app_override(code_agent_override_con
     tool_names = [getattr(t, "name", getattr(t, "__name__", str(t))) for t in tools]
     assert "load_skill" in tool_names
     assert "shell_tool" not in tool_names
-

--- a/tests/agent_test/sys_config/test_execution_env_override.py
+++ b/tests/agent_test/sys_config/test_execution_env_override.py
@@ -27,9 +27,12 @@ execution_env:
   bash_path: /bin/bash
     """)
     (system_config_dir / "llm.yaml").write_text("""
-common:
-  provider: "openai"
-  model: "gpt-4o"
+model:
+  default_model_type: powerful
+  powerful:
+    model: "openai/gpt-4o"
+  summary:
+    model: "openai/gpt-4o-mini"
 """)
     
     # Create application config override

--- a/tests/agent_test/sys_config/test_llm_config_only_from_llm_yaml.py
+++ b/tests/agent_test/sys_config/test_llm_config_only_from_llm_yaml.py
@@ -45,14 +45,17 @@ def test_model_config_loaded_from_llm_yaml(tmp_path, monkeypatch):
         llm_yaml_data={
             "model": {
                 "default_model_type": "powerful",
-                "common": {
-                    "model": "openai/test-common",
+                "powerful": {
+                    "model": "openai/gpt-5",
                     "base_url": "https://llm-from-llm-yaml.test/v1",
                     "api_key": "llm-yaml-key",
                     "requests_per_minute": 15,
                 },
-                "powerful": {"model": "openai/gpt-5"},
-                "fast": {"model": "openai/gpt-4o-mini"},
+                "fast": {
+                    "model": "openai/gpt-4o-mini",
+                    "base_url": "https://fast.test/v1",
+                    "api_key": "fast-key",
+                },
                 "summary": {"model": "openai/test-summary"},
             },
         },
@@ -61,10 +64,10 @@ def test_model_config_loaded_from_llm_yaml(tmp_path, monkeypatch):
 
     assert cfg.llm.for_type("powerful").model == "openai/gpt-5"
     assert cfg.llm.for_type("fast").model == "openai/gpt-4o-mini"
-    assert cfg.llm.common.base_url == "https://llm-from-llm-yaml.test/v1"
-    assert cfg.llm.common.api_key == "llm-yaml-key"
-    assert cfg.llm.common.requests_per_minute == 15
-    assert set(cfg.llm.available_types) == {"common", "powerful", "fast", "summary"}
+    assert cfg.llm.for_type("powerful").base_url == "https://llm-from-llm-yaml.test/v1"
+    assert cfg.llm.for_type("powerful").api_key == "llm-yaml-key"
+    assert cfg.llm.for_type("powerful").requests_per_minute == 15
+    assert set(cfg.llm.available_types) == {"powerful", "fast", "summary"}
 
 
 def test_langfuse_loaded_from_llm_yaml(tmp_path, monkeypatch):
@@ -75,8 +78,7 @@ def test_langfuse_loaded_from_llm_yaml(tmp_path, monkeypatch):
         llm_yaml_data={
             "model": {
                 "default_model_type": "powerful",
-                "common": {"model": "openai/test-common", "base_url": "https://test/v1", "api_key": "k"},
-                "powerful": {"model": "openai/test"},
+                "powerful": {"model": "openai/test", "base_url": "https://test/v1", "api_key": "k"},
                 "summary": {"model": "openai/test-summary"},
             },
             "langfuse": {
@@ -103,8 +105,7 @@ def test_model_in_system_yaml_ignored_llm_yaml_wins(tmp_path, monkeypatch):
             # 这些 LLM 键会被 _filter_llm_only_top_level_keys 过滤
             "model": {
                 "default_model_type": "fast",
-                "common": {"model": "openai/test-common", "base_url": "https://wrong.test/v1", "api_key": "wrong-key"},
-                "powerful": {"model": "openai/wrong-model"},
+                "powerful": {"model": "openai/wrong-model", "base_url": "https://wrong.test/v1", "api_key": "wrong-key"},
                 "summary": {"model": "openai/test-summary"},
             },
             "langfuse": {
@@ -115,8 +116,7 @@ def test_model_in_system_yaml_ignored_llm_yaml_wins(tmp_path, monkeypatch):
         llm_yaml_data={
             "model": {
                 "default_model_type": "powerful",
-                "common": {"model": "openai/test-common", "base_url": "https://correct.test/v1", "api_key": "correct-key"},
-                "powerful": {"model": "openai/correct-model"},
+                "powerful": {"model": "openai/correct-model", "base_url": "https://correct.test/v1", "api_key": "correct-key"},
                 "summary": {"model": "openai/test-summary"},
             },
             "langfuse": {
@@ -129,9 +129,9 @@ def test_model_in_system_yaml_ignored_llm_yaml_wins(tmp_path, monkeypatch):
 
     # llm.yaml 的配置生效
     assert cfg.llm.default_model_type == "powerful"
-    assert cfg.llm.common.base_url == "https://correct.test/v1"
-    assert cfg.llm.common.api_key == "correct-key"
     assert cfg.llm.for_type("powerful").model == "openai/correct-model"
+    assert cfg.llm.for_type("powerful").base_url == "https://correct.test/v1"
+    assert cfg.llm.for_type("powerful").api_key == "correct-key"
     assert cfg.llm.langfuse.enabled is True
     assert cfg.llm.langfuse.host == "https://correct-langfuse.test"
 
@@ -144,8 +144,7 @@ def test_llm_yaml_missing_fields_use_defaults(tmp_path, monkeypatch):
         llm_yaml_data={
             "model": {
                 "default_model_type": "powerful",
-                "common": {"model": "openai/test-common", "base_url": "https://test/v1", "api_key": "k"},
-                "powerful": {"model": "openai/test"},
+                "powerful": {"model": "openai/test", "base_url": "https://test/v1", "api_key": "k"},
                 "summary": {"model": "openai/test-summary"},
             },
             # 不写 langfuse — 应使用默认值

--- a/tests/smolagents_test/test_yaml_execution_env_docker_real_llm.py
+++ b/tests/smolagents_test/test_yaml_execution_env_docker_real_llm.py
@@ -78,22 +78,18 @@ def _load_model_runtime_from_yaml() -> dict[str, Any] | None:
     if not selected_model_id:
         return None
 
-    common_cfg = model_section.get("common")
-    if not isinstance(common_cfg, dict):
-        common_cfg = {}
-
     selected_cfg = model_section.get(selected_profile) if selected_profile else {}
     if not isinstance(selected_cfg, dict):
         selected_cfg = {}
 
     return {
         "model_id": selected_model_id,
-        "api_base": selected_cfg.get("base_url", common_cfg.get("base_url")),
-        "api_key": selected_cfg.get("api_key", common_cfg.get("api_key")),
-        "requests_per_minute": selected_cfg.get("requests_per_minute", common_cfg.get("requests_per_minute")),
-        "timeout": selected_cfg.get("timeout", common_cfg.get("timeout", 120)),
-        "temperature": selected_cfg.get("temperature", common_cfg.get("temperature", 0.0)),
-        "max_tokens": selected_cfg.get("max_tokens", common_cfg.get("max_tokens", 1024)),
+        "api_base": selected_cfg.get("base_url"),
+        "api_key": selected_cfg.get("api_key"),
+        "requests_per_minute": selected_cfg.get("requests_per_minute"),
+        "timeout": selected_cfg.get("timeout", 120),
+        "temperature": selected_cfg.get("temperature", 0.0),
+        "max_tokens": selected_cfg.get("max_tokens", 1024),
     }
 
 

--- a/tests/test_native_tool_calls_detection.py
+++ b/tests/test_native_tool_calls_detection.py
@@ -122,9 +122,6 @@ class TestLlmConfigParsing:
 
         raw = {
             "model": {
-                "common": {
-                    "model": "test/common",
-                },
                 "powerful": {
                     "model": "test/powerful",
                     "supports_native_tool_calls": "false",
@@ -136,7 +133,6 @@ class TestLlmConfigParsing:
         }
         config = LLMConfig.from_dict(raw)
         assert config.models["powerful"].supports_native_tool_calls == "false"
-        # summary should default to common's value (auto by default)
         assert config.models["summary"].supports_native_tool_calls == "auto"
 
     def test_from_dict_invalid_value_defaults_to_auto(self):
@@ -145,9 +141,6 @@ class TestLlmConfigParsing:
 
         raw = {
             "model": {
-                "common": {
-                    "model": "test/common",
-                },
                 "powerful": {
                     "model": "test/powerful",
                     "supports_native_tool_calls": "invalid_value",
@@ -160,8 +153,8 @@ class TestLlmConfigParsing:
         config = LLMConfig.from_dict(raw)
         assert config.models["powerful"].supports_native_tool_calls == "auto"
 
-    def test_common_value_inherited(self):
-        """Common-level supports_native_tool_calls should be inherited."""
+    def test_type_value_defaults_to_auto_without_inheritance(self):
+        """Model types do not inherit supports_native_tool_calls from other types."""
         from src.lib.config.llm_config import LLMConfig
 
         raw = {
@@ -179,11 +172,11 @@ class TestLlmConfigParsing:
             },
         }
         config = LLMConfig.from_dict(raw)
-        # Should inherit from common
-        assert config.models["powerful"].supports_native_tool_calls == "false"
+        assert "common" not in config.models
+        assert config.models["powerful"].supports_native_tool_calls == "auto"
 
-    def test_type_level_overrides_common(self):
-        """Type-level value should override common value."""
+    def test_type_level_value_is_independent(self):
+        """Each type's supports_native_tool_calls value is independent."""
         from src.lib.config.llm_config import LLMConfig
 
         raw = {
@@ -203,4 +196,4 @@ class TestLlmConfigParsing:
         }
         config = LLMConfig.from_dict(raw)
         assert config.models["powerful"].supports_native_tool_calls == "true"
-        assert config.models["summary"].supports_native_tool_calls == "false"
+        assert config.models["summary"].supports_native_tool_calls == "auto"

--- a/tools/skills-cn/create-app/SKILL.md
+++ b/tools/skills-cn/create-app/SKILL.md
@@ -84,7 +84,7 @@ AgentLoom Application 脚手架生成 Skill。可被 **Copilot Codex / Claude Co
 | 2 | **一句话功能描述** | ✅ | — | 必须由用户提供；用于 Agent 描述 |
 | 3 | **模式选择：单 Agent / 多 Agent** | ✅ | — | 任务可拆分为多个阶段 → 多 Agent；单一职责 → 单 Agent |
 | 4 | 多 Agent：阶段名称及职责 | 多 Agent 时必填 ✅ | — | 从用户描述中提取，或根据任务性质建议拆分方案 |
-| 5 | model_type | ❌ | 继承 `config/llm.yaml` 的 `model.default_model_type` | 读取项目配置后确认：使用默认 / 明确指定 |
+| 5 | model_type | ❌ | 仅当 `config/llm.yaml` 配置了 `model.default_model_type` 时才使用该默认值 | 读取项目配置后确认：使用已配置默认 / 明确指定 |
 | 6 | tool_call_type | ❌ | `code_act` | 极少需要更改 |
 | 7 | 预定义 Tool 列表 | ❌ | 根据任务自动推荐 | 分析 → `read_file`+`get_file_outline`；修改 → `edit_file`；报告 → `write_markdown_file` |
 | 8 | 自定义 Tool | ❌ | 无 | 用户明确提到需要自定义 Python 函数时 |
@@ -100,13 +100,14 @@ AgentLoom Application 脚手架生成 Skill。可被 **Copilot Codex / Claude Co
 在编写任何 Agent YAML 之前，先从项目根目录读取 `config/llm.yaml`：
 
 1. 从 `model` 节点提取可用类型（排除保留键 `default_model_type` 和非 dict 值）。
-2. 读取 `model.default_model_type` 作为默认模型类型。
+2. 读取 `model.default_model_type` 作为项目默认模型类型。如果缺失，不要省略 `model_type`；应明确选择一个可用类型。
 3. 在交互场景中，向用户确认：
    - 是否使用 `default_model_type`；
    - 如果不使用，展示"项目中可用的类型 + 自定义"供选择。
 4. 在自主场景中：
-   - 如果配置可读，默认使用 `default_model_type`；
-   - 如果读取失败，使用"继承项目默认模型类型"策略并在"假设列表"中声明。
+   - 如果配置可读且设置了 `default_model_type`，默认使用它；
+   - 如果缺少 `default_model_type`，明确选择一个可用类型；
+   - 如果读取失败，使用"必须显式指定 model_type 或确保项目默认已配置"策略并在"假设列表"中声明。
 
 > 约束：`model_type` 的可选值由项目配置决定，不是硬编码为 `powerful/fast/summary`。
 
@@ -138,7 +139,7 @@ AgentLoom Application 脚手架生成 Skill。可被 **Copilot Codex / Claude Co
 
 ```
 4. 使用哪种 model_type 策略？
-   - 使用项目默认（default_model_type）
+   - 使用已配置的项目默认（default_model_type）
    - 明确指定（从项目可用 model_type 列表中选择）
    - 自定义（必须已在 config/llm.yaml 中定义）
 ```
@@ -176,7 +177,7 @@ applications/<app_name>/
 
 ### Supervisor 配置摘要
 - name: <supervisor_name>
-- model_type: <使用 default_model_type 或明确指定的值>
+- model_type: <使用已配置的 default_model_type 或明确指定的值>
 - tool_call_type: <tool_call_type>
 - 自定义 Tool：<列表>
 - Worker 数量：N
@@ -184,8 +185,8 @@ applications/<app_name>/
 ### Worker 配置摘要
 | 阶段 | 名称 | 职责 | model_type 策略 | Tool |
 |------|------|------|-----------------|------|
-| 1 | <worker_a> | ... | 继承默认或明确指定 | [...] |
-| 2 | <worker_b> | ... | 继承默认或明确指定 | [...] |
+| 1 | <worker_a> | ... | 使用已配置默认或明确指定 | [...] |
+| 2 | <worker_b> | ... | 使用已配置默认或明确指定 | [...] |
 ```
 
 ### 单 Agent 模式计划模板
@@ -205,7 +206,7 @@ applications/<app_name>/
 
 ### Agent 配置摘要
 - name: <agent_name>
-- model_type: <使用 default_model_type 或明确指定的值>
+- model_type: <使用已配置的 default_model_type 或明确指定的值>
 - tool_call_type: <tool_call_type>
 - Tool：<列表>
 - max_steps: <N>
@@ -229,7 +230,7 @@ applications/<app_name>/
 - **路径**：`applications/<app_name>/workflows/<app_name>_agent.yaml`
 - **必填字段**：`name`、`description`、`workflow`（`|` 多行文本，或用于顺序工作流的非空 `list[str]`）
 - **Workflow 最佳实践**：建议采用五段式结构（① 背景与角色 ② 核心职责与约束 ③ 执行流程（使用 ````mermaid```` 代码块，框架会自动提取以注入强约束指令） ④ 各步骤详细说明 ⑤ 输出要求）。
-- **关键字段**：`model_type`（可选，省略时继承默认值）、`tool_call_type`、`tools`、`worker_agents`（仅使用 `path`）、`skills`（可选）、`execution_env`
+- **关键字段**：`model_type`（仅当已配置 `model.default_model_type` 时才可省略；否则必须明确指定）、`tool_call_type`、`tools`、`worker_agents`（仅使用 `path`）、`skills`（可选）、`execution_env`
 - **完整模板** → 参见 [templates.md](./references/templates.md) §3.1
 
 ### 3.2 Worker YAML（每个阶段一个文件）
@@ -424,7 +425,7 @@ loom run applications/<app_name>/workflows/<app_name>_agent.yaml
 - [ ] 自定义 Tool 的 `module` 和 `function` 成对出现
 - [ ] 自定义 Tool 是纯 Python 函数（无 `@tool` 装饰器），且有完整的 docstring
 - [ ] Agent YAML 中不包含 `model`/`llm`/`langfuse` 字段
-- [ ] `model_type` 策略已确认：使用 `default_model_type` 或明确指定项目中可用的类型
+- [ ] `model_type` 策略已确认：使用已配置的 `default_model_type` 或明确指定项目中可用的类型
 - [ ] 如果配置了 `execution_env`，`type` 必须为 `local` / `docker` / `e2b` / `wasm` 之一
 - [ ] 如果配置了 `skills`，其结构必须为 `list / dict / string`
 - [ ] 入口脚本 `_app.py` 中的 YAML 路径与实际文件路径一致

--- a/tools/skills-cn/create-app/references/full-example.md
+++ b/tools/skills-cn/create-app/references/full-example.md
@@ -19,8 +19,8 @@
 | Q1 Application 名称 | `code_review` |
 | Q2 一句话描述 | `对 Git 仓库进行多维度代码审查并输出结构化审查报告` |
 | Q3 Worker 阶段 | 3 个阶段：① 代码扫描与结构分析 ② 风险评估与问题标记 ③ 报告汇总 |
-| Q4 model_type 可用选项发现 | 读取 `config/llm.yaml`，发现可用类型：`common` / `powerful` / `fast` / `summary`，`default_model_type=powerful` |
-| Q5 Supervisor model_type 策略 | 使用 `default_model_type`（不明确指定） |
+| Q4 model_type 可用选项发现 | 读取 `config/llm.yaml`，发现可用类型：`powerful` / `fast` / `summary`，`default_model_type=powerful` |
+| Q5 Supervisor model_type 策略 | 使用已配置的 `default_model_type`（不明确指定） |
 | Q6 Worker model_type 策略 | 与 Supervisor 相同（不明确指定） |
 | Q7 tool_call_type | `code_act` |
 | Q8 自定义 Tool | 一个 `get_repo_context` Tool，用于获取仓库概览 |
@@ -57,7 +57,7 @@ applications/code_review/
 
 Supervisor 配置摘要：
 - name: code_review_agent
-- model_type: 继承 default_model_type（不明确指定）
+- model_type: 使用已配置的 default_model_type（不明确指定）
 - tool_call_type: code_act
 - 自定义 Tool：get_repo_context
 - Worker 数量：3
@@ -65,9 +65,9 @@ Supervisor 配置摘要：
 Worker 配置摘要：
 | 阶段 | 名称                    | 职责              | model_type 策略 | Tool                                                   |
 |------|-------------------------|--------------------|-----------------|--------------------------------------------------------|
-| 1    | code_scan               | 代码扫描与结构分析 | 继承默认        | read_file, get_file_outline, ripgrep_search_directory |
-| 2    | risk_assessment         | 风险评估与问题标记 | 继承默认        | read_file, ripgrep_search_directory             |
-| 3    | report_generation       | 报告汇总           | 继承默认        | write_markdown_file                                     |
+| 1    | code_scan               | 代码扫描与结构分析 | 使用已配置默认 | read_file, get_file_outline, ripgrep_search_directory |
+| 2    | risk_assessment         | 风险评估与问题标记 | 使用已配置默认 | read_file, ripgrep_search_directory             |
+| 3    | report_generation       | 报告汇总           | 使用已配置默认 | write_markdown_file                                     |
 ```
 
 用户确认：✅

--- a/tools/skills-cn/create-app/references/quick-reference.md
+++ b/tools/skills-cn/create-app/references/quick-reference.md
@@ -59,7 +59,7 @@
 
 `model_type` 不是固定枚举——应从项目的 `config/llm.yaml` 中动态读取：
 
-1. 读取 `model.default_model_type` 作为默认类型。
+1. 读取 `model.default_model_type` 作为项目默认类型。如果缺失，生成的 Agent YAML 必须显式设置 `model_type`。
 2. 读取 `model` 下的其余键作为可用类型（排除保留键 `default_model_type` 和非 dict 值）。
 3. 在交互场景中，向用户确认：使用默认 / 明确指定 / 自定义。
 4. 自定义值必须已在 `config/llm.yaml` 中定义，否则运行时会报错。

--- a/tools/skills-cn/create-app/references/templates.md
+++ b/tools/skills-cn/create-app/references/templates.md
@@ -16,7 +16,7 @@ description: |
   <用户提供的一句话描述，扩展为 2-3 句完整的角色定位>
 
 # model_type 选项：
-# - 省略：继承 config/llm.yaml 中 model.default_model_type 的值
+# - 仅当 config/llm.yaml 配置了 model.default_model_type 时可省略
 # - 指定：使用明确的类型（必须存在于 config/llm.yaml 的 model 节点中）
 # model_type: "<selected_model_type>"
 tool_call_type: "<tool_call_type>"
@@ -88,7 +88,7 @@ workflow:
 name: "step<N>_<name>"
 description: "<阶段描述>"
 tool_call_type: "<tool_call_type>"
-# model_type 可选，策略与 Supervisor 相同
+# model_type 策略与 Supervisor 相同
 # model_type: "<selected_model_type>"
 tools:
   - name: "<tool1>"
@@ -274,7 +274,7 @@ system_prompt: |
 name: "<app_name>"
 description: "<一句话描述>"
 # model_type 选项：
-# - 省略：继承 config/llm.yaml 中 model.default_model_type 的值
+# - 仅当 config/llm.yaml 配置了 model.default_model_type 时可省略
 # - 指定：使用明确的类型（必须存在于 config/llm.yaml 的 model 节点中）
 # model_type: "<selected_model_type>"
 tool_call_type: "<tool_call_type>"

--- a/tools/skills-cn/create-app/references/troubleshooting.md
+++ b/tools/skills-cn/create-app/references/troubleshooting.md
@@ -73,8 +73,8 @@ print(<function_name>.__doc__[:100])
 
 ### 症状
 ```
-KeyError: 'xxx' not found in llm config
-ValueError: Unknown model_type: ...
+ValueError: Model type 'xxx' is not defined in config/llm.yaml; the model call was not started.
+ValueError: No model_type was provided and config/llm.yaml does not set `model.default_model_type`; the model call was not started.
 ```
 
 ### 排查步骤
@@ -82,6 +82,7 @@ ValueError: Unknown model_type: ...
 1. 检查 `config/llm.yaml` 中是否定义了该 model_type
 2. 从 `config/llm.yaml` 的 `model` 节点动态确认可用类型（排除 `default_model_type` 和非字典值）
 3. 自定义 model_type 值必须先在 `config/llm.yaml` 中添加为配置块
+4. 如果 Agent YAML 省略了 `model_type`，确认 `model.default_model_type` 已配置且指向可用类型
 
 ### 快速验证
 

--- a/tools/skills-cn/shell-security/references/per-agent-examples.md
+++ b/tools/skills-cn/shell-security/references/per-agent-examples.md
@@ -71,7 +71,7 @@ workflow: |
 ```yaml
 name: "text_analyzer"
 description: "纯文本分析 Agent，不需要 Shell"
-model_type: "common"
+model_type: "fast"
 tool_call_type: "code_act"
 tools:
 

--- a/tools/skills-cn/update-skills/references/update-checklist.md
+++ b/tools/skills-cn/update-skills/references/update-checklist.md
@@ -29,11 +29,11 @@
   - 必填字段数量是否正确（name, description, workflow -- 3 个必填）
   - 可选字段列表是否完整（tools, model_type, tool_call_type, worker_agents, execution_env, prompt, skills, planning_interval, max_steps）
 - [ ] **信息提取检查清单（#1-#14）**：默认值和描述是否与最新文档一致
-  - `model_type` 默认值描述：继承自 `config/llm.yaml` 的 `model.default_model_type`
+  - `model_type` 默认值描述：仅当 `config/llm.yaml` 配置了 `model.default_model_type` 时使用；否则必须显式指定 `model_type`
   - `tool_call_type` 默认值：`code_act`
   - `execution_env` 可用值：`local`、`docker`、`e2b`、`wasm`
 - [ ] **model_type 发现和确认工作流**：与 `docs/cn/llm_config.md` 对齐
-  - 参数继承链：`models[model_type].param` -> `models.common.param` -> 代码默认值
+  - 参数读取链：`models[model_type].param` -> 代码默认值
   - 可用的 model_types 应从 `config/llm.yaml` 动态发现（排除 `default_model_type`），而非硬编码为固定集合
 - [ ] **LLM 配置隔离描述**：与 `docs/cn/config-overview.md` 和 `docs/cn/agent_config.md` 对齐
   - Agent YAML 中不得包含 `model`/`llm`/`langfuse`；这些会被自动过滤并输出警告
@@ -75,7 +75,7 @@
 ### references/full-example.md
 
 - [ ] **端到端示例流程**：目录结构和字段与最新文档和代码行为一致
-- [ ] **示例中的 model_type 策略**：反映了"动态发现 + 默认继承"机制
+- [ ] **示例中的 model_type 策略**：反映动态发现，以及必须使用已配置默认或显式类型的机制
 - [ ] **示例中的 skills/worker 配置**：与当前 `docs/cn/agent_config.md` 规则一致
 
 ### references/agent-yaml-schema.json

--- a/tools/skills-cn/workflow-review/SKILL.md
+++ b/tools/skills-cn/workflow-review/SKILL.md
@@ -219,7 +219,7 @@ print(extract_workflow_text('.../worker_agents/<step>.yaml'))
 **LLM 配置隔离：**
 - Agent YAML 或 `system.yaml` 中的 `model`、`llm`、`langfuse` 字段会被**自动过滤**并输出 warning 日志——所有 LLM 参数只能在 `config/llm.yaml` 中配置
 - Agent 通过 `model_type` 选择模型；若指定的类型在 `llm.yaml` 中不存在，运行时直接抛出 `ValueError`（不会静默回退）
-- 未指定 `model_type` 时的回退链：使用 `llm.yaml` 的 `default_model_type`（默认为 `"common"`）
+- 未指定 `model_type` 时，使用全局 `llm.yaml` 的 `default_model_type`；如果该 key 未配置或解析出的类型不存在，运行时抛出 `ValueError`。
 
 **配置覆盖：**
 - Agent YAML overlay 白名单（仅 7 个字段）：`system`、`smart_summary`、`tool_access_control`、`execution_env`、`code_agent`、`tools`、`prompt`

--- a/tools/skills-cn/workflow-review/references/best-practices.md
+++ b/tools/skills-cn/workflow-review/references/best-practices.md
@@ -256,7 +256,7 @@ AgentLoom 提供**内置断点续跑/心跳监控系统**，无需应用层代�
 
 | 参数 | 默认值 | 常见陷阱 | 推荐做法 |
 |------|--------|---------|---------|
-| `model_type` | `llm.yaml` 的 `default_model_type`（通常为 `"common"`） | 指定不存在的类型导致运行时 `ValueError`（不会静默回退） | 验证类型在 `llm.yaml` 中存在；复杂推理用 `powerful`，简单任务用 `fast` |
+| `model_type` | 全局 `llm.yaml` 的 `default_model_type`；若该 key 未配置则没有隐式默认值 | 指定不存在的类型导致运行时 `ValueError`（不会静默回退） | 验证类型在 `llm.yaml` 中存在；复杂推理用 `powerful`，简单任务用 `fast` |
 | `tool_call_type` | `"code_act"` | 对 Supervisor 使用 `tool_call` 会限制编排能力 | Supervisor 和复杂 Worker 用 `code_act`；简单单工具 Worker 用 `tool_call` |
 | `max_steps` | `80` | 简单 Worker 默认值过高（浪费资源）；复杂 Supervisor 可能过低 | 按任务复杂度设置；简单 Worker: 20-40；复杂 Supervisor: 60-120 |
 | `planning_interval` | 未设置 | 长任务链无定期规划会迷失进度 | 预期 20+ 步的 Agent 设置为 3-5 |
@@ -267,7 +267,7 @@ AgentLoom 提供**内置断点续跑/心跳监控系统**，无需应用层代�
 
 - **禁止**在 Agent YAML 或 `system.yaml` 中写 `model`、`llm`、`langfuse` 字段——它们会被自动过滤并输出 warning 日志
 - Agent 仅通过 `model_type` 选择模型；所有 LLM 参数只能在 `config/llm.yaml` 中配置
-- 未指定 `model_type` 时的回退链：`default_model_type` → `"common"` 类型 → 代码内置默认值
+- 未指定 `model_type` 时，Agent 使用全局 `default_model_type`；若该 key 未配置或解析出的类型不存在，运行时抛出 `ValueError`。
 
 ### 配置 overlay 白名单
 

--- a/tools/skills-cn/workflow-review/references/review-checklist.md
+++ b/tools/skills-cn/workflow-review/references/review-checklist.md
@@ -113,7 +113,7 @@
 - [ ] 指定的 `model_type` 是否存在于 `config/llm.yaml` 中？（不存在的类型会在运行时抛出 `ValueError`——不会静默回退）
 - [ ] `model_type` 是否与任务复杂度匹配？（`powerful` 用于复杂推理，`fast` 用于简单分类，`summary` 用于信息提取）
 - [ ] Agent YAML 是否包含被禁止的 LLM 字段（`model`、`llm`、`langfuse`）？（被自动过滤并输出 warning——所有 LLM 参数只能在 `config/llm.yaml`）
-- [ ] 未指定 `model_type` 时，`default_model_type`（默认为 `"common"`）是否适合？
+- [ ] 未指定 `model_type` 时，`llm.yaml` 中是否配置了合适的 `default_model_type`？
 
 ### 3.5 工具能力发现
 

--- a/tools/skills/create-app/SKILL.md
+++ b/tools/skills/create-app/SKILL.md
@@ -84,7 +84,7 @@ Extract the following information from the user's prompt or conversation. **Bold
 | 2 | **One-line feature description** | ✅ | — | Must be provided by user; used for Agent description |
 | 3 | **Mode selection: single Agent / multi-Agent** | ✅ | — | Task can be split into multiple phases → multi-Agent; single responsibility → single Agent |
 | 4 | Multi-Agent: phase names and responsibilities | Required for multi-Agent ✅ | — | Extract from user description, or suggest splits based on task nature |
-| 5 | model_type | ❌ | Inherits `config/llm.yaml`'s `model.default_model_type` | Confirm after reading project config: use default / explicitly specify |
+| 5 | model_type | ❌ | Uses `config/llm.yaml`'s `model.default_model_type` only when that key is configured | Confirm after reading project config: use configured default / explicitly specify |
 | 6 | tool_call_type | ❌ | `code_act` | Rarely needs changing |
 | 7 | Predefined tool list | ❌ | Auto-recommended based on task | Analysis → `read_file`+`get_file_outline`; Modification → `edit_file`; Reporting → `write_markdown_file` |
 | 8 | Custom tools | ❌ | None | When user explicitly mentions needing custom Python functions |
@@ -100,13 +100,14 @@ Extract the following information from the user's prompt or conversation. **Bold
 Before writing any Agent YAML, first read `config/llm.yaml` from the project root:
 
 1. Extract available types from the `model` node (excluding reserved keys `default_model_type` and non-dict values).
-2. Read `model.default_model_type` as the default model type.
+2. Read `model.default_model_type` as the project default model type. If it is missing, do not omit `model_type`; choose an explicit available type.
 3. In interactive scenarios, confirm with the user:
    - Whether to use the `default_model_type`;
    - If not, display "available types in the project + custom" for selection.
 4. In autonomous scenarios:
-   - If config is readable, default to using `default_model_type`;
-   - If reading fails, use the "inherit project default model type" strategy and declare it in the "assumptions list".
+   - If config is readable and `default_model_type` is set, default to using it;
+   - If `default_model_type` is missing, explicitly choose an available type;
+   - If reading fails, use the "explicit model_type required or configured project default required" strategy and declare it in the "assumptions list".
 
 > Constraint: The available options for `model_type` are determined by the project configuration, not hardcoded as `powerful/fast/summary`.
 
@@ -138,7 +139,7 @@ If `config/llm.yaml` has been identified, follow up with (optional but recommend
 
 ```
 4. Which model_type strategy to use?
-   - Use project default (default_model_type)
+   - Use configured project default (`default_model_type`)
    - Explicitly specify (choose from available model_type list in the project)
    - Custom (must be already defined in config/llm.yaml)
 ```
@@ -176,7 +177,7 @@ applications/<app_name>/
 
 ### Supervisor Configuration Summary
 - name: <supervisor_name>
-- model_type: <use default_model_type or explicitly specified value>
+- model_type: <use configured default_model_type or explicitly specified value>
 - tool_call_type: <tool_call_type>
 - Custom tools: <list>
 - Worker count: N
@@ -184,8 +185,8 @@ applications/<app_name>/
 ### Worker Configuration Summary
 | Stage | Name | Responsibility | model_type Strategy | Tools |
 |-------|------|----------------|---------------------|-------|
-| 1 | <worker_a> | ... | Inherit default or explicitly specify | [...] |
-| 2 | <worker_b> | ... | Inherit default or explicitly specify | [...] |
+| 1 | <worker_a> | ... | Use configured default or explicitly specify | [...] |
+| 2 | <worker_b> | ... | Use configured default or explicitly specify | [...] |
 ```
 
 ### Single Agent Mode Plan Template
@@ -205,7 +206,7 @@ applications/<app_name>/
 
 ### Agent Configuration Summary
 - name: <agent_name>
-- model_type: <use default_model_type or explicitly specified value>
+- model_type: <use configured default_model_type or explicitly specified value>
 - tool_call_type: <tool_call_type>
 - Tools: <list>
 - max_steps: <N>
@@ -229,7 +230,7 @@ After entering Phase 3, **generate all files in the following order** (interacti
 - **Path**: `applications/<app_name>/workflows/<app_name>_agent.yaml`
 - **Required fields**: `name`, `description`, `workflow` (`|` multiline text, or non-empty `list[str]` for sequential workflows)
 - **Workflow Best Practice**: The `workflow` field should ideally follow a five-section structure: 1. Background, 2. Core Responsibilities & Constraints, 3. Execution Flow (use ````mermaid```` code blocks — the framework automatically extracts this to inject strict instructions), 4. Detailed Steps, 5. Output Requirements.
-- **Key fields**: `model_type` (optional, inherits default when omitted), `tool_call_type`, `tools`, `worker_agents` (use `path` only), `skills` (optional), `execution_env`
+- **Key fields**: `model_type` (optional only when `model.default_model_type` is configured; otherwise specify explicitly), `tool_call_type`, `tools`, `worker_agents` (use `path` only), `skills` (optional), `execution_env`
 - **Full template** → See [templates.md](./references/templates.md) §3.1
 
 ### 3.2 Worker YAML (one file per phase)
@@ -425,7 +426,7 @@ After all files are generated, perform the following checks to ensure correctnes
 - [ ] Custom tool `module` and `function` appear in pairs
 - [ ] Custom tools are plain Python functions (no `@tool` decorator) with complete docstrings
 - [ ] Agent YAML does not contain `model`/`llm`/`langfuse` fields
-- [ ] `model_type` strategy has been confirmed: use `default_model_type` or explicitly specify an available type in the project
+- [ ] `model_type` strategy has been confirmed: use configured `default_model_type` or explicitly specify an available type in the project
 - [ ] If `execution_env` is configured, `type` must be one of `local` / `docker` / `e2b` / `wasm`
 - [ ] If `skills` is configured, its structure must be `list / dict / string`
 - [ ] The YAML path in the entry script `_app.py` matches the actual file path

--- a/tools/skills/create-app/references/full-example.md
+++ b/tools/skills/create-app/references/full-example.md
@@ -19,8 +19,8 @@ User requirement: "Help me create a Code Review Application that can perform mul
 | Q1 Application name | `code_review` |
 | Q2 One-line description | `Perform multi-dimensional code review on a Git repository and output a structured review report` |
 | Q3 Worker stages | 3 stages: ① Code scanning & structure analysis ② Risk assessment & issue tagging ③ Report summary |
-| Q4 model_type available options discovery | Read `config/llm.yaml`, discovered available types: `common` / `powerful` / `fast` / `summary`, `default_model_type=powerful` |
-| Q5 Supervisor model_type strategy | Use `default_model_type` (not explicitly specified) |
+| Q4 model_type available options discovery | Read `config/llm.yaml`, discovered available types: `powerful` / `fast` / `summary`, `default_model_type=powerful` |
+| Q5 Supervisor model_type strategy | Use configured `default_model_type` (not explicitly specified) |
 | Q6 Worker model_type strategy | Same as Supervisor (not explicitly specified) |
 | Q7 tool_call_type | `code_act` |
 | Q8 Custom tools | One `get_repo_context` tool to get repository overview |
@@ -57,7 +57,7 @@ applications/code_review/
 
 Supervisor configuration summary:
 - name: code_review_agent
-- model_type: Inherits default_model_type (not explicitly specified)
+- model_type: Uses configured default_model_type (not explicitly specified)
 - tool_call_type: code_act
 - Custom tools: get_repo_context
 - Worker count: 3
@@ -65,9 +65,9 @@ Supervisor configuration summary:
 Worker configuration summary:
 | Stage | Name                    | Responsibility              | model_type Strategy | Tools                                                   |
 |-------|-------------------------|-----------------------------|---------------------|---------------------------------------------------------|
-| 1     | code_scan               | Code scanning & structure analysis | Inherit default     | read_file, get_file_outline, ripgrep_search_directory |
-| 2     | risk_assessment         | Risk assessment & issue tagging    | Inherit default     | read_file, ripgrep_search_directory             |
-| 3     | report_generation       | Report summary              | Inherit default     | write_markdown_file                                      |
+| 1     | code_scan               | Code scanning & structure analysis | Use configured default | read_file, get_file_outline, ripgrep_search_directory |
+| 2     | risk_assessment         | Risk assessment & issue tagging    | Use configured default | read_file, ripgrep_search_directory             |
+| 3     | report_generation       | Report summary              | Use configured default | write_markdown_file                                      |
 ```
 
 User confirmation: ✅

--- a/tools/skills/create-app/references/quick-reference.md
+++ b/tools/skills/create-app/references/quick-reference.md
@@ -59,7 +59,7 @@
 
 `model_type` is not a fixed enum — it should be dynamically read from the project's `config/llm.yaml`:
 
-1. Read `model.default_model_type` as the default type.
+1. Read `model.default_model_type` as the project default type. If it is missing, generated Agent YAML must explicitly set `model_type`.
 2. Read the remaining keys under `model` as available types (excluding reserved keys `default_model_type` and non-dict values).
 3. In interactive scenarios, confirm with the user: use default / specify explicitly / custom.
 4. Custom values must already be defined in `config/llm.yaml`, otherwise a runtime error will occur.

--- a/tools/skills/create-app/references/templates.md
+++ b/tools/skills/create-app/references/templates.md
@@ -16,7 +16,7 @@ description: |
   <User-provided one-line description, expanded into 2-3 sentences of complete role positioning>
 
 # model_type options:
-# - Omit: Inherits model.default_model_type from config/llm.yaml
+# - Omit only when config/llm.yaml sets model.default_model_type
 # - Specify: Use an explicit type (must exist in the model node of config/llm.yaml)
 # model_type: "<selected_model_type>"
 tool_call_type: "<tool_call_type>"
@@ -88,7 +88,7 @@ workflow:
 name: "step<N>_<name>"
 description: "<stage description>"
 tool_call_type: "<tool_call_type>"
-# model_type is optional, same strategy as Supervisor
+# model_type follows the same strategy as Supervisor
 # model_type: "<selected_model_type>"
 tools:
   - name: "<tool1>"
@@ -274,7 +274,7 @@ system_prompt: |
 name: "<app_name>"
 description: "<one-line description>"
 # model_type options:
-# - Omit: Inherits model.default_model_type from config/llm.yaml
+# - Omit only when config/llm.yaml sets model.default_model_type
 # - Specify: Use an explicit type (must exist in the model node of config/llm.yaml)
 # model_type: "<selected_model_type>"
 tool_call_type: "<tool_call_type>"

--- a/tools/skills/create-app/references/troubleshooting.md
+++ b/tools/skills/create-app/references/troubleshooting.md
@@ -73,8 +73,8 @@ print(<function_name>.__doc__[:100])
 
 ### Symptoms
 ```
-KeyError: 'xxx' not found in llm config
-ValueError: Unknown model_type: ...
+ValueError: Model type 'xxx' is not defined in config/llm.yaml; the model call was not started.
+ValueError: No model_type was provided and config/llm.yaml does not set `model.default_model_type`; the model call was not started.
 ```
 
 ### Troubleshooting Steps
@@ -82,6 +82,7 @@ ValueError: Unknown model_type: ...
 1. Check whether the model_type is defined in `config/llm.yaml`
 2. Dynamically confirm available types from the `model` node in `config/llm.yaml` (excluding `default_model_type` and non-dict values)
 3. Custom model_type values must first be added as a configuration block in `config/llm.yaml`
+4. If Agent YAML omits `model_type`, make sure `model.default_model_type` is configured and points to an available type
 
 ### Quick Verification
 

--- a/tools/skills/shell-security/references/per-agent-examples.md
+++ b/tools/skills/shell-security/references/per-agent-examples.md
@@ -71,7 +71,7 @@ Does not declare `shell_tool`, so the agent cannot execute any shell commands.
 ```yaml
 name: "text_analyzer"
 description: "Pure text analysis agent, no shell needed"
-model_type: "common"
+model_type: "fast"
 tool_call_type: "code_act"
 
 tools:

--- a/tools/skills/update-skills/references/update-checklist.md
+++ b/tools/skills/update-skills/references/update-checklist.md
@@ -29,11 +29,11 @@
   - Is the number of required fields correct (name, description, workflow -- 3 required)
   - Is the optional field list complete (tools, model_type, tool_call_type, worker_agents, execution_env, prompt, skills, planning_interval, max_steps)
 - [ ] **Information Extraction Checklist (#1-#14)**: Are default values and descriptions consistent with the latest documentation
-  - `model_type` default value description: inherits from `config/llm.yaml`'s `model.default_model_type`
+  - `model_type` default value description: uses `config/llm.yaml`'s `model.default_model_type` only when configured; otherwise explicit `model_type` is required
   - `tool_call_type` default value: `code_act`
   - `execution_env` available values: `local`, `docker`, `e2b`, `wasm`
 - [ ] **model_type Discovery and Confirmation Workflow**: Aligned with `docs/en/llm_config.md`
-  - Parameter inheritance chain: `models[model_type].param` -> `models.common.param` -> code defaults
+  - Parameter lookup chain: `models[model_type].param` -> code defaults
   - Available model_types should be dynamically discovered from `config/llm.yaml` (excluding `default_model_type`), not hardcoded to a fixed set
 - [ ] **LLM Config Isolation Description**: Aligned with `docs/en/config-overview.md` and `docs/en/agent_config.md`
   - Agent YAML must not contain `model`/`llm`/`langfuse`; these will be automatically filtered with a warning output
@@ -75,7 +75,7 @@
 ### references/full-example.md
 
 - [ ] **End-to-End Example Flow**: Directory structure and fields consistent with the latest documentation and code behavior
-- [ ] **model_type Strategy in Example**: Reflects the "dynamic discovery + default inheritance" mechanism
+- [ ] **model_type Strategy in Example**: Reflects dynamic discovery and the requirement to use a configured default or explicit type
 - [ ] **skills/worker Configuration in Example**: Consistent with current `docs/en/agent_config.md` rules
 
 ### references/agent-yaml-schema.json

--- a/tools/skills/workflow-review/SKILL.md
+++ b/tools/skills/workflow-review/SKILL.md
@@ -219,7 +219,7 @@ Only output dimensions with findings; dimensions without findings are covered in
 **LLM configuration isolation:**
 - Fields `model`, `llm`, `langfuse` in Agent YAML or `system.yaml` are **auto-filtered** with warning logs — all LLM parameters must only be in `config/llm.yaml`
 - Agent selects model via `model_type`; if the specified type does not exist in `llm.yaml`, runtime raises `ValueError` (no silent fallback)
-- Fallback chain when `model_type` is omitted: uses `default_model_type` from `llm.yaml` (defaults to `"common"`)
+- When `model_type` is omitted, use the global `default_model_type` from `llm.yaml`; if that key is omitted or resolves to a missing type, runtime raises `ValueError`.
 
 **Configuration overlay:**
 - Agent YAML overlay whitelist (7 keys only): `system`, `smart_summary`, `tool_access_control`, `execution_env`, `code_agent`, `tools`, `prompt`

--- a/tools/skills/workflow-review/references/best-practices.md
+++ b/tools/skills/workflow-review/references/best-practices.md
@@ -258,7 +258,7 @@ AgentLoom provides a **built-in checkpoint/resume/heartbeat system** requiring n
 
 | Parameter | Default | Common Pitfalls | Recommended Practice |
 |-----------|---------|----------------|---------------------|
-| `model_type` | `default_model_type` from `llm.yaml` (usually `"common"`) | Specifying a non-existent type causes `ValueError` at runtime (no silent fallback) | Verify the type exists in `llm.yaml`; use `powerful` for complex reasoning, `fast` for simple tasks |
+| `model_type` | Global `default_model_type` from `llm.yaml`; no implicit default if omitted there | Specifying a non-existent type causes `ValueError` at runtime (no silent fallback) | Verify the type exists in `llm.yaml`; use `powerful` for complex reasoning, `fast` for simple tasks |
 | `tool_call_type` | `"code_act"` | Using `tool_call` for Supervisors limits orchestration capability | Use `code_act` for Supervisors and complex Workers; `tool_call` only for simple single-tool Workers |
 | `max_steps` | `80` | Default too high for simple Workers (wastes resources); too low for complex Supervisors | Set proportional to task complexity; simple Workers: 20-40; complex Supervisors: 60-120 |
 | `planning_interval` | Not set | Long task chains without periodic planning lose track of progress | Set to 3-5 for Agents with 20+ expected steps |
@@ -269,7 +269,7 @@ AgentLoom provides a **built-in checkpoint/resume/heartbeat system** requiring n
 
 - **Never write** `model`, `llm`, or `langfuse` fields in Agent YAML or `system.yaml` — they are auto-filtered with warning logs
 - Agent selects model via `model_type` only; all LLM parameters live exclusively in `config/llm.yaml`
-- When `model_type` is unspecified, fallback chain: `default_model_type` → `"common"` type → built-in defaults
+- When `model_type` is unspecified, the Agent uses the global `default_model_type`; if that key is omitted or resolves to a missing type, runtime raises `ValueError`.
 
 ### Configuration Overlay Whitelist
 

--- a/tools/skills/workflow-review/references/review-checklist.md
+++ b/tools/skills/workflow-review/references/review-checklist.md
@@ -113,7 +113,7 @@ This checklist is used for item-by-item review. You may only output items with f
 - [ ] Does the specified `model_type` exist in `config/llm.yaml`? (Non-existent types cause `ValueError` at runtime — no silent fallback)
 - [ ] Is `model_type` appropriate for the task? (`powerful` for complex reasoning, `fast` for simple classification, `summary` for extraction)
 - [ ] Does the Agent YAML contain prohibited LLM fields (`model`, `llm`, `langfuse`)? (These are auto-filtered with warnings — all LLM params must be in `config/llm.yaml`)
-- [ ] When `model_type` is omitted, is the `default_model_type` (defaults to `"common"`) from `llm.yaml` suitable?
+- [ ] When `model_type` is omitted, is `default_model_type` configured in `llm.yaml` and suitable?
 
 ### 3.5 Tool Capability Discovery
 


### PR DESCRIPTION
## Summary
- remove implicit `common` fallback from LLM model resolution
- require `default_model_type` to point to a configured model type before model calls
- update CN/EN docs and examples to describe explicit model config semantics

## Tests
- `.venv/bin/python -m py_compile src/lib/config/llm_config.py src/lib/config/config.py src/lib/smolagents/models/model_types.py`
- `.venv/bin/python -m pytest tests/agent_test/llm_cfg_test tests/agent_test/sys_config tests/test_native_tool_calls_detection.py tests/test_model_type_passthrough.py`
- manual `LLMConfig.load_from_yaml(...)` checks for `config/llm.example.yaml` and local ignored `config/llm.yaml`