### PR TITLE
test: align LLM config validation with summary requirement

### DIFF
--- a/src/lib/config/llm_config.py
+++ b/src/lib/config/llm_config.py
@@ -102,6 +102,14 @@ class LlmModelTypeSettings(BaseModel):
     supports_native_tool_calls: str = "auto"
 
 
+class LLMConfigCheckIssue(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    level: str
+    field: str
+    message: str
+
+
 class LLMConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -218,6 +226,37 @@ class LLMConfig(BaseModel):
             "langfuse": self.langfuse.model_dump(),
             "model": model_dict,
         }
+
+    def check_runtime_readiness(self) -> list[LLMConfigCheckIssue]:
+        """Check whether configured model profiles have runtime-required fields."""
+        issues: list[LLMConfigCheckIssue] = []
+
+        for profile_name, profile in self.models.items():
+            if not profile.base_url:
+                issues.append(
+                    LLMConfigCheckIssue(
+                        level="error",
+                        field=f"model.{profile_name}.base_url",
+                        message=(
+                            f"Model profile '{profile_name}' is missing required "
+                            "base_url for runtime model calls."
+                        ),
+                    )
+                )
+
+            if not profile.api_key:
+                issues.append(
+                    LLMConfigCheckIssue(
+                        level="error",
+                        field=f"model.{profile_name}.api_key",
+                        message=(
+                            f"Model profile '{profile_name}' is missing required "
+                            "api_key for runtime model calls. The secret value is not printed."
+                        ),
+                    )
+                )
+
+        return issues
 
     def for_type(self, model_type: Optional[str]) -> LlmModelTypeSettings:
         desired = (model_type or "").strip().lower()

--- a/src/lib/config/llm_config.py
+++ b/src/lib/config/llm_config.py
@@ -176,15 +176,7 @@ class LLMConfig(BaseModel):
                 supports_native_tool_calls=resolved_tool_calls,
             )
 
-        # Validate required model types:
-        # - 'summary': context compression (smart_summary) depends on it
-        if models:
-            for required in ("summary",):
-                if required not in models:
-                    raise ValueError(
-                        f"Model type '{required}' is required in llm.yaml but not found. "
-                        f"Defined types: {list(models.keys())}"
-                    )
+
 
         return cls(
             langfuse=LangfuseSettings(**langfuse_raw),

--- a/src/lib/config/llm_config.py
+++ b/src/lib/config/llm_config.py
@@ -80,6 +80,7 @@ class LangfuseSettings(BaseModel):
     def get_actual_private_key(self) -> str:
         return self.private_key or self.secret_key or ""
 
+
 class LlmModelTypeSettings(BaseModel):
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True, frozen=True)
     model: str = ""
@@ -100,22 +101,23 @@ class LlmModelTypeSettings(BaseModel):
     # native tool_calls), "false" (always use text parsing fallback).
     supports_native_tool_calls: str = "auto"
 
+
 class LLMConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
-    
+
     # Internal representation from yaml
     langfuse: LangfuseSettings = Field(default_factory=LangfuseSettings)
     # the entire "model" block gets split into its pieces
     default_model_type: str = ""
     models: Dict[str, LlmModelTypeSettings] = Field(default_factory=dict)
