### PR TITLE
docs: refresh README messaging and visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 English | <a href="docs/cn/README.md">简体中文</a>
 </sub></div>
 
-
 <h1 align="center">AgentLoom</h1>
 
 <p align="center">
-  <strong>Build complex multi-agent applications with simple configuration, minimal glue code, safe runtime controls, and first-class observability.</strong>
+  <strong>Application-level framework for building multi-agent systems from YAML.</strong>
 </p>
 
 <p align="center">
-  <strong>AgentLoom helps developers turn multi-agent workflows into runnable, observable, resumable, and controllable applications.</strong>
+  Build multi-agent apps by writing YAML, route each sub-agent to the right model, load Skills / MCP / tools, run repeated work in parallel, and resume long runs from saved state.
 </p>
 
 <p align="center">
@@ -19,11 +18,15 @@ English | <a href="docs/cn/README.md">简体中文</a>
   <a href="https://github.com/linora-u/AgentLoom/releases/tag/v1.0.1"><img alt="release v1.0.1" src="https://img.shields.io/badge/release-v1.0.1-007EC6"></a>
 </p>
 
+<p align="center">
+  <img alt="AgentLoom application flow" src="docs/assets/agentloom-application-flow.svg">
+</p>
+
 ---
 
-## Quick Start
+## 3-Minute Quick Start
 
