### PR TITLE
修复 repo_map 与 DeepSeek thinking 模式的兼容性

### DIFF
--- a/applications/repo_map/workflows/repo_map_agent.yaml
+++ b/applications/repo_map/workflows/repo_map_agent.yaml
@@ -9,7 +9,7 @@ description: |
   4) 校验 skill 完整性并输出总结
 
 model_type: "powerful"
-tool_call_type: "tool_call"
+tool_call_type: "code_act"
 
 workflow: |
   # Repo Map 架构分析工作流

--- a/applications/repo_map/workflows/worker_agents/dir_architecture_analysis.yaml
+++ b/applications/repo_map/workflows/worker_agents/dir_architecture_analysis.yaml
@@ -6,7 +6,7 @@ description: |
   不做文件读写，只做分析。
 
 model_type: "powerful"
-tool_call_type: "tool_call"
+tool_call_type: "code_act"
 concurrency: auto
 
 workflow: |

--- a/applications/repo_map/workflows/worker_agents/repo_map_skill_writer.yaml
+++ b/applications/repo_map/workflows/worker_agents/repo_map_skill_writer.yaml
@@ -5,10 +5,62 @@ description: |
   使用 write_markdown_file 写入 SKILL.md 与 assets/examples/*.md。
 
 model_type: "powerful"
-tool_call_type: "tool_call"
+tool_call_type: "code_act"
 
 workflow: |
   # Repo Map Skill Writer
+  
+  ## code_act 输出格式硬性要求
+
+  你当前运行在 code_act 模式。每一步回复都必须是可执行的 Python 代码，不要直接输出 Markdown 正文、中文说明或普通文本。
+
+  如果需要读取文件，必须写成 Python 工具调用，例如：
+
+  ```python
+  context_text = read_file(file_path=f"{output_dir}/data/skill_build_context.json")
+  ```
+
+  如果需要写入 Markdown 文件，必须把 Markdown 正文放进 Python 字符串里，再调用 write_markdown_file，例如：
+
+  ```python
+  content = r"""
+  ---
+  name: repo-map-navigator
+  description: 在阅读或修改源码前，先查阅对应路径的 repo_map 文档。
+  ---
+
+  ## 概述
+
+  这里写 Markdown 正文。
+  """
+
+  write_markdown_file(
+      file_path=f"{skill_root}/SKILL.md",
+      title="",
+      metadata=None,
+      sections=[
+          {
+              "heading": "",
+              "body": content,
+          }
+      ],
+  )
+  ```
+
+  如果需要返回最终结果，必须调用：
+
+  ```python
+  final_answer("已写入 SKILL.md 和示例文件，校验通过。")
+  ```
+
+  严禁直接输出如下内容：
+
+  ```markdown
+  ## 概述
+  repo_map 在每个目录下提供 index.md 和 analysis.md。
+  ```
+
+  因为裸 Markdown 会被 code_act 当成 Python 代码解析，从而触发 SyntaxError。
 
   你是 Skill 文档写入 Agent。你只做一件事：在已准备好的 skill 目录中写入高质量的 Markdown 文件，
   让任何 AI 编程助手（Copilot、Claude Code、Cursor 等）在阅读源码时，能先通过 repo_map 文档

--- a/src/lib/smolagents/models/litellm_model.py
+++ b/src/lib/smolagents/models/litellm_model.py
@@ -110,6 +110,16 @@ class LiteLLMModelV2(LiteLLMModel):
     def _prepare_completion_kwargs(self, *args, **kwargs):
         completion_kwargs = super()._prepare_completion_kwargs(*args, **kwargs)
 
+        if getattr(self, "supports_native_tool_calls", "auto") == "false":
+            removed_tool_choice = completion_kwargs.pop("tool_choice", None)
+            self.logger.debug(
+                "[DEBUG_TOOL_CHOICE] supports_native_tool_calls=false; "
+                "removed tool_choice=%r; has_tools=%s; extra_body=%s",
+                removed_tool_choice,
+                "tools" in completion_kwargs,
+                completion_kwargs.get("extra_body"),
+            )
+
         # Remove </code> from stop sequences. smolagents adds it as a stop token,
         # but some APIs (e.g. ARK) return partial residue ("</cod") when given
         # multiple stops. Removing it is safe: parse_code_blobs uses regex to


### PR DESCRIPTION
本 PR 修复了 repo_map 与 DeepSeek thinking 模式之间的兼容性问题。

修改内容：
- 当 `supports_native_tool_calls` 设置为 `"false"` 时，从 LiteLLM 的 completion kwargs 中移除 `tool_choice`。
- 将 repo_map 相关 workflow 切换为 `code_act` 模式，以避免开启 thinking 的模型与原生工具调用之间发生冲突。
- 为 repo_map skill writer 添加明确的 code_act 输出格式要求，避免模型直接输出 Markdown 正文并被解析为 Python 代码。

测试配置：
- `openai/deepseek-v4-pro`
- `extra_body.thinking.type: enabled`
- `supports_native_tool_calls: "false"`

测试结果：
- 执行命令：`python applications/repo_map/repo_map_app.py applications/repo_map/tests --output_dir .repo_map_output\tests --log_to_file=True`
- 运行成功完成。