### PR TITLE
Fix Chinese README release badge link

### DIFF
--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://github.com/linora-u/AgentLoom/actions/workflows/tests.yml"><img alt="tests" src="https://github.com/linora-u/AgentLoom/actions/workflows/tests.yml/badge.svg"></a>
   <a href="https://www.python.org/downloads/"><img alt="python >=3.12" src="https://img.shields.io/badge/python-%3E%3D3.12-3776AB?logo=python&logoColor=white"></a>
-  <img alt="v1.0.1" src="https://img.shields.io/badge/-v1.0.1-007EC6">
+  <a href="https://github.com/linora-u/AgentLoom/releases/tag/v1.0.1"><img alt="release v1.0.1" src="https://img.shields.io/badge/release-v1.0.1-007EC6"></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

- Make the Chinese README release badge match the English README.
- Link the `v1.0.1` badge to the corresponding GitHub release page.

## Why

The Chinese README showed the release badge as a plain image, so clicking the version did not navigate to the release. The English README already linked the badge correctly.

## Validation

- `git diff --check`