-AgentLoom is designed to get you from repository clone to a real multi-agent application quickly.
+AgentLoom is for developers who want ready-to-run agent apps: YAML-defined agents, explicit Worker contracts, model routing, runtime logs, checkpoint state, and optional UI monitoring.
 
 ```bash
 git clone <repo-url> AgentLoom
@@ -47,102 +50,102 @@ After the first run, you should see:
 - optional visualization through `uv run loom ui`;
 - optional terminal monitoring through `uv run loom dashboard`.
 
-## What AgentLoom Provides
+## Create a Multi-Agent App with Codex
 
-AgentLoom already implements the runtime pieces needed to build and operate complex agent applications:
+The fastest path is to let Codex use the framework skill that ships with this repository. Codex can create the YAML files, run the AgentLoom app, watch terminal output and `.logs/`, inspect checkpoint state, and revise the app when a Worker gets stuck or a config is wrong.
 
-| Area | Implemented Capabilities |
-|---|---|
-| Multi-agent app assembly | Supervisor / Worker roles, YAML `workflow`, `worker_agents`, direct `loom run`, generated entry scripts with `loom create`, and Python embedding through `run_app()`. |
-| Agent-as-Tool | Workers export as callable tools through `agent_function_schema`, with generated function signatures, required-input validation, docstrings, string results, and `.batch(tasks)`. |
-| Execution modes | Structured `tool_call` mode for traceable orchestration and `code_act` mode for flexible code-execution tasks. |
-| Python pre/post processing | Custom tool functions and wrappers for scanning, caching, loops, retries, validation, error isolation, progress persistence, and artifact writing. |
-| Batch concurrency | Worker `concurrency: auto` or fixed concurrency, `tool.batch(tasks)`, back-pressure, circuit breaker, progress callbacks, and per-call state isolation. |
-| Skills and Hooks | Claude-style `SKILL.md` packages, YAML-controlled on-demand / eager loading, bundled resources and scripts, and lifecycle Hooks for tools, tasks, sub-agents, sessions, compaction, setup, and config changes. |
-| Model and context control | Per-agent `model_type`, multiple LLM endpoints, parameter inheritance, retry behavior, prompt customization, and multi-layer context compression. |
-| Tool ecosystem | Built-in file, shell, search, code-edit, git, todo, skill-loading, local Python tools, and local Codex Exec tools, plus MCP client integration. |
-| Local Codex integration | Register local `codex exec` as a normal function tool, with multiple aliases, `fixed_args`, `sandbox` / `search` pass-through, and local Codex login/permission behavior. |
-| Code intelligence | LSP service management for definition, references, symbols, hover, and workspace symbols, with tree-sitter fallback. |
-| Runtime safety | Path boundaries, include/exclude rules, per-agent policies, shell command/operator allowlists, shell security checks, sandbox wrapping, and `shell_audit.log`. |
-| Long-task resilience | Checkpoint resume, heartbeat detection, conversation recovery, tool-call error recovery, file history, worker skip-on-resume, and task cleanup. |
-| Observability | Rich terminal logs, plain text file logs, per-step duration, cumulative/incremental token usage, task/subtask/agent context, and run archiving under `.logs/`. |
-| UI and monitoring | Web UI with SSE updates, topology graph, timeline replay, multi-run grouping, plus TUI dashboard for active and resumable tasks. |
-| Reference applications | `ai_quality_analysis`, `unit_test_studio`, `repo_map`, and `codex_exec_demo` demonstrate direct runs, custom Python entrypoints, strict pipelines, concurrent Worker analysis, and local Codex tool calls. |
+Use a prompt like this:
+
+```text
+Read agentloom-framework-skill/SKILL.md first.
+
+Create an AgentLoom application named <app_name> for this goal:
+<describe the user-facing task, input, output, and acceptance criteria>
+
+Requirements:
+- Create files under applications/<app_name>/.
+- Use a Supervisor YAML plus at least two Worker YAML files.
+- Each Worker must define agent_function_schema with clear inputs and output.
+- Choose model_type values only from config/llm.yaml.
+- Add Skills or MCP config only if they are useful for this app.
+- Write an application README with run commands, Worker responsibilities, validation records, and known limits.
+- Run the app, watch the logs/checkpoints, and fix any YAML or tool issues you find.
+```
+
+You can let Codex run and monitor the app for you, or run it yourself:
+
+```bash
+uv run loom run applications/<app_name>/workflows/<app_name>_agent.yaml
+```
+
+Useful runtime checks while the app is running:
+
+```bash
+uv run loom list-tasks
+uv run loom dashboard
+ls .logs/
+```
+
+If you prefer Claude Code, give it the same request: read `agentloom-framework-skill/SKILL.md`, create the app under `applications/<app_name>/`, run it, and summarize what worked or failed.
+
+The main config ideas are simple:
+
+- `model_type`: which configured model category this Agent uses.
+- `worker_agents`: which Worker YAML files the Supervisor can call.
+- `agent_function_schema`: the input and output contract for a Worker.
+- `skills` / `mcp_servers`: optional extra knowledge and external tools.
 
 ## Why AgentLoom
 
-### Build Complex Agent Apps With Less Code
+Many agent frameworks expose components. AgentLoom gives you a complete app structure.
 
-Many agent frameworks give you components. AgentLoom gives you an application shape.
+Complex agent applications often repeat the same setup code: Worker registration, parameter adapters, runtime entrypoints, batch execution, logging, checkpointing, and safety controls. AgentLoom moves those reusable parts into YAML and the runtime. Your application code stays focused on domain work: preprocessing, validation, artifact writing, and the actual Agent roles.
 
-Complex agent applications often grow the same glue code again and again: Worker registration, parameter adapters, runtime entrypoints, pre/post processing, batch execution, logging, tracing, and safety controls. That code is costly because it is rarely reusable when the next agent application has a different workflow.
+The practical result:
 
-Worker Agents are exported as callable tools, and Supervisor Agents load and schedule them automatically. That means a complex workflow can be assembled from focused agents, a small amount of business glue code, and a direct runtime entrypoint.
-
-AgentLoom moves the reusable parts into YAML and the runtime. YAML describes the workflow, Worker list, tools, models, permissions, and skills; Workers become callable tools; Supervisors load them automatically; Python stays focused on the application-specific parts such as preprocessing, postprocessing, caching, loops, validation, and artifact writing. Skills and Hooks package lifecycle behavior so it can be reused across applications.
-
-You can start with:
-
-- `uv run loom run <workflow>` to run an application directly;
-- `uv run loom create <workflow>` to generate a Python entry script;
-- `run_app("<workflow>")` to embed an AgentLoom app inside your own Python pipeline;
-- `tool.batch(tasks)` to call the same Worker Agent across many inputs in parallel.
-
-This is the core development-cycle win: you spend less time building orchestration plumbing and more time shaping the actual agent roles, tools, and task flow.
-
-## How AgentLoom Is Different
-
-| Common Agent Framework Pattern | AgentLoom's Approach |
+| Need | AgentLoom approach |
 |---|---|
-| Component-first: users assemble low-level primitives themselves. | Application-first: run, generate, embed, monitor, and resume multi-agent apps directly. |
-| Each complex app tends to grow a new layer of glue code. | Reusable orchestration, runtime controls, observability, and lifecycle extensions live in AgentLoom; app code handles business-specific differences. |
-| Safety, recovery, and observability are often added later. | Runtime guardrails, checkpoints, logs, audit trails, UI, and dashboard are built into the framework path. |
-| Logs mostly describe model calls and final output. | Logs are designed to debug agent application structure: task, subtask, agent, step, token, checkpoint, and topology. |
-| Good for quick demos, but production-like runs need extra infrastructure. | Built for long-running, unattended tasks that need progress, recovery, and post-run analysis. |
+| Build a full multi-agent app | Define a Supervisor, Workers, tools, Skills, and runtime behavior in YAML. |
+| Route roles to different models | Set `model_type` per Agent and keep credentials isolated in `config/llm.yaml`. |
+| Turn sub-agents into tools | Give Workers `agent_function_schema`; the Supervisor calls them like normal tools. |
+| Reuse coding-assistant knowledge | Load Claude-style `SKILL.md` packages on demand or eagerly. |
+| Connect external tools | Register local Python tools, local `codex exec`, and MCP servers through `mcp_servers`. |
+| Handle repeated work | Use Worker `concurrency` and `tool.batch(tasks)` for independent repeated inputs. |
+| Understand long runs | Use structured logs, `.logs/` archives, checkpoints, `loom ui`, and `loom dashboard`. |
 
-## Build A multi-agent App With Less Code
+## Architecture
 
-AgentLoom's core model is simple:
+<p align="center">
+  <img alt="AgentLoom runtime architecture" src="docs/assets/agentloom-runtime-architecture.svg">
+</p>
 
-```mermaid
-flowchart LR
-    User["Application / CLI"] --> Supervisor["Supervisor Agent"]
-    Supervisor --> WorkerA["Worker Agent as Tool"]
-    Supervisor --> WorkerB["Worker Agent as Tool"]
-    Supervisor --> LocalTools["Local Tools"]
-    Supervisor --> MCP["MCP Tools"]
-    WorkerA --> Runtime["Runtime Controls"]
-    WorkerB --> Runtime
-    Runtime --> Logs["Logs / Checkpoints / UI"]
-```
+The important boundary is:
 
-The important part is the boundary:
+- Worker Agents define their role, tools, inputs, and output contract.
+- AgentLoom turns Workers into callable tools with generated function signatures.
+- The Supervisor coordinates Workers and normal tools to complete the application task.
+- Python remains available for deterministic preprocessing, validation, caching, and artifact writing.
 
-- a Worker Agent defines its purpose, tools, inputs, and output contract;
-- AgentLoom turns that Worker into a callable Python tool with a real function signature;
-- the Supervisor calls Workers like tools and coordinates the full task;
-- business Python can still wrap the workflow for deterministic steps such as scanning, caching, validation, argument parsing, and artifact writing.
+## Capabilities
 
-### Where The Glue Code Goes
-
-| Work That Usually Becomes Glue Code | AgentLoom Placement |
+| Capability | What is already implemented |
 |---|---|
-| Reusable agent orchestration | YAML `workflow` and `worker_agents`. |
-| Worker parameter adaptation | `agent_function_schema` and generated function signatures. |
-| Project-specific pre/post processing | Python wrappers registered as tools. |
-| Cross-application lifecycle behavior | Skills and Hooks. |
-
-The `repo_map` application demonstrates this hybrid style: deterministic Python scans and ranks a repository, then AgentLoom calls Worker Agents to analyze directories and produce architecture documentation.
+| Application-first YAML | `loom run` executes an Agent YAML directly; `loom create` generates a Python entry script; `run_app()` embeds the app in Python. |
+| Per-Agent model routing | Each Agent selects a `model_type`; the actual provider, key, endpoint, retries, and parameters live in `config/llm.yaml`. |
+| Agent-as-Tool coordination | Worker Agents export as callable tools through `agent_function_schema`, including required-input validation and string outputs. |
+| Skills, MCP, and tools | Agents can load `SKILL.md` packages, local Python functions, built-in file/shell/search/git tools, local Codex tools, and MCP client tools through `mcp_servers`. |
+| Concurrent repeated work | Worker `concurrency: auto` or fixed concurrency works with `.batch(tasks)` for many independent inputs. |
+| State and observability | Rich terminal logs, plain text file logs, per-step timing, token usage, `.logs/` archives, checkpoint resume, Web UI, and TUI dashboard. |
 
 ## Example Applications
 
-The `applications/` directory contains working apps that show how AgentLoom is intended to be used.
+The `applications/` directory contains working apps that show the intended usage patterns.
 
-| Application | What It Builds | What It Demonstrates |
+| Application | What it builds | What it demonstrates |
 |---|---|---|
 | `ai_quality_analysis` | Multi-dimensional code review application. | 12 Worker Agents, staged review, direct `loom run`, long-running codebase analysis. |
 | `unit_test_studio` | Python pytest generation workflow. | Strict multi-step pipeline, custom entry script, function intake, scenario planning, test generation, refinement, delivery report. |
-| `repo_map` | Repository architecture map generator. | Deterministic Python preprocessing plus Agent-driven analysis, bottom-up directory processing, `tool.batch(tasks)`, progress persistence. |
+| `repo_map` | Repository architecture map generator. | Deterministic Python preprocessing plus Agent analysis, bottom-up directory processing, `tool.batch(tasks)`, progress persistence. |
 | `codex_exec_demo` | Local Codex Exec tool-call example. | Direct `loom run`, normal function tool registration, `fixed_args` for Codex parameters, structured `tool_call` sequencing. |
 
 Run the default code review example:
@@ -177,39 +180,23 @@ uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
 
 ## Core Concepts
 
-### Agent As Tool
-
-Worker Agents can be exported as callable tools. AgentLoom generates function signatures, validates required inputs, builds the task payload, and returns a string result. The same Worker can also expose `.batch(tasks)` for parallel execution.
-
 ### Supervisor / Worker
 
-A Supervisor Agent coordinates the task. Worker Agents specialize in one part of the job. This keeps responsibilities explicit and makes the workflow easier to debug.
+A Supervisor Agent coordinates the task. Worker Agents specialize in one part of the job. In multi-agent apps, the Supervisor references Workers through `worker_agents`, and Workers expose callable contracts through `agent_function_schema`.
 
-### Workflow
+### Agent as Tool
 
-A workflow describes what an agent should accomplish and how the Supervisor should use its Workers. AgentLoom uses the workflow to build the runtime task specification and keep long-running runs aligned.
+Worker Agents can be exported as callable tools. AgentLoom generates function signatures, validates required inputs, builds the task payload, and returns a string result. The same Worker can expose `.batch(tasks)` for parallel execution.
 
-### Skills And Hooks
+### Skills and Hooks
 
-Skills add reusable knowledge or behavior. Hooks attach logic around task lifecycle, sub-agent lifecycle, tool calls, and other runtime events. They can be used for validation, memory, policy enforcement, result transformation, and visualization collection.
-
-### Execution Modes
-
-AgentLoom supports structured tool calling for controlled orchestration and code execution mode for more flexible programming tasks. Each agent can choose the mode that fits its role.
+Skills provide reusable knowledge or behavior through Claude-style `SKILL.md` packages. Hooks attach logic around task lifecycle, sub-agent lifecycle, tool calls, sessions, compaction, setup, and config changes.
 
 ### Local Codex Tool
 
-AgentLoom includes `src.tools.codex.codex_tool.codex`, which exposes local
-`codex exec` as a normal function tool. Register it in Agent YAML with
-`module/function`; no dedicated `system.yaml` Codex section is required.
+AgentLoom includes `src.tools.codex.codex_tool.codex`, which exposes local `codex exec` as a normal function tool. Register it in Agent YAML with `module/function`. Use `fixed_args` to lock inputs such as `prompt`, `cwd`, `sandbox`, and `search`; fixed inputs are removed from the LLM-visible tool schema.
 
-Use `fixed_args` to lock inputs such as `prompt`, `cwd`, `sandbox`, and
-`search`. Fixed inputs are bound by the framework and removed from the
-LLM-visible tool schema; unfixed inputs remain available for the LLM to provide.
-`sandbox: ""` omits `--sandbox` and lets the local Codex CLI configuration decide
-permissions. `search: "true"` passes `--search`; search is off by default. Before
-running the tool, make sure `codex` is on `PATH` and `codex login status`
-succeeds.
+Before running the tool, make sure `codex` is on `PATH` and `codex login status` succeeds.
 
 ## CLI Reference
 
@@ -230,32 +217,21 @@ succeeds.
 | [Agent Configuration](docs/en/agent_config.md) | Supervisor/Worker fields, tools, model selection, workflows, and skills. |
 | [LLM Configuration](docs/en/llm_config.md) | Model types, provider settings, inheritance, retries, and prompt cache settings. |
 | [System Configuration](docs/en/system_config.md) | Runtime settings, permissions, logging, execution environments, and tools. |
-| [Skills Configuration](docs/en/skills_config.md) | Skill package format, loading, invocation controls, and built-in skills. |
+| [Skills Configuration](docs/en/skills_config.md) | Skill package format, loading, runtime policy, and built-in skills. |
 | [Hooks Reference](docs/en/hooks.md) | Lifecycle events, hook types, matching, and execution behavior. |
 | [Checkpoint Resume](docs/en/checkpoint.md) | Checkpoint layout, resume behavior, and long-task recovery. |
 
 ## AgentLoom Framework Skill
 
-The repository includes one root-level Agent Skill for AI coding assistants:
-`agentloom-framework-skill/`.
+The repository includes one root-level Agent Skill for AI coding assistants: `agentloom-framework-skill/`.
 
-Use it when you want an assistant to develop with AgentLoom instead of guessing
-the framework shape from scratch. Ask the assistant to read
-`agentloom-framework-skill/SKILL.md`, then describe the capability you want to
-build or extend.
+Use it when you want Codex, Claude Code, or another coding assistant to develop with AgentLoom instead of guessing the required files and fields from scratch. Ask the assistant to read `agentloom-framework-skill/SKILL.md`, then describe the application capability you want to build.
 
-The Skill guides the assistant to clarify the goal, inputs, outputs, and
-acceptance criteria; decide whether a single Agent, Supervisor/Worker workflow,
-Tool, private Skill, Hook, or documentation change is the shortest path; create
-or update the relevant files; and record validation results in the README.
+This Skill is a development aid for coding assistants. It is not stored under `skills/`, so AgentLoom runtime applications do not auto-load it as a normal runtime Skill.
 
-This Skill is a development aid for coding assistants. It is not stored under
-`skills/`, so AgentLoom runtime applications do not auto-load it as a normal
-runtime Skill.
+## Support and Contributing
 
-## Support & Contributing
-
-AgentLoom is built as a practical framework for complex agent automation. Issues, feature ideas, docs improvements, and example applications are welcome.
+AgentLoom is built as a practical framework for complex agent automation. Issues, feature ideas, documentation improvements, and example applications are welcome.
 
 - Open an issue: [GitHub Issues](https://github.com/linora-u/AgentLoom/issues)
 - Contact: [raine_walker@163.com](mailto:raine_walker@163.com?subject=AgentLoom%20Collaboration)

--- a/config/llm.example.yaml
+++ b/config/llm.example.yaml
@@ -20,6 +20,9 @@ model:
     # context_cache: true enables automatic prompt caching for ALL models.
     # litellm handles per-provider behavior (Anthropic preserves, OpenAI strips, etc.)
     context_cache: true
+    extra_body:
+      thinking:
+        type: "enabled"
     # system_prompt_boundary: optional marker to split system prompt into
     # static (cached) and dynamic (uncached) segments for higher cache hit rates.
     # Example: system_prompt_boundary: "<!-- DYNAMIC_BOUNDARY -->"

--- a/docs/assets/agentloom-application-flow.svg
+++ b/docs/assets/agentloom-application-flow.svg
@@ -1,0 +1,106 @@
+<svg width="1200" height="520" viewBox="0 0 1200 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">AgentLoom hero visual</title>
+  <desc id="desc">A stylized AgentLoom hero visual showing a central application runtime surrounded by model routing, Worker Agents, Skills, MCP tools, concurrency, and state.</desc>
+  <defs>
+    <radialGradient id="bgA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(274 126) rotate(35) scale(520 330)">
+      <stop stop-color="#0EA5E9" stop-opacity="0.75"/>
+      <stop offset="1" stop-color="#0EA5E9" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="bgB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(930 322) rotate(150) scale(550 360)">
+      <stop stop-color="#22C55E" stop-opacity="0.65"/>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="coreGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(600 250) scale(260 170)">
+      <stop stop-color="#5EEAD4" stop-opacity="0.62"/>
+      <stop offset="1" stop-color="#5EEAD4" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="core" x1="430" y1="135" x2="782" y2="362" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#101B35"/>
+      <stop offset="0.48" stop-color="#0F3756"/>
+      <stop offset="1" stop-color="#0F766E"/>
+    </linearGradient>
+    <linearGradient id="shine" x1="432" y1="0" x2="768" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38BDF8"/>
+      <stop offset="0.46" stop-color="#22C55E"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#FFFFFF" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#E0F2FE" stop-opacity="0.78"/>
+    </linearGradient>
+    <filter id="shadow" x="-30%" y="-35%" width="160%" height="180%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="22" stdDeviation="24" flood-color="#020617" flood-opacity="0.26"/>
+    </filter>
+    <filter id="soft" x="-30%" y="-35%" width="160%" height="180%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="12" stdDeviation="16" flood-color="#020617" flood-opacity="0.16"/>
+    </filter>
+    <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse">
+      <path d="M36 0H0V36" stroke="#93C5FD" stroke-opacity="0.11" stroke-width="1"/>
+    </pattern>
+    <style>
+      .text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 0; }
+      .brand { fill: #F8FAFC; font-size: 55px; font-weight: 850; }
+      .tag { fill: #CFFAFE; font-size: 21px; font-weight: 720; }
+      .node { fill: #0F172A; font-size: 18px; font-weight: 780; }
+      .panel { fill: #334155; font-size: 16px; font-weight: 720; }
+      .panel-soft { fill: #64748B; font-size: 14px; font-weight: 650; }
+      .white { fill: #FFFFFF; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="520" rx="34" fill="#07111F"/>
+  <rect width="1200" height="520" rx="34" fill="url(#bgA)"/>
+  <rect width="1200" height="520" rx="34" fill="url(#bgB)"/>
+  <rect x="34" y="34" width="1132" height="452" rx="30" fill="url(#grid)"/>
+
+  <ellipse cx="600" cy="260" rx="410" ry="166" stroke="#67E8F9" stroke-opacity="0.2" stroke-width="2"/>
+  <ellipse cx="600" cy="260" rx="318" ry="118" stroke="#A7F3D0" stroke-opacity="0.22" stroke-width="2"/>
+  <ellipse cx="600" cy="260" rx="238" ry="78" stroke="#FDBA74" stroke-opacity="0.2" stroke-width="2"/>
+
+  <g filter="url(#soft)" opacity="0.95">
+    <path d="M148 132C148 114 162 100 180 100H366C384 100 398 114 398 132V246C398 264 384 278 366 278H180C162 278 148 264 148 246V132Z" fill="url(#glass)" stroke="#C7DBEA"/>
+    <text x="182" y="146" class="text panel">assistant prompt</text>
+    <rect x="182" y="169" width="112" height="10" rx="5" fill="#2563EB" opacity="0.85"/>
+    <rect x="182" y="194" width="158" height="10" rx="5" fill="#22C55E" opacity="0.7"/>
+    <rect x="182" y="219" width="126" height="10" rx="5" fill="#F97316" opacity="0.64"/>
+    <text x="182" y="254" class="text panel-soft">Codex / Claude Code</text>
+  </g>
+
+  <g filter="url(#soft)" opacity="0.95">
+    <path d="M808 96C808 78 822 64 840 64H1026C1044 64 1058 78 1058 96V214C1058 232 1044 246 1026 246H840C822 246 808 232 808 214V96Z" fill="url(#glass)" stroke="#C7DBEA"/>
+    <text x="842" y="112" class="text panel">application.yaml</text>
+    <path d="M846 142H980M846 168H1010M846 194H936" stroke="#0891B2" stroke-width="10" stroke-linecap="round" opacity="0.72"/>
+    <text x="842" y="224" class="text panel-soft">Supervisor + Workers</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <circle cx="600" cy="250" r="150" fill="url(#coreGlow)"/>
+    <rect x="422" y="142" width="356" height="216" rx="46" fill="url(#core)"/>
+    <rect x="456" y="174" width="288" height="5" rx="2.5" fill="url(#shine)"/>
+    <text x="600" y="248" text-anchor="middle" class="text brand">AgentLoom</text>
+    <text x="600" y="286" text-anchor="middle" class="text tag">Application-level agents</text>
+  </g>
+
+  <g filter="url(#soft)">
+    <circle cx="337" cy="357" r="45" fill="#FFFFFF" stroke="#BFE4F5"/>
+    <text x="337" y="363" text-anchor="middle" class="text node">Models</text>
+  </g>
+  <g filter="url(#soft)">
+    <circle cx="472" cy="407" r="48" fill="#FFFFFF" stroke="#BFE4F5"/>
+    <text x="472" y="413" text-anchor="middle" class="text node">Workers</text>
+  </g>
+  <g filter="url(#soft)">
+    <circle cx="632" cy="414" r="52" fill="#FFFFFF" stroke="#BFE4F5"/>
+    <text x="632" y="411" text-anchor="middle" class="text node">Skills</text>
+    <text x="632" y="434" text-anchor="middle" class="text panel-soft">MCP</text>
+  </g>
+  <g filter="url(#soft)">
+    <circle cx="790" cy="388" r="51" fill="#FFFFFF" stroke="#BFE4F5"/>
+    <text x="790" y="394" text-anchor="middle" class="text node">Parallel</text>
+  </g>
+  <g filter="url(#soft)">
+    <circle cx="922" cy="318" r="45" fill="#FFFFFF" stroke="#BFE4F5"/>
+    <text x="922" y="324" text-anchor="middle" class="text node">State</text>
+  </g>
+
+</svg>

--- a/docs/assets/agentloom-runtime-architecture.svg
+++ b/docs/assets/agentloom-runtime-architecture.svg
@@ -1,0 +1,132 @@
+<svg width="1200" height="640" viewBox="0 0 1200 640" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">AgentLoom runtime architecture</title>
+  <desc id="desc">A layered architecture diagram showing Codex and the framework skill creating YAML application specs, AgentLoom running a Supervisor and Worker Agents, shared capabilities, and runtime state.</desc>
+  <defs>
+    <linearGradient id="bg" x1="90" y1="36" x2="1104" y2="610" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#06172A"/>
+      <stop offset="0.55" stop-color="#0B2539"/>
+      <stop offset="1" stop-color="#0F3D3A"/>
+    </linearGradient>
+    <radialGradient id="glowBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(286 164) rotate(42) scale(510 290)">
+      <stop stop-color="#38BDF8" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(922 486) rotate(148) scale(520 310)">
+      <stop stop-color="#34D399" stop-opacity="0.36"/>
+      <stop offset="1" stop-color="#34D399" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="runtime" x1="252" y1="186" x2="848" y2="454" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#102A43"/>
+      <stop offset="1" stop-color="#0F766E"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="174" y1="0" x2="1014" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38BDF8"/>
+      <stop offset="0.5" stop-color="#22C55E"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-25%" width="140%" height="160%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#020617" flood-opacity="0.24"/>
+    </filter>
+    <filter id="softShadow" x="-20%" y="-30%" width="140%" height="170%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#020617" flood-opacity="0.16"/>
+    </filter>
+    <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse">
+      <path d="M36 0H0V36" stroke="#93C5FD" stroke-opacity="0.08" stroke-width="1"/>
+    </pattern>
+    <style>
+      .text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 0; }
+      .heading { fill: #F8FAFC; font-size: 30px; font-weight: 850; }
+      .label { fill: #0F172A; font-size: 19px; font-weight: 800; }
+      .small { fill: #475569; font-size: 15px; font-weight: 650; }
+      .white { fill: #F8FAFC; }
+      .soft { fill: #CFFAFE; font-size: 16px; font-weight: 700; }
+      .tiny { fill: #64748B; font-size: 13px; font-weight: 650; }
+      .pill { fill: #334155; font-size: 15px; font-weight: 720; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="640" rx="34" fill="url(#bg)"/>
+  <rect width="1200" height="640" rx="34" fill="url(#glowBlue)"/>
+  <rect width="1200" height="640" rx="34" fill="url(#glowGreen)"/>
+  <rect x="36" y="34" width="1128" height="572" rx="28" fill="url(#grid)"/>
+
+  <text x="600" y="76" text-anchor="middle" class="text heading">AgentLoom Runtime Architecture</text>
+  <rect x="184" y="100" width="832" height="4" rx="2" fill="url(#accent)"/>
+  <rect x="74" y="278" width="1052" height="2" rx="1" fill="#67E8F9" opacity="0.25"/>
+  <rect x="74" y="506" width="1052" height="2" rx="1" fill="#A7F3D0" opacity="0.25"/>
+
+  <g filter="url(#softShadow)">
+    <rect x="76" y="132" width="260" height="132" rx="24" fill="#F8FAFC" stroke="#C7DDEC"/>
+    <text x="108" y="170" class="text label">Build with Codex</text>
+    <text x="108" y="200" class="text small">reads framework skill</text>
+    <text x="108" y="226" class="text small">creates YAML app files</text>
+    <text x="108" y="252" class="text small">runs and fixes the app</text>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect x="382" y="124" width="436" height="118" rx="24" fill="#F8FAFC" stroke="#C7DDEC"/>
+    <text x="414" y="162" class="text label">Application Spec</text>
+    <rect x="414" y="184" width="112" height="30" rx="15" fill="#E0F2FE"/>
+    <text x="470" y="204" text-anchor="middle" class="text pill">Supervisor</text>
+    <rect x="542" y="184" width="104" height="30" rx="15" fill="#DCFCE7"/>
+    <text x="594" y="204" text-anchor="middle" class="text pill">Workers</text>
+    <rect x="662" y="184" width="122" height="30" rx="15" fill="#FFEDD5"/>
+    <text x="723" y="204" text-anchor="middle" class="text pill">Skills/MCP</text>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect x="864" y="132" width="260" height="132" rx="24" fill="#F8FAFC" stroke="#C7DDEC"/>
+    <text x="896" y="170" class="text label">Run State</text>
+    <text x="896" y="200" class="text small">terminal output</text>
+    <text x="896" y="226" class="text small">.logs archive</text>
+    <text x="896" y="252" class="text small">checkpoints + UI</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="192" y="294" width="816" height="194" rx="34" fill="url(#runtime)" stroke="#5EEAD4" stroke-opacity="0.42"/>
+    <text x="600" y="340" text-anchor="middle" class="text heading">AgentLoom Runtime</text>
+    <text x="600" y="370" text-anchor="middle" class="text soft">loads YAML, wires Workers as tools, manages execution state</text>
+
+    <rect x="250" y="404" width="194" height="56" rx="18" fill="#FFFFFF" fill-opacity="0.95"/>
+    <text x="347" y="439" text-anchor="middle" class="text label">Supervisor</text>
+
+    <rect x="502" y="400" width="96" height="64" rx="18" fill="#FFFFFF" fill-opacity="0.95"/>
+    <text x="550" y="426" text-anchor="middle" class="text label">Worker</text>
+    <text x="550" y="447" text-anchor="middle" class="text tiny">as tool</text>
+
+    <rect x="622" y="400" width="96" height="64" rx="18" fill="#FFFFFF" fill-opacity="0.95"/>
+    <text x="670" y="426" text-anchor="middle" class="text label">Worker</text>
+    <text x="670" y="447" text-anchor="middle" class="text tiny">as tool</text>
+
+    <rect x="742" y="400" width="96" height="64" rx="18" fill="#FFFFFF" fill-opacity="0.95"/>
+    <text x="790" y="426" text-anchor="middle" class="text label">Worker</text>
+    <text x="790" y="447" text-anchor="middle" class="text tiny">batch</text>
+  </g>
+
+  <g opacity="0.9">
+    <path d="M206 264V278" stroke="#67E8F9" stroke-width="3" stroke-linecap="round"/>
+    <path d="M600 242V294" stroke="#A7F3D0" stroke-width="3" stroke-linecap="round"/>
+    <path d="M994 264V278" stroke="#FBBF24" stroke-width="3" stroke-linecap="round"/>
+    <path d="M347 488V506" stroke="#5EEAD4" stroke-width="3" stroke-linecap="round"/>
+    <path d="M670 488V506" stroke="#5EEAD4" stroke-width="3" stroke-linecap="round"/>
+    <path d="M972 488V506" stroke="#5EEAD4" stroke-width="3" stroke-linecap="round"/>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect x="92" y="526" width="218" height="58" rx="19" fill="#F8FAFC" stroke="#C7DDEC"/>
+    <text x="201" y="562" text-anchor="middle" class="text label">LLM models</text>
+  </g>
+  <g filter="url(#softShadow)">
+    <rect x="340" y="526" width="218" height="58" rx="19" fill="#F8FAFC" stroke="#C7DDEC"/>
+    <text x="449" y="562" text-anchor="middle" class="text label">Built-in tools</text>
+  </g>
+  <g filter="url(#softShadow)">
+    <rect x="588" y="526" width="218" height="58" rx="19" fill="#F8FAFC" stroke="#C7DDEC"/>
+    <text x="697" y="562" text-anchor="middle" class="text label">Skills / MCP</text>
+  </g>
+  <g filter="url(#softShadow)">
+    <rect x="836" y="526" width="272" height="58" rx="19" fill="#F8FAFC" stroke="#C7DDEC"/>
+    <text x="972" y="562" text-anchor="middle" class="text label">Logs / Checkpoints</text>
+  </g>
+
+</svg>

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -5,11 +5,11 @@
 <h1 align="center">AgentLoom</h1>
 
 <p align="center">
-  <strong>用简单配置和少量代码搭建复杂 multi-agent 应用，并获得安全运行边界与人性化日志追踪系统。</strong>
+  <strong>用 YAML 构建应用级 multi-agent 系统的框架。</strong>
 </p>
 
 <p align="center">
-  <strong>AgentLoom 帮开发者把 multi-agent 工作流变成可运行、可观测、可恢复、可控的应用。</strong>
+  通过 YAML 构建 multi-agent 应用，为不同子 Agent 选择合适模型，加载 Skills / MCP / 工具，并发处理重复任务，并从保存的状态恢复长任务。
 </p>
 
 <p align="center">
@@ -18,11 +18,15 @@
   <a href="https://github.com/linora-u/AgentLoom/releases/tag/v1.0.1"><img alt="release v1.0.1" src="https://img.shields.io/badge/release-v1.0.1-007EC6"></a>
 </p>
 
+<p align="center">
+  <img alt="AgentLoom application flow" src="../assets/agentloom-application-flow.svg">
+</p>
+
 ---
 
-## 快速开始
+## 3 分钟快速开始
 
-AgentLoom 的目标是让你尽快从仓库克隆进入一个真实可运行的 multi-agent 应用。
+AgentLoom 面向想构建可直接运行的 Agent 应用的开发者：YAML 定义 Agent，Worker 有明确调用契约，模型可以按 Agent 路由，运行过程有日志、checkpoint 状态和可选 UI 监控。
 
 ```bash
 git clone <repo-url> AgentLoom