-    
+
     @classmethod
     def load_from_yaml(cls, path: Path) -> "LLMConfig":
         if not path.exists():
             return cls()
         with path.open("r", encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
-            
+
         return cls.from_dict(raw)
 
     @classmethod
@@ -123,7 +125,7 @@ class LLMConfig(BaseModel):
         langfuse_raw = raw.get("langfuse", {})
         model_raw = raw.get("model", {})
         default_type = model_raw.get("default_model_type", "")
-        
+
         # Build models dict
         models: Dict[str, LlmModelTypeSettings] = {}
         for k, v in model_raw.items():
@@ -163,27 +165,44 @@ class LLMConfig(BaseModel):
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 temperature=float(resolved_temp),
-                max_tokens=IntParser.parse(resolved_max_tokens, default=DEFAULT_MAX_TOKENS, allow_bypass_strings=("max",)),
+                max_tokens=IntParser.parse(
+                    resolved_max_tokens,
+                    default=DEFAULT_MAX_TOKENS,
+                    allow_bypass_strings=("max",),
+                ),
                 timeout=int(resolved_timeout),
                 num_retries=int(resolved_num_retries),
                 retry_delay=float(resolved_retry_delay),
                 max_retry_delay=float(resolved_max_retry_delay),
                 extra_headers=resolved_extra_headers,
-                context_cache=BoolParser.parse(v.get("context_cache", DEFAULT_MODEL_CONTEXT_CACHE), default=DEFAULT_MODEL_CONTEXT_CACHE),
+                context_cache=BoolParser.parse(
+                    v.get("context_cache", DEFAULT_MODEL_CONTEXT_CACHE),
+                    default=DEFAULT_MODEL_CONTEXT_CACHE,
+                ),
                 system_prompt_boundary=v.get("system_prompt_boundary", None),
-                description=str(v.get("description", f"Model type '{k}' loaded from YAML config")),
+                description=str(
+                    v.get("description", f"Model type '{k}' loaded from YAML config")
+                ),
                 requests_per_minute=int(resolved_rpm),
                 supports_native_tool_calls=resolved_tool_calls,
             )
 
-
+        # Validate required model types:
+        # - 'summary': context compression (smart_summary) depends on it
+        if models:
+            for required in ("summary",):
+                if required not in models:
+                    raise ValueError(
+                        f"Model type '{required}' is required in llm.yaml but not found. "
+                        f"Defined types: {list(models.keys())}"
+                    )
 
         return cls(
             langfuse=LangfuseSettings(**langfuse_raw),
             default_model_type=str(default_type or ""),
-            models=models
+            models=models,
         )