@@ -46,92 +50,92 @@ uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yam
 - 可通过 `uv run loom ui` 打开的 Web 可视化面板；
 - 可通过 `uv run loom dashboard` 打开的终端任务监控面板。
 
-## AgentLoom 提供什么能力
+## 以 Codex 为例快速创建多 Agent 应用
 
-AgentLoom 已经实现了一套构建和运行复杂 Agent 应用所需的运行时能力：
+最快的方式是让 Codex 使用仓库自带的 framework skill。Codex 不只是生成 YAML：它也可以直接运行 AgentLoom 应用，观察终端输出和 `.logs/`，查看 checkpoint 状态，并在 Worker 卡住或配置出错时继续修改应用。
 
-| 能力领域 | 已实现功能 |
-|---|---|
-| Multi-agent 应用组装 | Supervisor / Worker 角色、YAML `workflow`、`worker_agents`、`loom run` 直接运行、`loom create` 生成入口脚本、`run_app()` 嵌入 Python。 |
-| Agent-as-Tool | Worker 通过 `agent_function_schema` 导出为可调用工具，自动生成函数签名、必填参数校验、docstring、字符串结果和 `.batch(tasks)`。 |
-| 执行模式 | `tool_call` 用于结构化、可追踪编排，`code_act` 用于更灵活的代码执行任务。 |
-| Python 前后置处理 | 支持自定义工具函数和 wrapper，用于扫描、缓存、循环、重试、校验、错误隔离、进度持久化和产物落盘。 |
-| 批量并发 | Worker 支持 `concurrency: auto` 或固定并发，支持 `tool.batch(tasks)`、反压控制、熔断、进度回调和单次调用状态隔离。 |
-| Skills 与 Hooks | 可复用 Skills、强制注入 / 按需加载 / 隐藏模式，以及工具、任务、子 Agent、会话、压缩、安装、配置变更等生命周期 Hooks。 |
-| 模型与上下文控制 | 按 Agent 配置 `model_type`、多 LLM 端点、参数继承、重试机制、Prompt 定制和多层上下文压缩。 |
-| 工具体系 | 内置文件、Shell、搜索、代码编辑、Git、Todo、Skill 加载、本地 Python 工具和本地 Codex Exec 工具，并支持 MCP Client 集成。 |
-| 本地 Codex 集成 | 可把本机 `codex exec` 注册为普通 function tool，支持多个别名、`fixed_args` 固定参数、`sandbox` / `search` 透传，并遵循本机 Codex 登录和权限配置。 |
-| 代码智能 | LSP 服务管理，支持 definition、references、symbols、hover、workspace symbols，并提供 tree-sitter fallback。 |
-| 运行时安全 | 路径边界、include/exclude、按 Agent 生效的权限策略、Shell 命令/操作符白名单、安全检查、沙盒包装和 `shell_audit.log`。 |
-| 长任务韧性 | checkpoint resume、心跳检测、对话恢复、工具调用错误恢复、文件历史、worker skip-on-resume 和任务清理。 |
-| 可观测性 | Rich 终端日志、纯文本文件日志、每步耗时、累计/增量 Token、task/subtask/agent 上下文，以及 `.logs/` 运行归档。 |
-| UI 与监控 | Web UI 支持 SSE 实时更新、拓扑图、时间线回放、多运行分组；TUI dashboard 支持活跃任务和可恢复任务监控。 |
-| 示例应用 | `ai_quality_analysis`、`unit_test_studio`、`repo_map`、`codex_exec_demo` 展示直接运行、自定义 Python 入口、严格流水线、并发 Worker 分析和本地 Codex 工具调用。 |
+可以这样对 Codex 说：
+
+```text
+先读取 agentloom-framework-skill/SKILL.md。
+
+为下面目标创建一个名为 <app_name> 的 AgentLoom 应用：
+<说明用户任务、输入、输出和验收标准>
+
+要求：
+- 所有文件放在 applications/<app_name>/ 下。
+- 使用一个 Supervisor YAML 和至少两个 Worker YAML。
+- 每个 Worker 必须定义 agent_function_schema，写清输入和输出。
+- model_type 只能从 config/llm.yaml 中选择。
+- 只有对这个应用有帮助时，才添加 Skills 或 MCP 配置。
+- 编写应用 README，包含运行命令、Worker 分工、验证记录和已知限制。
+- 运行应用，观察日志和 checkpoint，并修复发现的 YAML 或工具问题。
+```
+
+你可以让 Codex 帮你运行和观察，也可以自己运行：
+
+```bash
+uv run loom run applications/<app_name>/workflows/<app_name>_agent.yaml
+```
+
+运行过程中常用的查看命令：
+
+```bash
+uv run loom list-tasks
+uv run loom dashboard
+ls .logs/
+```
+
+如果你更习惯 Claude Code，也可以用同样的思路：先读 `agentloom-framework-skill/SKILL.md`，在 `applications/<app_name>/` 下创建应用，运行它，并总结成功和失败的地方。
+
+核心配置可以先理解成四件事：
+
+- `model_type`：这个 Agent 用哪一类已配置好的模型。
+- `worker_agents`：Supervisor 可以调用哪些 Worker YAML。
+- `agent_function_schema`：Worker 接收什么输入、返回什么输出。
+- `skills` / `mcp_servers`：可选的额外知识和外部工具。
 
 ## 为什么选择 AgentLoom
 
-### 用更少代码搭建复杂 Agent 应用
+很多 Agent 框架提供的是组件。AgentLoom 提供的是完整应用结构。
 
-很多 Agent 框架提供的是组件。AgentLoom 提供的是应用形态。
+复杂 Agent 应用经常重复写同一批基础代码：Worker 注册、参数适配、运行入口、批量并发、日志、checkpoint 和安全控制。AgentLoom 把这些可复用部分放进 YAML 和运行时里。你的应用代码只需要关注领域任务：前处理、校验、产物落盘，以及真正的 Agent 分工。
 
-复杂 Agent 应用通常会反复长出同一批胶水代码：Worker 注册、参数适配、运行入口、前后置处理、批量并发、日志追踪和安全控制。更麻烦的是，这些代码在下一个 Agent 应用里往往又要重新写一遍。
+实际收益是：
 
-Worker Agent 可以被导出为可调用工具，Supervisor Agent 会自动加载并调度这些 Worker。复杂流程可以由多个专职 Agent、少量业务胶水代码和直接可运行的入口组成。
-
-AgentLoom 把可复用部分沉到 YAML 和运行时里。YAML 描述 workflow、Worker 列表、工具、模型、权限和 Skills；Worker 自动变成可调用工具；Supervisor 自动加载 Worker；Python 只保留项目特有的前处理、后处理、缓存、循环、校验和产物落盘逻辑。Skills 与 Hooks 则把生命周期能力打包成可跨应用复用的模块。
-
-你可以从这些入口开始：
-
-- `uv run loom run <workflow>` 直接运行一个应用；
-- `uv run loom create <workflow>` 生成 Python 入口脚本；
-- `run_app("<workflow>")` 把 AgentLoom 应用嵌入自己的 Python 流水线；
-- `tool.batch(tasks)` 用同一个 Worker Agent 并发处理大量输入。
-
-这就是开发周期上的核心收益：少写编排胶水，多花时间设计 Agent 分工、工具边界和任务流程。
-
-## AgentLoom 的不同之处
-
-| 普通 Agent 框架常见模式 | AgentLoom 的方式 |
+| 需求 | AgentLoom 的方式 |
 |---|---|