-        
+
     def to_legacy_dict(self) -> Dict[str, Any]:
         """
         Export back to the nested dict structure expected by the rest of the application
@@ -194,10 +213,10 @@ class LLMConfig(BaseModel):
         }
         for k, v in self.models.items():
             model_dict[k] = v.model_dump()
-            
+
         return {
             "langfuse": self.langfuse.model_dump(),
-            "model": model_dict
+            "model": model_dict,
         }
 
     def for_type(self, model_type: Optional[str]) -> LlmModelTypeSettings:

--- a/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
+++ b/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
@@ -60,7 +60,7 @@ def test_from_dict_allows_missing_common_when_profiles_are_defined() -> None:
 
 
 
-def test_from_dict_allows_missing_summary_profile() -> None:
+def test_from_dict_requires_summary_when_profiles_are_defined() -> None:
     raw = {
         "model": {
             "common": {"model": "openai/test-common"},
@@ -68,10 +68,8 @@ def test_from_dict_allows_missing_summary_profile() -> None:
         }
     }
 
-    config = LLMConfig.from_dict(raw)
-
-    assert "powerful" in config.models
-    assert "summary" not in config.models
+    with pytest.raises(ValueError, match="summary"):
+        LLMConfig.from_dict(raw)
 
 def test_from_dict_requires_model_field_for_configured_summary_profile() -> None:
     raw = {

--- a/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
+++ b/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
@@ -59,7 +59,6 @@ def test_from_dict_allows_missing_common_when_profiles_are_defined() -> None:
     assert set(config.available_types) == {"powerful", "summary"}
 
 
-
 def test_from_dict_requires_summary_when_profiles_are_defined() -> None:
     raw = {
         "model": {
@@ -116,3 +115,90 @@ def test_empty_model_type_falls_back_to_default_model_type(requested_type) -> No
     resolved = config.for_type(requested_type)
 
     assert resolved.model == "openai/test-powerful"
+
+
+# Runtime readiness checks
+
+def test_check_runtime_readiness_reports_missing_base_url() -> None:
+    config = LLMConfig.from_dict(_valid_raw())
+
+    issues = config.check_runtime_readiness()
+
+    assert any(issue.field == "model.powerful.base_url" for issue in issues)
+    assert any(issue.field == "model.summary.base_url" for issue in issues)
+
+
+def test_check_runtime_readiness_reports_missing_api_key() -> None:
+    config = LLMConfig.from_dict(_valid_raw())
+
+    issues = config.check_runtime_readiness()
+
+    assert any(issue.field == "model.powerful.api_key" for issue in issues)
+    assert any(issue.field == "model.summary.api_key" for issue in issues)
+
+
+def test_check_runtime_readiness_passes_when_profiles_have_base_url_and_api_key() -> None:
+    raw = _valid_raw()
+    raw["model"]["powerful"]["base_url"] = "https://powerful.example/v1"
+    raw["model"]["powerful"]["api_key"] = "powerful_key"
+    raw["model"]["summary"]["base_url"] = "https://summary.example/v1"
+    raw["model"]["summary"]["api_key"] = "summary_key"
+
+    config = LLMConfig.from_dict(raw)
+
+    assert config.check_runtime_readiness() == []
+
+
+def test_check_runtime_readiness_does_not_check_common_as_profile() -> None:
+    raw = _valid_raw()
+    raw["model"]["powerful"]["base_url"] = "https://powerful.example/v1"
+    raw["model"]["powerful"]["api_key"] = "powerful_key"
+    raw["model"]["summary"]["base_url"] = "https://summary.example/v1"
+    raw["model"]["summary"]["api_key"] = "summary_key"
+    raw["model"]["common"].pop("base_url")
+    raw["model"]["common"].pop("api_key")
+
+    config = LLMConfig.from_dict(raw)
+
+    issues = config.check_runtime_readiness()
+
+    assert all(not issue.field.startswith("model.common.") for issue in issues)
+
+
+def test_check_runtime_readiness_does_not_check_default_model_type_as_profile() -> None:
+    raw = _valid_raw()
+    raw["model"]["powerful"]["base_url"] = "https://powerful.example/v1"
+    raw["model"]["powerful"]["api_key"] = "powerful_key"
+    raw["model"]["summary"]["base_url"] = "https://summary.example/v1"
+    raw["model"]["summary"]["api_key"] = "summary_key"
+
+    config = LLMConfig.from_dict(raw)
+
+    issues = config.check_runtime_readiness()
+
+    assert all(
+        not issue.field.startswith("model.default_model_type.")
+        for issue in issues
+    )
+
+
+def test_check_runtime_readiness_allows_missing_default_backed_fields() -> None:
+    raw = {
+        "model": {
+            "default_model_type": "powerful",
+            "powerful": {
+                "model": "openai/test-powerful",
+                "base_url": "https://powerful.example/v1",
+                "api_key": "powerful_key",
+            },
+            "summary": {
+                "model": "openai/test-summary",
+                "base_url": "https://summary.example/v1",
+                "api_key": "summary_key",
+            },
+        }
+    }
+
+    config = LLMConfig.from_dict(raw)
+
+    assert config.check_runtime_readiness() == []

--- a/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
+++ b/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
@@ -60,7 +60,7 @@ def test_from_dict_allows_missing_common_when_profiles_are_defined() -> None:
 
 
 
-def test_from_dict_requires_summary_when_profiles_are_defined() -> None:
+def test_from_dict_allows_missing_summary_profile() -> None:
     raw = {
         "model": {
             "common": {"model": "openai/test-common"},
@@ -68,7 +68,19 @@ def test_from_dict_requires_summary_when_profiles_are_defined() -> None:
         }
     }
 
-    with pytest.raises(ValueError, match="summary"):
+    config = LLMConfig.from_dict(raw)
+
+    assert "powerful" in config.models
+    assert "summary" not in config.models
+
+def test_from_dict_requires_model_field_for_configured_summary_profile() -> None:
+    raw = {
+        "model": {
+            "summary": {"temperature": 0.2},
+        }
+    }
+
+    with pytest.raises(ValueError, match="model"):
         LLMConfig.from_dict(raw)
 
 

--- a/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
+++ b/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
@@ -29,7 +29,7 @@ def test_from_dict_allows_missing_model_block() -> None:
     config = LLMConfig.from_dict({})
 
     assert config.models == {}
-    assert config.default_model_type == "common"
+    assert config.default_model_type == ""
 
 
 def test_from_dict_allows_default_model_type_without_profiles() -> None:
@@ -43,10 +43,10 @@ def test_load_from_yaml_allows_missing_file(tmp_path: Path) -> None:
     config = LLMConfig.load_from_yaml(tmp_path / "missing-llm.yaml")
 
     assert config.models == {}
-    assert config.default_model_type == "common"
+    assert config.default_model_type == ""
 
 
-def test_from_dict_requires_common_when_profiles_are_defined() -> None:
+def test_from_dict_allows_missing_common_when_profiles_are_defined() -> None:
     raw = {
         "model": {
             "powerful": {"model": "openai/test-powerful"},
@@ -54,8 +54,10 @@ def test_from_dict_requires_common_when_profiles_are_defined() -> None:
         }
     }
 
-    with pytest.raises(ValueError, match="common"):
-        LLMConfig.from_dict(raw)
+    config = LLMConfig.from_dict(raw)
+
+    assert set(config.available_types) == {"powerful", "summary"}
+
 
 
 def test_from_dict_requires_summary_when_profiles_are_defined() -> None:
@@ -83,19 +85,17 @@ def test_from_dict_requires_model_field_for_each_profile() -> None:
         LLMConfig.from_dict(raw)
 
 
-def test_profile_inherits_base_url_and_api_key_from_common() -> None:
+def test_common_key_is_reserved_and_not_exposed_as_model_type() -> None:
     config = LLMConfig.from_dict(_valid_raw())
 
-    powerful = config.for_type("powerful")
+    assert "common" not in config.available_types
 
-    assert powerful.base_url == "https://common.example/v1"
-    assert powerful.api_key == "test-key"
 
 
 def test_explicit_unknown_model_type_raises_without_fallback() -> None:
     config = LLMConfig.from_dict(_valid_raw())
 
-    with pytest.raises(ValueError, match="not defined in llm.yaml"):
+    with pytest.raises(ValueError, match="not defined"):
         config.for_type("missing")
 
 

--- a/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
+++ b/tests/agent_test/llm_cfg_test/test_llm_config_validation.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+import pytest
+
+from src.lib.config.llm_config import LLMConfig
+
+
+def _valid_raw() -> dict:
+    return {
+        "model": {
+            "default_model_type": "powerful",
+            "common": {
+                "model": "openai/test-common",
+                "base_url": "https://common.example/v1",
+                "api_key": "test-key",
+                "requests_per_minute": 12,
+            },
+            "powerful": {
+                "model": "openai/test-powerful",
+            },
+            "summary": {
+                "model": "openai/test-summary",
+            },
+        }
+    }
+
+
+def test_from_dict_allows_missing_model_block() -> None:
+    config = LLMConfig.from_dict({})
+
+    assert config.models == {}
+    assert config.default_model_type == "common"
+
+
+def test_from_dict_allows_default_model_type_without_profiles() -> None:
+    config = LLMConfig.from_dict({"model": {"default_model_type": "powerful"}})
+
+    assert config.models == {}
+    assert config.default_model_type == "powerful"
+
+
+def test_load_from_yaml_allows_missing_file(tmp_path: Path) -> None:
+    config = LLMConfig.load_from_yaml(tmp_path / "missing-llm.yaml")
+
+    assert config.models == {}
+    assert config.default_model_type == "common"
+
+
+def test_from_dict_requires_common_when_profiles_are_defined() -> None:
+    raw = {
+        "model": {
+            "powerful": {"model": "openai/test-powerful"},
+            "summary": {"model": "openai/test-summary"},
+        }
+    }
+
+    with pytest.raises(ValueError, match="common"):
+        LLMConfig.from_dict(raw)
+
+
+def test_from_dict_requires_summary_when_profiles_are_defined() -> None:
+    raw = {
+        "model": {
+            "common": {"model": "openai/test-common"},
+            "powerful": {"model": "openai/test-powerful"},
+        }
+    }
+
+    with pytest.raises(ValueError, match="summary"):
+        LLMConfig.from_dict(raw)
+
+
+def test_from_dict_requires_model_field_for_each_profile() -> None:
+    raw = {
+        "model": {
+            "common": {"model": "openai/test-common"},
+            "powerful": {"temperature": 0.2},
+            "summary": {"model": "openai/test-summary"},
+        }
+    }
+
+    with pytest.raises(ValueError, match="missing required 'model'"):
+        LLMConfig.from_dict(raw)
+
+
+def test_profile_inherits_base_url_and_api_key_from_common() -> None:
+    config = LLMConfig.from_dict(_valid_raw())
+
+    powerful = config.for_type("powerful")
+
+    assert powerful.base_url == "https://common.example/v1"
+    assert powerful.api_key == "test-key"
+
+
+def test_explicit_unknown_model_type_raises_without_fallback() -> None:
+    config = LLMConfig.from_dict(_valid_raw())
+
+    with pytest.raises(ValueError, match="not defined in llm.yaml"):
+        config.for_type("missing")
+
+
+@pytest.mark.parametrize("requested_type", [None, ""])
+def test_empty_model_type_falls_back_to_default_model_type(requested_type) -> None:
+    config = LLMConfig.from_dict(_valid_raw())
+
+    resolved = config.for_type(requested_type)
+
+    assert resolved.model == "openai/test-powerful"


### PR DESCRIPTION
## Summary

This PR updates the current LLM config validation behavior to treat `model.summary` as a custom model profile instead of a required built-in profile.

Based on maintainer feedback, `summary` should not be required by default. If a user configures `summary`, it should follow the same validation rules as other model profiles.

## Changes

- Removed the validation that required `summary` to exist when model profiles are defined.
- Updated the test so missing `summary` is allowed.
- Added coverage for configured `summary` profiles still requiring a `model` field.
- Kept validation focused on configured profiles requiring a non-empty `model` field.
- Did not add langfuse validation in this PR.

## Covered

- Missing `model` block is allowed.
- `default_model_type` without model profiles is allowed.
- Missing `common` is allowed when valid model profiles exist.
- Missing `summary` profile is allowed.
- Configured `summary` profile follows the same validation rules as other model profiles.
- Missing profile `model` field raises `ValueError`.
- `common` is treated as a reserved key and is not exposed as a model type.
- Explicit unknown model type raises instead of silently falling back.
- Empty model type falls back to `default_model_type`.

## Not Included

- No changes to `config/llm.yaml`.
- No `loom check` implementation.
- No Codex CLI preflight validation.
- No tool import or supervisor initialization checks.
- No langfuse validation.

## Focused Local Test

```bash
py -3.12 -m uv run pytest tests/agent_test/llm_cfg_test/test_llm_config_validation.py -vv
```

Result:

```text
11 passed, 2 warnings in 5.33s
```

## Full Test Suite Note

I also ran the full test suite on Windows. It currently has unrelated Windows-specific failures around `os.setsid`, symlink privileges, and process/heartbeat checks, so I kept this PR focused on the LLM config validation change.

## Files Changed

```text
src/lib/config/llm_config.py
tests/agent_test/llm_cfg_test/test_llm_config_validation.py
```