-| 组件优先，用户自己组装底层抽象。 | 应用优先：直接运行、生成入口、嵌入业务代码、监控和恢复 multi-agent 应用。 |
-| 每个复杂应用都容易重新长出一层胶水代码。 | 可复用编排、运行边界、观测和生命周期扩展沉到 AgentLoom，应用层只保留业务差异。 |
-| 安全、恢复、观测能力经常后置。 | 运行边界、checkpoint、日志、审计、Web UI、dashboard 是框架路径的一部分。 |
-| 日志主要围绕模型调用和最终输出。 | 日志服务于 Agent 应用调试：task、subtask、agent、step、token、checkpoint、拓扑都能追踪。 |
-| 快速 demo 容易，长期无人值守任务需要额外基础设施。 | 面向多阶段、长时间、可恢复、可复盘的 Agent 自动化任务。 |
+| 构建完整 multi-agent 应用 | 用 YAML 定义 Supervisor、Workers、工具、Skills 和运行时行为。 |
+| 为不同角色选择不同模型 | 每个 Agent 设置自己的 `model_type`，真实密钥和端点隔离在 `config/llm.yaml`。 |
+| 把子 Agent 当工具调用 | Worker 定义 `agent_function_schema`，Supervisor 像调用普通工具一样调用它。 |
+| 复用编程助手知识 | 加载 Claude-style `SKILL.md` 包，支持按需加载或全文预加载。 |
+| 接入外部工具 | 注册本地 Python 工具、本地 `codex exec`，并通过 `mcp_servers` 接入 MCP servers。 |
+| 处理重复性工作 | 用 Worker `concurrency` 和 `tool.batch(tasks)` 并发处理独立输入。 |
+| 理解长任务状态 | 使用结构化日志、`.logs/` 归档、checkpoint、`loom ui` 和 `loom dashboard`。 |
 
-## 用更少代码构建 multi-agent 应用
+## 架构
 
-AgentLoom 的核心模型很直接：
-
-```mermaid
-flowchart LR
-    User["Application / CLI"] --> Supervisor["Supervisor Agent"]
-    Supervisor --> WorkerA["Worker Agent as Tool"]
-    Supervisor --> WorkerB["Worker Agent as Tool"]
-    Supervisor --> LocalTools["Local Tools"]
-    Supervisor --> MCP["MCP Tools"]
-    WorkerA --> Runtime["Runtime Controls"]
-    WorkerB --> Runtime
-    Runtime --> Logs["Logs / Checkpoints / UI"]
-```
+<p align="center">
+  <img alt="AgentLoom runtime architecture" src="../assets/agentloom-runtime-architecture.svg">
+</p>
 
 关键边界是：
 
-- Worker Agent 定义自己的职责、工具、输入和输出契约；
-- AgentLoom 把 Worker 转成带真实函数签名的可调用工具；
-- Supervisor 像调用工具一样调度 Worker，完成完整任务；
-- 业务 Python 仍然可以包在外层，处理扫描、缓存、参数解析、校验、落盘等确定性逻辑。
+- Worker Agent 定义自己的角色、工具、输入和输出契约。
+- AgentLoom 把 Worker 转成带真实函数签名的可调用工具。
+- Supervisor 协调 Workers 和普通工具，完成应用级任务。
+- Python 仍然可以负责确定性的前处理、校验、缓存和产物落盘。
 
-### 胶水代码放在哪里
+## 核心能力
 
-| 通常会变成胶水代码的部分 | AgentLoom 中的位置 |
+| 能力 | 已实现内容 |
 |---|---|
-| 可复用 Agent 编排 | YAML `workflow` 和 `worker_agents`。 |
-| Worker 参数适配 | `agent_function_schema` 和生成的函数签名。 |
-| 项目特有前后置处理 | 注册为工具的 Python wrapper。 |
-| 跨应用生命周期行为 | Skills 与 Hooks。 |
-
-`repo_map` 应用展示了这种混合模式：Python 负责确定性的仓库扫描和排序，AgentLoom 负责调用 Worker Agent 逐目录分析并生成架构文档。
+| 应用优先的 YAML | `loom run` 直接执行 Agent YAML；`loom create` 生成 Python 入口脚本；`run_app()` 可嵌入 Python。 |
+| 按 Agent 路由模型 | 每个 Agent 选择 `model_type`；真实 provider、key、endpoint、retry 和参数在 `config/llm.yaml` 中管理。 |
+| Agent-as-Tool 协作 | Worker 通过 `agent_function_schema` 导出为可调用工具，包含必填输入校验和字符串输出。 |
+| Skills、MCP 与工具 | Agent 可加载 `SKILL.md` 包、本地 Python 函数、内置文件/Shell/搜索/Git 工具、本地 Codex 工具，并通过 `mcp_servers` 接入 MCP Client 工具。 |
+| 并发重复任务 | Worker `concurrency: auto` 或固定并发配合 `.batch(tasks)` 处理大量独立输入。 |
+| 状态与可观测性 | Rich 终端日志、纯文本文件日志、每步耗时、Token 统计、`.logs/` 归档、checkpoint resume、Web UI 和 TUI dashboard。 |
 
 ## 示例应用
 
@@ -176,37 +180,23 @@ uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
 
 ## 核心概念
 
+### Supervisor / Worker
+
+Supervisor Agent 负责协调任务。Worker Agent 专注其中一个部分。多 Agent 应用中，Supervisor 通过 `worker_agents` 引用 Workers，Workers 通过 `agent_function_schema` 暴露可调用契约。
+
 ### Agent 即工具
 
 Worker Agent 可以导出为可调用工具。AgentLoom 会生成函数签名、校验必填输入、构造任务载荷并返回字符串结果。同一个 Worker 还可以暴露 `.batch(tasks)` 用于并发执行。
 
-### Supervisor / Worker
-
-Supervisor Agent 负责协调任务。Worker Agent 专注其中一个部分。这样的拆分让职责更明确，也更容易调试。
-
-### Workflow
-
-Workflow 描述 Agent 要完成什么，以及 Supervisor 应如何使用 Worker。AgentLoom 会基于 Workflow 构造运行时任务说明，让长任务更容易保持方向。
-
 ### Skills 与 Hooks
 
-Skills 提供可复用知识或行为。Hooks 可以挂载在任务生命周期、子 Agent 生命周期、工具调用等运行时事件上，用于校验、记忆、策略约束、结果转换和可视化采集。
-
-### 执行模式
-
-AgentLoom 支持结构化工具调用，也支持更灵活的代码执行模式。每个 Agent 可以根据自己的职责选择更合适的模式。
+Skills 通过 Claude-style `SKILL.md` 包提供可复用知识或行为。Hooks 可以挂载在任务生命周期、子 Agent 生命周期、工具调用、会话、压缩、安装和配置变更等运行时事件上。
 
 ### 本地 Codex 工具
 
-AgentLoom 内置 `src.tools.codex.codex_tool.codex`，用于把本机 `codex exec`
-作为普通 function tool 暴露给 Agent。它不需要额外的 `system.yaml` 专用配置；
-在 Agent YAML 的 `tools` 中通过 `module/function` 注册即可。
+AgentLoom 内置 `src.tools.codex.codex_tool.codex`，用于把本机 `codex exec` 作为普通 function tool 暴露给 Agent。在 Agent YAML 的 `tools` 中通过 `module/function` 注册即可。使用 `fixed_args` 可以锁定 `prompt`、`cwd`、`sandbox`、`search` 等输入；被固定的参数不会出现在 LLM 可见的 tool schema 中。
 
-如果希望锁定 Codex 的 `prompt`、`cwd`、`sandbox`、`search` 等输入，使用
-`fixed_args`。被固定的参数会由框架绑定，不会出现在 LLM 可传入的 tool schema
-中；未固定的参数仍会暴露给 LLM。`sandbox: ""` 表示不传 `--sandbox`，由本机
-Codex 配置和默认规则决定权限；`search: "true"` 会透传 `--search`，默认不启用
-网络搜索。使用前需要确保 `codex` 在 `PATH` 中，并且 `codex login status` 成功。
+使用前需要确保 `codex` 在 `PATH` 中，并且 `codex login status` 成功。
 
 ## CLI 命令
 
@@ -227,23 +217,17 @@ Codex 配置和默认规则决定权限；`search: "true"` 会透传 `--search`�
 | [Agent 配置](agent_config.md) | Supervisor/Worker 字段、工具、模型选择、工作流和 Skills。 |
 | [LLM 配置](llm_config.md) | 模型类型、Provider 设置、继承、重试和 Prompt 缓存。 |
 | [系统配置](system_config.md) | 运行时设置、权限、日志、执行环境和工具系统。 |
-| [Skills 配置](skills_config.md) | Skill 包格式、加载方式、调用控制和内置 Skills。 |
+| [Skills 配置](skills_config.md) | Skill 包格式、加载方式、运行时策略和内置 Skills。 |
 | [Hooks 参考](hooks.md) | 生命周期事件、Hook 类型、匹配规则和执行行为。 |
 | [Checkpoint 断点恢复](checkpoint.md) | Checkpoint 布局、恢复行为和长任务恢复机制。 |
 
 ## AgentLoom Framework Skill
 
-仓库根目录提供一个给 AI 编程助手使用的框架级 Skill：
-`agentloom-framework-skill/`。
+仓库根目录提供一个给 AI 编程助手使用的框架级 Skill：`agentloom-framework-skill/`。
 
-当你想快速开发或扩展 AgentLoom 能力时，让助手先读取
-`agentloom-framework-skill/SKILL.md`，再描述你要做的功能。这个 Skill 会引导
-助手先澄清目标、输入、输出和验收标准，再判断最短路径：创建 Application、扩展
-现有 Application、增加 Worker、实现 Tool、创建私有 Skill/Hook，或只更新文档。
-最后必须同步运行验证并把结果写进 README。
+当你想让 Codex、Claude Code 或其他编程助手基于 AgentLoom 开发，而不是从零猜框架结构时，让助手先读取 `agentloom-framework-skill/SKILL.md`，再描述你要构建的应用能力。
 
-这个 Skill 是开发辅助，不放在 `skills/` 运行时自动发现目录下，因此不是运行
-AgentLoom 应用的必需依赖。
+这个 Skill 是开发辅助，不放在 `skills/` 运行时自动发现目录下，因此不是运行 AgentLoom 应用的必需依赖。
 
 ## 支持与参与
 


### PR DESCRIPTION
Update the English and Chinese README to focus on Codex-driven multi-agent creation and runtime monitoring.

Add GitHub-friendly SVG hero and runtime architecture diagrams.

Enable thinking in the sample LLM config.

## Summary

-

## Changes

-

## Tests

-

## Risk / Notes

-

## Checklist

- [ ] I ran the relevant tests, or explained why they were not run.
- [ ] I updated docs or examples when behavior changed.
- [ ] I did not commit secrets, `config/llm.yaml`, runtime logs, or local artifacts.
- [ ] I noted the impact of any workflow, dependency, or configuration changes.
