### PR TITLE
Refactor runtime storage around run and task scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yam
 After the first run, you should see:
 
 - structured terminal logs with agent names, task IDs, step duration, and token usage;
-- archived run files under `.logs/<agent>/<timestamp>/`;
-- resumable task state when checkpointing is enabled;
+- one execution attempt under `.agentloom/runs/<application_id>/<run_id>/`, with a manifest, bounded runtime log, Shell audit, and raw artifacts;
+- resumable task state under `.agentloom/checkpoints/<application_id>/<task_id>/` when checkpointing is enabled;
 - optional visualization through `uv run loom ui`;
 - optional terminal monitoring through `uv run loom dashboard`.
 
+`run_id` identifies one execution attempt and changes on resume. `task_id` identifies the logical task and remains stable, so a resumed attempt writes a new run directory while continuing the same checkpoint. The agent-visible `.runtime/` workspace is intentionally separate from framework runtime storage.
+
 ## Create a Multi-Agent App with Codex
 
-The fastest path is to let Codex use the framework skill that ships with this repository. Codex can create the YAML files, run the AgentLoom app, watch terminal output and `.logs/`, inspect checkpoint state, and revise the app when a Worker gets stuck or a config is wrong.
+The fastest path is to let Codex use the framework skill that ships with this repository. Codex can create the YAML files, run the AgentLoom app, inspect `.agentloom/` run and checkpoint evidence, and revise the app when a Worker gets stuck or a config is wrong.
 
 Use a prompt like this:
 
@@ -83,7 +85,12 @@ Useful runtime checks while the app is running:
 ```bash
 uv run loom list-tasks
 uv run loom dashboard
-ls .logs/
+
+manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
+run_dir=$(dirname "$manifest")
+sed -n '1,160p' "$manifest"
+tail -n 80 "$run_dir/logs/runtime.log"
+tail -n 80 "$run_dir/audit/shell.jsonl"
 ```
 
 If you prefer Claude Code, give it the same request: read `agentloom-framework-skill/SKILL.md`, create the app under `applications/<app_name>/`, run it, and summarize what worked or failed.
@@ -111,7 +118,7 @@ The practical result:
 | Reuse coding-assistant knowledge | Load Claude-style `SKILL.md` packages on demand or eagerly. |
 | Connect external tools | Register local Python tools, local `codex exec`, and MCP servers through `mcp_servers`. |
 | Handle repeated work | Use Worker `concurrency` and `tool.batch(tasks)` for independent repeated inputs. |
-| Understand long runs | Use structured logs, `.logs/` archives, checkpoints, `loom ui`, and `loom dashboard`. |
+| Understand long runs | Read the run manifest, bounded runtime log, Shell audit, task checkpoint, `loom ui`, and `loom dashboard`. |
 
 ## Architecture
 
@@ -135,7 +142,7 @@ The important boundary is:
 | Agent-as-Tool coordination | Worker Agents export as callable tools through `agent_function_schema`, including required-input validation and string outputs. |
 | Skills, MCP, and tools | Agents can load `SKILL.md` packages, local Python functions, built-in file/shell/search/git tools, local Codex tools, and MCP client tools through `mcp_servers`. |
 | Concurrent repeated work | Worker `concurrency: auto` or fixed concurrency works with `.batch(tasks)` for many independent inputs. |
-| State and observability | Rich terminal logs, plain text file logs, per-step timing, token usage, `.logs/` archives, checkpoint resume, Web UI, and TUI dashboard. |
+| State and observability | Rich terminal logs, bounded per-run file logs, per-step timing, token usage, run manifests, checkpoint resume, Web UI, and TUI dashboard. |
 
 ## Example Applications
 
@@ -208,6 +215,9 @@ Before running the tool, make sure `codex` is on `PATH` and `codex login status`
 | `uv run loom dashboard` | Open the terminal task dashboard. |
 | `uv run loom list-tasks` | List resumable checkpoint tasks. |
 | `uv run loom clean-tasks` | Clean old checkpoint data. |
+| `uv run loom clean-runtime` | Apply configured retention to completed run directories and raw artifacts. |
+| `uv run loom migrate-runtime --dry-run` | Preview valid legacy checkpoint candidates without changing disk state. |
+| `uv run loom migrate-runtime --apply` | Migrate valid legacy checkpoints and archive the old `.logs` tree. |
 
 ## Documentation
 

--- a/agentloom-framework-skill/SKILL.md
+++ b/agentloom-framework-skill/SKILL.md
@@ -26,7 +26,7 @@ argument-hint: "<AgentLoom task or application path>"
 - 需要为 Application 配置或创建私有 Skill：读 [`references/configuration-surface.md`](references/configuration-surface.md) 的 Skills/Hook 配置，再读 [`references/application-generation.md`](references/application-generation.md) 的目录规范。
 - 需要配置或验证 shell 权限、allowlist、audit log、sandbox、路径安全、后台任务或 stall 检测：先读 [`references/shell-security-audit.md`](references/shell-security-audit.md)，再按需要读配置面和验证评审。
 - 需要验证是否真是多 Agent、是否能运行、问题怎么记录：读 [`references/validation-and-review.md`](references/validation-and-review.md)。
-- 修改 ContextEngine/压缩、checkpoint、resume、日志/维测、并发 Worker、文件回滚、`loom list-tasks` 或 `loom clean-tasks` 这类框架运行时能力：读 [`references/validation-and-review.md`](references/validation-and-review.md) 的“框架运行时功能验证”，并用真实 Application 跑功能路径。
+- 修改 ContextEngine/压缩、checkpoint、resume、run-scoped 日志/维测、并发 Worker、文件回滚、`loom list-tasks`、`loom clean-tasks`、`loom clean-runtime` 或 `loom migrate-runtime` 这类框架运行时能力：读 [`references/validation-and-review.md`](references/validation-and-review.md) 的“框架运行时功能验证”，并用真实 Application 跑功能路径。
 - 需要写 README 或验证记录：读 [`references/readme-template.md`](references/readme-template.md)。
 - 需要看一个按本 Skill 创建的简单多 Agent 示例：参考 `applications/feature_planner_demo/README.md`。
 - 只有当规则会跨多个 Application 复用、需要 Hook、或必须长期注入领域协议时，才创建新的私有 Skill；否则不要创建 Skill。
@@ -54,8 +54,8 @@ argument-hint: "<AgentLoom task or application path>"
 8. 框架功能不要新增兼容桥、旧字段回退或第二套路径；如果契约需要变化，直接改主路径、配置白名单、文档和验证。
 9. 设计或修改框架功能时必须先写验证矩阵：单测证明局部规则，真实 Application 证明完整运行链路；涉及上下文压缩时必须验证压缩后能按 `ContextRef` retrieve 原文，涉及 resume 时必须验证恢复后旧 ref 仍可 retrieve。
 10. 代码编写完成后不能只跑单测或 YAML 校验。必须按改动风险选择多条真实 Application 跑功能验证；现有 Application 覆盖不足时，新增最小验证 Application，保留在 `applications/<validation_app>/`，让后续 Agent 可复跑。
-11. 每个真实 Application 跑完后都要读运行日志和关键产物，再判断是否符合预期；不要只看进程退出码或 LLM final answer。验证记录至少包含：命令、退出码、final answer、关键 tool 调用/worker 调用、日志里的错误/警告、产物文件或 checkpoint/context/audit 证据。
-12. 如果用户不确定 shell 权限怎么配，先用隔离 runtime 跑真实 workflow，读取 `shell_audit.log` 里的 `[POLICY_SNAPSHOT]` 和拦截事件，再收敛 `allowed_commands`、`allowed_operators`、路径规则或 sandbox。
+11. 每个真实 Application 跑完后都要读 `.agentloom/runs/<application_id>/<run_id>/manifest.json`、`logs/runtime.log`、`audit/shell.jsonl` 和关键产物，再判断是否符合预期；不要只看进程退出码或 LLM final answer。验证记录至少包含：命令、退出码、`task_id`/`run_id`、final answer、关键 tool/worker 调用、日志错误/警告、产物或 checkpoint/context/audit 证据。
+12. 如果用户不确定 shell 权限怎么配，先用隔离 runtime 跑真实 workflow，读取当前 run 的 `audit/shell.jsonl` 里的 `[POLICY_SNAPSHOT]` 和拦截事件，再收敛 `allowed_commands`、`allowed_operators`、路径规则或 sandbox。
 13. 最后必须运行验证命令。能跑到哪一步就记录到哪一步，不把“未执行”说成“通过”。
 
 ## 命令速查
@@ -84,6 +84,13 @@ print(scan_app_structure('applications/<app_name>'))
 
 # 直接运行 YAML（首选运行入口；会触发真实模型调用和外部工具）
 .venv/bin/loom run applications/<app_name>/workflows/<app_name>_agent.yaml
+
+# 查看真实 run 证据；file logging 默认开启，单次关闭用 --no-file-log
+manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
+run_dir=$(dirname "$manifest")
+sed -n '1,160p' "$manifest"
+tail -n 100 "$run_dir/logs/runtime.log"
+tail -n 100 "$run_dir/audit/shell.jsonl"
 
 # 入口脚本生成链路校验
 .venv/bin/loom create applications/<app_name>/workflows/<app_name>_agent.yaml \

--- a/agentloom-framework-skill/references/application-generation.md
+++ b/agentloom-framework-skill/references/application-generation.md
@@ -43,7 +43,7 @@ applications/<app_name>/
 .venv/bin/loom run applications/<app_name>/workflows/<app_name>_agent.yaml
 ```
 
-`<app_name>_app.py` 不是 Application 必需文件。只有当应用需要自定义自然语言请求、预处理/后处理、批量循环、`log_to_file`/`resume` 包装，或需要通过 `run_app(..., task_override=...)` 嵌入到别的 Python 流程时，才创建入口脚本。
+`<app_name>_app.py` 不是 Application 必需文件。只有当应用需要自定义自然语言请求、预处理/后处理、批量循环、`file_logging`/`resume` 包装，或需要通过 `run_app(..., task_override=...)` 嵌入到别的 Python 流程时，才创建入口脚本。
 
 ```python
 #!/usr/bin/env python3
@@ -61,7 +61,7 @@ if project_root not in sys.path:
 from src.runner import run_app
 
 
-def main(user_request: str, log_to_file: bool = False, resume: str | None = None) -> str:
+def main(user_request: str, file_logging: bool | None = None, resume: str | None = None) -> str:
     if not user_request or not user_request.strip():
         raise ValueError("user_request must be non-empty")
 
@@ -69,7 +69,7 @@ def main(user_request: str, log_to_file: bool = False, resume: str | None = None
     result = run_app(
         "applications/<app_name>/workflows/<app_name>_agent.yaml",
         task_override=task,
-        log_to_file=log_to_file,
+        file_logging=file_logging,
         resume_task_id=resume,
     )
     print(result)
@@ -79,6 +79,8 @@ def main(user_request: str, log_to_file: bool = False, resume: str | None = None
 if __name__ == "__main__":
     fire.Fire(main)
 ```
+
+`file_logging=None` 表示遵循全局 `logging.file_enabled`，`False` 表示仅关闭当前 attempt 的文件 runtime log；checkpoint 和 Shell audit 不受影响。不要保留旧 `log_to_file` 参数兼容。
 
 ## Tool 生成原则
 
@@ -121,7 +123,7 @@ mcp_servers:
 
 列表是整体替换，不是追加；写 Agent 级 `toolsets`、`skills` 这类列表时要表达完整意图。完整配置面见 `configuration-surface.md`。
 
-`allowed_commands: "*"` 与 `allowed_operators: "*"` 是全放开，只适合可信开发环境或先观察 audit 的探索阶段。用户不确定权限时，先运行真实 workflow，读取 `shell_audit.log` 的 `[POLICY_SNAPSHOT]` 和拦截事件，再收敛命令、操作符、路径或 sandbox 配置。
+`allowed_commands: "*"` 与 `allowed_operators: "*"` 是全放开，只适合可信开发环境或先观察 audit 的探索阶段。用户不确定权限时，先运行真实 workflow，读取当前 run 的 `manifest.json` 和 `audit/shell.jsonl`，再根据 `[POLICY_SNAPSHOT]` 与拦截事件收敛命令、操作符、路径或 sandbox 配置。
 
 ## README 必写内容
 

--- a/agentloom-framework-skill/references/configuration-surface.md
+++ b/agentloom-framework-skill/references/configuration-surface.md
@@ -17,7 +17,7 @@
 
 | 配置面 | 写在哪里 | 用途 | 关键规则 |
 |---|---|---|---|
-| 全局系统配置 | `config/system.yaml` | 工具、权限、shell、prompt、skills、checkpoint 等系统行为 | 参与 deep merge；列表整段替换 |
+| 全局系统配置 | `config/system.yaml` | runtime root、日志、工具、权限、shell、prompt、skills、checkpoint 等系统行为 | `runtime`/`logging` 只在此处生效；其他字段参与 deep merge；列表整段替换 |
 | 本地模型配置 | `config/llm.yaml` | 模型类型、密钥、网关、推理参数、限流、重试 | 独立加载，不被 app/Agent YAML 覆盖；通常被 `.gitignore` 忽略 |
 | 应用级系统覆盖 | `applications/<app>/config/system.yaml` | 当前应用专属的系统行为覆盖 | 从 Agent YAML 路径向上找到最近 `workflows/`，其父目录即 app root |
 | Agent YAML | `applications/<app>/workflows/*.yaml` | 单个 Agent 的角色、workflow、工具、模型类型、运行模式 | 只有白名单字段会 overlay 到系统配置，其余是 Agent 自身属性 |
@@ -28,6 +28,10 @@
 合并顺序：框架默认值 -> `config/system.yaml` -> `applications/<app>/config/system.yaml` -> Agent YAML 白名单字段。字典递归合并；列表和标量整体替换。
 
 LLM 配置不参与这个链条。`model`、`llm`、`langfuse` 写进 `system.yaml` 或 Agent YAML 会被过滤并警告。
+
+`runtime` 与 `logging` 是 global-only：Application 级 `config/system.yaml` 和 Agent YAML 一旦包含任一顶层字段就会校验失败；必须删除并改到项目根 `config/system.yaml`。这样错误位置的配置不会被静默忽略。`checkpoint` 仍可由 Application 级 system overlay 调整，但不在 Agent YAML 白名单中。
+
+需要隔离子进程时只允许使用 `AGENTLOOM_RUNTIME_ROOT` 覆盖整套 canonical runtime home；禁止恢复 self-learning 专用 root 或让日志/checkpoint/session 分根。
 
 ## Agent YAML 可配置字段
 
@@ -98,6 +102,7 @@ tools_mapping, default_toolsets, toolsets, prompt, mcp_servers, self_learning
 - `context_engine` 可以在 Agent YAML 覆盖，用于按应用或 Agent 调整可逆上下文压缩。
 - `self_learning` 可以在应用或 Agent YAML 覆盖；memory reviewer 必须从当前 root 的最终生效配置读取，不能使用进程全局回退。
 - `mcp_servers` 可以在 Agent YAML 覆盖，并支持 string/list/dict。
+- `runtime`、`logging`、`checkpoint` 不在 Agent YAML 白名单；不要把存储 root、日志策略或 resume 生命周期塞进 Agent workflow。
 - Worker 的有效配置由全局、应用级、Worker YAML 自己重建；不会继承 Supervisor 的运行时覆盖。Worker 需要同样权限时必须自己写。
 
 ## system.yaml 配置面
@@ -114,7 +119,8 @@ tools_mapping, default_toolsets, toolsets, prompt, mcp_servers, self_learning
 | `lsp_servers` | LSP 服务开关、重启次数、语言列表 |
 | `execution_env` | 默认执行环境 |
 | `code_agent` | `code_act` 可 import 模块和可调用内置函数 |
-| `logging` | 日志开关、级别、文件路径和目录；以全局配置为准 |
+| `runtime` | 唯一 `.agentloom` root、run/artifact 保留天数和自动清理间隔；只允许全局配置 |
+| `logging` | `level/console_enabled/file_enabled/max_file_bytes/backup_count`；run-scoped 且只允许全局配置 |
 | `default_toolsets` | 默认加载 toolset 名列表 |
 | `toolsets` | Agent 级内置 toolset 覆盖，空列表表示无内置工具 |
 | `shell_settings` | shell 命令白名单、安全检查、sandbox、后台任务、audit log |
@@ -151,7 +157,6 @@ context_engine:
 ```yaml
 self_learning:
   enabled: true
-  root_dir: ".agentloom"
   events_retention_days: 90
   memory:
     prompt_max_chars: 12000
@@ -212,7 +217,7 @@ code_agent:
 - `background_tasks`：`enabled/max_concurrent/auto_background_on_timeout/max_output_bytes/stall_detection/stall_threshold_seconds`。
 - `audit_log`：`enabled/log_policy_snapshot/log_success`。
 
-如果用户不确定 shell 权限怎么配，先按 `shell-security-audit.md` 跑真实 workflow，读 `shell_audit.log` 的 `[POLICY_SNAPSHOT]` 和拦截事件，再收敛 `allowed_commands`、`allowed_operators`、路径规则或 sandbox。
+如果用户不确定 shell 权限怎么配，先按 `shell-security-audit.md` 跑真实 workflow，读当前 run 的 `audit/shell.jsonl` 中 `[POLICY_SNAPSHOT]` 和拦截事件，再收敛 `allowed_commands`、`allowed_operators`、路径规则或 sandbox。
 
 ### tool_access_control
 
@@ -424,6 +429,24 @@ Setup, ConfigChange, Notification
 
 ## checkpoint 配置
 
+Runtime 与 checkpoint 的身份边界：`run_id` 表示一次 attempt，resume 时改变；`task_id` 表示同一逻辑任务，resume 时保持不变。
+
+```yaml
+runtime:
+  root_dir: ".agentloom"
+  successful_run_retention_days: 7
+  failed_run_retention_days: 30
+  artifact_retention_days: 3
+  cleanup_interval_hours: 24
+
+logging:
+  level: "INFO"
+  console_enabled: true
+  file_enabled: true
+  max_file_bytes: 26214400
+  backup_count: 3
+```
+
 ```yaml
 checkpoint:
   enabled: true
@@ -432,7 +455,9 @@ checkpoint:
   heartbeat_interval: 5
 ```
 
-checkpoint 存在于每次运行的日志时间戳目录下，包含 `task_events.jsonl`、`task_tree.json`、Supervisor `checkpoint.json`、heartbeat、file-history，以及 Worker per-call checkpoint。`loom list-tasks`、`loom clean-tasks`、`loom run --resume <task_id>` 是验证入口。
+每次 attempt 写入 `.agentloom/runs/<application_id>/<run_id>/`，其中包含 `manifest.json`、`logs/runtime.log`、`audit/shell.jsonl` 和 `artifacts/{shell,background,skills}`。逻辑任务状态独立写入 `.agentloom/checkpoints/<application_id>/<task_id>/`，包含 `task_events.jsonl`、`task_tree.json`、Supervisor `checkpoint.json`、heartbeat、ContextStore、file-history 和 Worker per-call checkpoint。日志关闭、轮转和 run 清理不能影响 checkpoint；`.runtime/` 与 Application outputs 也不属于 runtime cleaner。
+
+CLI 契约：文件日志默认按配置落盘，单次关闭用 `loom run --no-file-log`；不存在 `--log-to-file`。`loom list-tasks`、`loom clean-tasks`、`loom run --resume <task_id>` 验证 checkpoint；`loom clean-runtime` 应用 run retention；`loom migrate-runtime --dry-run|--apply` 迁移/归档旧 `.logs`。真实运行必须读 manifest、runtime.log 与 shell.jsonl，不能只看退出码。
 
 ## MCP 配置
 

--- a/agentloom-framework-skill/references/readme-template.md
+++ b/agentloom-framework-skill/references/readme-template.md
@@ -56,6 +56,7 @@ applications/<app_name>/
 | `scan_app_structure(...)` | 通过/失败 |
 | `py_compile ...` | 通过/失败 |
 | 运行验证 | 通过/失败/未执行，原因 |
+| Run 证据 | `manifest.json`、`logs/runtime.log`、`audit/shell.jsonl` 的真实路径与关键结论 |
 
 ## 已知问题
 
@@ -68,3 +69,5 @@ applications/<app_name>/
 - 不把“未执行”写成“通过”。
 - 如果运行失败，记录根因和下一步。
 - 如果是多 Agent，必须写清每个 Worker 的输入输出。
+- 运行验证必须记录 manifest 中的 `application_id`、`task_id`、`run_id`，并读同一 run 的 runtime log/audit；不要只记录退出码或 final answer。
+- Application 用户交付物写自身 `output_dir`；`.agentloom/runs/.../artifacts` 只放 raw runtime artifacts，`.runtime/` 仍是独立的 Agent 可见工作区。

--- a/agentloom-framework-skill/references/shell-security-audit.md
+++ b/agentloom-framework-skill/references/shell-security-audit.md
@@ -5,11 +5,12 @@
 当用户不确定 `shell_settings` 应该怎么配时，不要先猜一份白名单。最短路径是：
 
 1. 用隔离 runtime 跑一次真实 workflow。
-2. 打开同目录的 `.logs/<agent>/<timestamp>/shell_audit.log`。
-3. 先读 `[POLICY_SNAPSHOT]`，确认本次有效策略：`allowed_commands`、`allowed_operators`、`security_checks`、`dangerous_paths`、`sandbox_enabled`。
-4. 再读拦截事件：`WHITELIST_REJECT`、`PATH_VIOLATION`、`SECURITY_BLOCK`、`STALL_DETECTED`、`TIMEOUT`、`BACKGROUND_PROMOTION`、`SANDBOX_UNAVAILABLE`。
-5. 只把真实需要的命令、操作符、路径或 sandbox 例外写进 Agent YAML / Worker YAML / 应用级 `config/system.yaml`。
-6. 用收敛后的策略重跑真实 workflow，确认该允许的允许、该拒绝的拒绝。
+2. 先读 `.agentloom/runs/<application_id>/<run_id>/manifest.json`，确认本次 `application_id`、`task_id`、`run_id`。
+3. 打开同一 run 下的 `audit/shell.jsonl`；主日志位于 `logs/runtime.log`。
+4. 先读 `[POLICY_SNAPSHOT]`，确认本次有效策略：`allowed_commands`、`allowed_operators`、`security_checks`、`dangerous_paths`、`sandbox_enabled`。
+5. 再读拦截事件：`WHITELIST_REJECT`、`PATH_VIOLATION`、`SECURITY_BLOCK`、`STALL_DETECTED`、`TIMEOUT`、`BACKGROUND_PROMOTION`、`SANDBOX_UNAVAILABLE`。
+6. 只把真实需要的命令、操作符、路径或 sandbox 例外写进 Agent YAML / Worker YAML / 应用级 `config/system.yaml`。
+7. 用收敛后的策略重跑真实 workflow，确认该允许的允许、该拒绝的拒绝。
 
 默认 `allowed_commands: "*"` 与 `allowed_operators: "*"` 是全放行。即使没有任何命令被拦截，也必须能在 audit log 里看到 `[POLICY_SNAPSHOT]`，否则无法证明“没拦截”是因为策略全允许，而不是审计缺失。
 
@@ -82,29 +83,27 @@ shell_settings:
 
 ## 必跑真实验证
 
-修改 shell 权限、审计、sandbox、路径安全、后台任务或 stall 逻辑时，不能只跑单测。至少选择相关真实 Application，使用隔离 runtime：
+修改 shell 权限、审计、sandbox、路径安全、后台任务或 stall 逻辑时，不能只跑单测。至少选择相关真实 Application；在隔离 checkout 的全局 `config/system.yaml` 中把 `runtime.root_dir` 指向临时目录，例如 `/tmp/agentloom-runtime-shell-security`。`runtime` 是 global-only，不能用 Application overlay 代替。
 
-```bash
-export AGENT_LOOM_RUNTIME_ROOT=/tmp/agentloom-runtime-shell-security
-```
+文件日志默认开启且有界；只有验证关闭文件日志时才加 `--no-file-log`，不存在 `--log-to-file`。
 
 建议矩阵：
 
 ```bash
-.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_policy_snapshot_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_audit_log_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_audit_signals_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_shell_allowlist_matrix/workflows/test_shell_allowlist_matrix_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_demo/workflows/test_path_access_control_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_demo/workflows/test_security_transparency_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_demo/workflows/test_background_task_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_demo/workflows/test_shell_stall_detection_agent.yaml --log-to-file
+.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_policy_snapshot_agent.yaml
+.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_audit_log_agent.yaml
+.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_audit_signals_agent.yaml
+.venv/bin/loom run applications/test_shell_allowlist_matrix/workflows/test_shell_allowlist_matrix_agent.yaml
+.venv/bin/loom run applications/test_demo/workflows/test_path_access_control_agent.yaml
+.venv/bin/loom run applications/test_demo/workflows/test_security_transparency_agent.yaml
+.venv/bin/loom run applications/test_demo/workflows/test_background_task_agent.yaml
+.venv/bin/loom run applications/test_demo/workflows/test_shell_stall_detection_agent.yaml
 ```
 
 通过标准：
 
-- LLM final 不能只说 PASS，必须列出实际 `shell_audit.log` 路径和关键证据行。
-- agent log 与 shell audit log 父目录一致。
+- LLM final 不能只说 PASS，必须列出实际 `manifest.json`、`logs/runtime.log`、`audit/shell.jsonl` 路径和关键证据行。
+- Runtime log 与 Shell audit 必须归属同一个 `<application_id>/<run_id>` run 目录，不能借用其他 run。
 - 全允许场景必须有 `[POLICY_SNAPSHOT]`，且显示 `allowed_commands: *` / `allowed_operators: *`。
 - 收敛白名单场景必须证明允许命令成功、未允许命令被拒绝、未允许操作符被拒绝。
 - `;` 等操作符被拒绝时 suggestion 必须是 `allowed_operators`，不得建议放进 `allowed_commands`。

--- a/agentloom-framework-skill/references/validation-and-review.md
+++ b/agentloom-framework-skill/references/validation-and-review.md
@@ -71,7 +71,7 @@ find applications/<app_name>/agent_tools -name '*.py' -print0 2>/dev/null | xarg
 
 日志审计要求：
 
-- 保存或记录 `loom run ... --log-to-file` 的 log 路径；如果未使用 `--log-to-file`，至少把 stdout/stderr 落到 `/tmp/agentloom_<case>.log`。
+- 文件日志默认按 `logging.file_enabled` 写入当前 run 的 `logs/runtime.log`；不存在 `--log-to-file`。记录 `manifest.json` 给出的 `application_id`、`task_id`、`run_id` 与真实 run 路径；需要验证关闭文件日志时才使用 `--no-file-log`。
 - 检查日志里实际出现了预期 tool 调用、worker 调用、hook 拦截/放行、checkpoint/context/audit 写入等证据。
 - 检查日志中的 `ERROR`、`Traceback`、`Exception`、`WARNING`、`parse failure`、`stale`、`blocked`；非阻塞警告也要判断是否符合预期。
 - 对写文件、ContextRef、checkpoint、shell audit 这类功能，必须检查落地产物内容，而不是只相信模型总结。
@@ -99,22 +99,26 @@ find applications/<app_name>/agent_tools -name '*.py' -print0 2>/dev/null | xarg
 
 修改 ContextEngine/CCR、checkpoint、resume、日志/维测、并发 Worker、文件回滚、任务列表或任务清理时，不能只跑单测；至少选 2 个真实 Application 或已有真实 workflow 跑功能路径。优先使用仓库里的 `applications/test_demo/*checkpoint*`、`applications/test_demo/*file_rewind*`、`applications/feature_planner_demo` 这类覆盖面明确的应用。
 
-建议用隔离运行根，避免污染用户已有 checkpoint：
+建议用隔离运行根，避免污染用户已有 checkpoint。隔离子进程优先用 `AGENTLOOM_RUNTIME_ROOT` 覆盖整个 canonical runtime home；它会同时移动 runs、checkpoints、sessions、learning 和 `self_learning.db`，不会只改某一类存储：
 
 ```bash
-export AGENT_LOOM_RUNTIME_ROOT=/tmp/agentloom-runtime-checkpoint
-rm -rf "$AGENT_LOOM_RUNTIME_ROOT"
+export AGENTLOOM_RUNTIME_ROOT=/tmp/agentloom-runtime-checkpoint
 ```
+
+只有在专门验证配置解析时，才在隔离 checkout 的项目根 `config/system.yaml` 修改 `runtime.root_dir`。`runtime`/`logging` 仍是 global-only，Application overlay 不能替代全局配置。执行前清理 `/tmp/agentloom-runtime-checkpoint`，验收结束后取消环境变量或恢复隔离 checkout 的配置。
 
 必须验证的证据：
 
-- `loom run <workflow.yaml> "<task>"` 能创建 checkpoint 目录。
+- `loom run <workflow.yaml> "<task>"` 能同时创建 `.agentloom/runs/<application_id>/<run_id>/manifest.json` 与 `.agentloom/checkpoints/<application_id>/<task_id>/`（使用自定义 root 时替换 `.agentloom`）。
+- Manifest 必须记录 `application_id`、`task_id`、`run_id` 和最终状态；`logs/runtime.log`、`audit/shell.jsonl`、`artifacts/{shell,background,skills}` 只能写进当前 run。
 - 新 checkpoint 有 `task_events.jsonl`；`task_tree.json` 只是投影且能被 `loom list-tasks --detail` 展示。
 - 多 Worker 或重复 Worker 调用场景下，`workers/<worker>/calls/<call_index>/checkpoint.json` 存在，`call_index` 不互相覆盖。
 - resume 场景要实际执行 `loom run <workflow.yaml> --resume <task_id>`；若为了制造中断而提前停止，记录中断方式和恢复结果。
+- Resume 后必须证明 `task_id` 不变、`run_id` 改变，新旧 attempt 分属两个 run 目录，但都关联同一个 task checkpoint；heartbeat 和 run event 使用新 `run_id`。
 - 涉及 subagent/Worker checkpoint 时，要分别验证 Supervisor 中断恢复和 Worker 半路中断恢复；Worker 恢复必须证明没有新开重复 `call_index`，且能从 per-call memory checkpoint 继续。
 - file-history 场景要检查 `file-history/snapshots.json` 和备份文件，确认早期备份没有被后续 snapshot 覆盖。
-- 清理场景要实际跑 `loom clean-tasks --all`，确认新旧 worker checkpoint 布局都会被删除。
+- Checkpoint 清理场景要实际跑 `loom clean-tasks --all`；run retention 要跑 `loom clean-runtime`，证明不会删除 checkpoint、`.runtime/`、`.agentloom/legacy/` 或 Application outputs。
+- 迁移要先跑 `loom migrate-runtime --dry-run`，再在隔离副本跑 `--apply`，证明忽略坏 `.task_index.json`、幂等/失败回滚、checksum 校验、有效 task resume、旧 ContextRef retrieve 与 file-history 恢复；最后确认旧 `.logs` 整体进入 `.agentloom/legacy/logs-v1-<timestamp>/`，新运行不再写 `.logs`。
 
 ContextEngine/CCR 额外必须验证：
 
@@ -143,34 +147,30 @@ PYTHONPATH=/Users/bytedance/code/data_clear/AgentLoom-checkpoint \
 
 修改 shell 权限、审计、sandbox、路径安全、后台任务或 stall 检测时，不能只跑单测。按 `shell-security-audit.md` 先确认 audit log 能记录有效策略，再用真实 Application 验证该允许的允许、该拒绝的拒绝。
 
-建议使用隔离 runtime：
-
-```bash
-export AGENT_LOOM_RUNTIME_ROOT=/tmp/agentloom-runtime-shell-security
-```
+建议在隔离 checkout 的全局 `config/system.yaml` 中把 `runtime.root_dir` 设为 `/tmp/agentloom-runtime-shell-security`，并在执行前清理该目录。
 
 核心真实 LLM 验证：
 
 ```bash
-.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_policy_snapshot_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_audit_log_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_audit_signals_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_shell_allowlist_matrix/workflows/test_shell_allowlist_matrix_agent.yaml --log-to-file
+.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_policy_snapshot_agent.yaml
+.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_audit_log_agent.yaml
+.venv/bin/loom run applications/test_shell_audit/workflows/test_shell_audit_signals_agent.yaml
+.venv/bin/loom run applications/test_shell_allowlist_matrix/workflows/test_shell_allowlist_matrix_agent.yaml
 ```
 
 补充验证：
 
 ```bash
-.venv/bin/loom run applications/test_demo/workflows/test_security_transparency_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_demo/workflows/test_background_task_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_demo/workflows/test_shell_stall_detection_agent.yaml --log-to-file
-.venv/bin/loom run applications/test_demo/workflows/test_shell_session_isolation_supervisor.yaml --log-to-file
+.venv/bin/loom run applications/test_demo/workflows/test_security_transparency_agent.yaml
+.venv/bin/loom run applications/test_demo/workflows/test_background_task_agent.yaml
+.venv/bin/loom run applications/test_demo/workflows/test_shell_stall_detection_agent.yaml
+.venv/bin/loom run applications/test_demo/workflows/test_shell_session_isolation_supervisor.yaml
 ```
 
 通过标准：
 
-- LLM final 不能只写 PASS，必须列出实际 `shell_audit.log` 路径和关键证据行。
-- agent log 与 shell audit log 父目录一致。
+- LLM final 不能只写 PASS，必须列出当前 run 的 `manifest.json`、`logs/runtime.log`、`audit/shell.jsonl` 路径和关键证据行。
+- runtime log 与 Shell audit 必须属于同一个 `<application_id>/<run_id>` run 目录，不能借用其他 run。
 - 全允许场景必须有 `[POLICY_SNAPSHOT]`，且记录 `allowed_commands: *` / `allowed_operators: *`。
 - 白名单场景必须证明允许命令成功、未允许命令被拒绝、未允许操作符被拒绝。
 - `;` 等操作符拒绝的 suggestion 必须指向 `allowed_operators`，不得建议放进 `allowed_commands`。

--- a/agentloom-framework-skill/scripts/validate_application_yaml.py
+++ b/agentloom-framework-skill/scripts/validate_application_yaml.py
@@ -19,6 +19,7 @@ import yaml
 
 REQUIRED_FIELDS = ("name", "description", "workflow")
 FORBIDDEN_TOP_LEVEL = {"model", "llm", "langfuse"}
+GLOBAL_ONLY_TOP_LEVEL = {"runtime", "logging"}
 ALLOWED_TOOL_CALL_TYPES = {"code_act", "tool_call"}
 ALLOWED_EXECUTION_ENV_TYPES = {"local", "docker", "e2b", "wasm"}
 ALLOWED_WORKER_EXTENSIONS = {".yaml", ".yml", ".md"}
@@ -289,6 +290,18 @@ def _validate_common_rules(
                 rule="forbidden_top_level_key",
                 message=f"禁止在 Agent YAML 顶层使用 '{field}'",
                 suggestion="删除该字段，并改为在 config/llm.yaml 中配置模型参数",
+                project_root=project_root,
+            )
+
+    for field in GLOBAL_ONLY_TOP_LEVEL:
+        if field in config:
+            _add_error(
+                errors,
+                file_path=file_path,
+                field=field,
+                rule="global_only_top_level_key",
+                message=f"禁止在 Agent YAML 顶层使用全局配置 '{field}'",
+                suggestion=f"删除该字段；'{field}' 只能配置在项目根 config/system.yaml",
                 project_root=project_root,
             )
 
@@ -829,6 +842,18 @@ def _validate_system_config_map(
                 project_root=project_root,
             )
 
+    for field in GLOBAL_ONLY_TOP_LEVEL:
+        if field in config:
+            _add_error(
+                errors,
+                file_path=file_path,
+                field=field,
+                rule="global_only_top_level_key",
+                message=f"禁止在 Application system.yaml 中使用全局配置 '{field}'",
+                suggestion=f"删除该字段；'{field}' 只能配置在项目根 config/system.yaml",
+                project_root=project_root,
+            )
+
     _validate_skills_config(config, file_path, errors, project_root)
     _validate_overlay_config_types(config, file_path, errors, project_root)
     _validate_mcp_servers_config(config, file_path, errors, project_root)
@@ -878,18 +903,6 @@ def _validate_system_config_map(
             rule="type_dict",
             message="lsp_servers 必须是字典",
             suggestion="删除该字段，或使用 lsp_servers: {enabled: true, servers: ['python']}",
-            project_root=project_root,
-        )
-
-    logging_cfg = config.get("logging")
-    if logging_cfg is not None and not isinstance(logging_cfg, dict):
-        _add_error(
-            errors,
-            file_path=file_path,
-            field="logging",
-            rule="type_dict",
-            message="logging 必须是字典",
-            suggestion="删除该字段，或使用 logging: {enabled: true, level: INFO}",
             project_root=project_root,
         )
 

--- a/applications/ai_quality_analysis/ai_quality_analysis_demo.py
+++ b/applications/ai_quality_analysis/ai_quality_analysis_demo.py
@@ -23,7 +23,7 @@ from src.workflows.workflow_manager import get_supervisor_agent_yaml_path
 
 def run_ai_quality_analysis(
     project_path: str = ".",
-    log_to_file: bool = False,
+    file_logging: bool | None = None,
     resume: str | None = None,
 ):
     """
@@ -31,7 +31,7 @@ def run_ai_quality_analysis(
 
     Args:
         project_path: Path to the project directory to analyze.
-        log_to_file:  Whether to write logs to a file.
+        file_logging: Per-run file logging override. ``None`` follows global config.
         resume:       Resume from a checkpoint task ID.
     """
     from src.runner import run_app
@@ -61,7 +61,7 @@ def run_ai_quality_analysis(
     try:
         run_app(
             str(yaml_path),
-            log_to_file=log_to_file,
+            file_logging=file_logging,
             resume_task_id=resume,
         )
         return True
@@ -79,7 +79,7 @@ def run_ai_quality_analysis(
 
 def cli_run_ai_quality_analysis(
     project_path: str = ".",
-    log_to_file: bool = False,
+    file_logging: bool | None = None,
     resume: str | None = None,
 ):
     """
@@ -87,20 +87,24 @@ def cli_run_ai_quality_analysis(
 
     Args:
         project_path: Path to the project directory to analyze.
-        log_to_file:  Whether to log to file (e.g., --log-to-file).
+        file_logging: Per-run file logging override. ``None`` follows global config.
         resume:       Resume from a checkpoint task ID (e.g., --resume task_xxx).
 
     Examples:
         # Analyze a specific project
         python ai_quality_analysis_demo.py /path/to/project
 
-        # With logging
-        python ai_quality_analysis_demo.py /path/to/project --log-to-file
+        # Disable this attempt's file runtime log
+        python ai_quality_analysis_demo.py /path/to/project --file-logging=false
 
         # Resume after interruption
         python ai_quality_analysis_demo.py /path/to/project --resume task_xxx
     """
-    success = run_ai_quality_analysis(project_path, log_to_file=log_to_file, resume=resume)
+    success = run_ai_quality_analysis(
+        project_path,
+        file_logging=file_logging,
+        resume=resume,
+    )
     if not success:
         print("\n❌ Code review execution failed")
         sys.exit(1)

--- a/applications/browser_harness_probe/README.md
+++ b/applications/browser_harness_probe/README.md
@@ -77,7 +77,7 @@ command -v browser-harness
 
 `loom run` 会使用 YAML 的 `description` 作为任务；本 Application 的默认任务是先跑 doctor，再按 isolated -> real 的顺序验证两个 demo。
 
-`browser_harness_probe_app.py` 不是运行所必需。当前保留它只做便利 wrapper：当需要传入自定义自然语言请求、`log_to_file` 或 `resume` 时，它会调用 `run_app(..., task_override=...)`。
+`browser_harness_probe_app.py` 不是运行所必需。当前保留它只做便利 wrapper：当需要传入自定义自然语言请求、`file_logging` 或 `resume` 时，它会调用 `run_app(..., task_override=...)`。`file_logging=None` 遵循全局配置，`False` 只关闭当前 attempt 的文件 runtime log。
 
 通过 wrapper 默认同时验证 isolated Chrome 和 real Chrome：
 

--- a/applications/browser_harness_probe/browser_harness_probe_app.py
+++ b/applications/browser_harness_probe/browser_harness_probe_app.py
@@ -15,7 +15,7 @@ from src.runner import run_app
 
 def main(
     user_request: str = "Run browser-harness doctor, then verify both isolated Chrome and real Chrome demo probes.",
-    log_to_file: bool = False,
+    file_logging: bool | None = None,
     resume: str | None = None,
 ) -> str:
     """Run the browser-harness AgentLoom probe application."""
@@ -32,7 +32,7 @@ def main(
     result = run_app(
         "applications/browser_harness_probe/workflows/browser_harness_probe_agent.yaml",
         task_override=task,
-        log_to_file=log_to_file,
+        file_logging=file_logging,
         resume_task_id=resume,
     )
     print(result)

--- a/applications/browser_harness_probe/skills/browser-harness-agentloom/SKILL.md
+++ b/applications/browser_harness_probe/skills/browser-harness-agentloom/SKILL.md
@@ -16,7 +16,7 @@ cd /Users/bytedance/code/data_clear/AgentLoom-main-skill
 .venv/bin/loom run applications/browser_harness_probe/workflows/browser_harness_probe_agent.yaml
 ```
 
-`browser_harness_probe_app.py` is optional. Use it only when you need a custom natural-language request, `log_to_file`, or `resume`; direct YAML execution is the shorter default path.
+`browser_harness_probe_app.py` is optional. Use it only when you need a custom natural-language request, a `file_logging` override, or `resume`; direct YAML execution is the shorter default path.
 
 ## Setup
 

--- a/applications/browser_harness_probe/zsxq_scraper_app.py
+++ b/applications/browser_harness_probe/zsxq_scraper_app.py
@@ -34,7 +34,7 @@ DEFAULT_TASK = (
 
 def main(
     user_request: str = DEFAULT_TASK,
-    log_to_file: bool = False,
+    file_logging: bool | None = None,
     resume: str | None = None,
 ) -> str:
     """Run the zsxq owner-post scraper Agent."""
@@ -49,7 +49,7 @@ def main(
     result = run_app(
         "applications/browser_harness_probe/workflows/zsxq_scraper_agent.yaml",
         task_override=task,
-        log_to_file=log_to_file,
+        file_logging=file_logging,
         resume_task_id=resume,
     )
     print(result)

--- a/applications/memory_feature_validation/scripts/audit_memory_review_campaign.py
+++ b/applications/memory_feature_validation/scripts/audit_memory_review_campaign.py
@@ -1127,7 +1127,7 @@ def _plan_issues(plan: dict[str, Any]) -> list[str]:
         issues.append("plan does not match the canonical committed dataset plan")
     if plan.get("dataset") != dataset_manifest():
         issues.append("dataset manifest does not match the canonical campaign dataset")
-    if plan.get("cli_contract") != "loom run <workflow> --log-to-file":
+    if plan.get("cli_contract") != "loom run <workflow>":
         issues.append("campaign bypassed the production loom run CLI")
     if plan.get("memory_cli_contract") != ["list", "pending", "approve", "reject"]:
         issues.append("memory CLI contract is not list/pending/approve/reject")

--- a/applications/memory_feature_validation/scripts/run_memory_review_campaign.py
+++ b/applications/memory_feature_validation/scripts/run_memory_review_campaign.py
@@ -1016,7 +1016,7 @@ def _run_cli(state_root: Path, args: list[str], markers: list[str]) -> dict[str,
     env = os.environ.copy()
     env.pop(CAPSULE_TOKEN_ENV, None)
     env.pop(CAMPAIGN_LLM_CONFIG_FD_ENV, None)
-    env["AGENTLOOM_SELF_LEARNING_ROOT"] = str(state_root)
+    env["AGENTLOOM_RUNTIME_ROOT"] = str(state_root)
     command = [_loom(), "memory", *args]
     if capsule_is_active():
         command = guarded_runtime_command(command, repo_root=REPO_ROOT)
@@ -1256,14 +1256,14 @@ def _run_attempt(
     env.update(
         {
             "AGENT_LOOM_RUNTIME_ROOT": str(runtime_root),
-            "AGENTLOOM_SELF_LEARNING_ROOT": str(state_root),
+            "AGENTLOOM_RUNTIME_ROOT": str(state_root),
             "AGENTLOOM_MEMORY_CASE_ID": spec.case_id,
             "AGENTLOOM_MEMORY_CASE_PHASE": spec.phase,
             "AGENTLOOM_MEMORY_CAMPAIGN_SAFE_ARTIFACTS": "1",
             "PYTHONUNBUFFERED": "1",
         }
     )
-    command = [_loom(), "run", str(workflow_path), "--log-to-file"]
+    command = [_loom(), "run", str(workflow_path)]
     if capsule_is_active():
         if _ACTIVE_MODEL_CONFIG_BYTES is None:
             raise RuntimeError("capsule model configuration was not initialized")
@@ -1352,7 +1352,7 @@ def _run_attempt(
         "started_at": started_at,
         "finished_at": finished_at,
         "duration_seconds": elapsed,
-        "command": ["loom", "run", spec.workflow, "--log-to-file"],
+        "command": ["loom", "run", spec.workflow],
         "agent_root": spec.agent_root,
         "runtime_root": runtime_root.relative_to(execution_root).as_posix(),
         "state_root": state_root.relative_to(execution_root).as_posix(),
@@ -2183,7 +2183,7 @@ def main() -> int:
         "canary_count": min(5, len(specs)),
         "max_concurrency": args.max_workers,
         "infrastructure_retries": 1,
-        "cli_contract": "loom run <workflow> --log-to-file",
+        "cli_contract": "loom run <workflow>",
         "memory_cli_contract": ["list", "pending", "approve", "reject"],
         "dataset": dataset_manifest(),
         "scenario_quotas": dict(Counter(spec.scenario for spec in specs)),

--- a/applications/memory_feature_validation/scripts/test_memory_review_campaign_contract.py
+++ b/applications/memory_feature_validation/scripts/test_memory_review_campaign_contract.py
@@ -1417,7 +1417,7 @@ def test_plan_audit_rejects_dataset_manifest_substitution() -> None:
     plan = {
         "requested_runs": 5,
         "max_concurrency": 1,
-        "cli_contract": "loom run <workflow> --log-to-file",
+        "cli_contract": "loom run <workflow>",
         "memory_cli_contract": ["list", "pending", "approve", "reject"],
         "dataset": {"files": []},
         "runs": [spec.to_dict() for spec in specs],
@@ -1774,7 +1774,7 @@ def test_dry_run_artifacts_reaudit_without_model_calls(tmp_path: Path) -> None:
         "requested_runs": 5,
         "selected_runs": 5,
         "max_concurrency": 2,
-        "cli_contract": "loom run <workflow> --log-to-file",
+        "cli_contract": "loom run <workflow>",
         "memory_cli_contract": ["list", "pending", "approve", "reject"],
         "dataset": dataset_manifest(),
         "runs": [spec.to_dict() for spec in specs],
@@ -1795,10 +1795,12 @@ def test_dry_run_artifacts_reaudit_without_model_calls(tmp_path: Path) -> None:
 
 
 def test_campaign_scripts_do_not_import_self_learning_implementation() -> None:
+    removed_file_logging_flag = "--log" + "-to-file"
     for name in ("run_memory_review_campaign.py", "audit_memory_review_campaign.py"):
         source = (APP_ROOT / "scripts" / name).read_text(encoding="utf-8")
         assert "from src." not in source
         assert "import src." not in source
+        assert removed_file_logging_flag not in source
 
 
 def test_canary_continues_past_soft_semantic_misses_but_not_hard_failures() -> None:
@@ -2615,6 +2617,11 @@ def test_campaign_retries_once_for_typed_provider_tempfail(
         ),
     ]
     restores: list[Path] = []
+    commands: list[list[str]] = []
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        return outputs.pop(0)
 
     monkeypatch.setattr(campaign_runner, "capsule_is_active", lambda: False)
     monkeypatch.setattr(campaign_runner, "_loom", lambda: "loom")
@@ -2630,7 +2637,7 @@ def test_campaign_retries_once_for_typed_provider_tempfail(
     monkeypatch.setattr(
         campaign_runner.subprocess,
         "run",
-        lambda *_args, **_kwargs: outputs.pop(0),
+        run,
     )
     state_root = tmp_path / "state"
     state_root.mkdir()
@@ -2652,6 +2659,16 @@ def test_campaign_retries_once_for_typed_provider_tempfail(
     )
     assert len(restores) == 1
     assert outputs == []
+    expected_command = [
+        "loom",
+        "run",
+        str((REPO_ROOT / spec.workflow).resolve()),
+    ]
+    assert commands == [expected_command, expected_command]
+    assert [attempt["command"] for attempt in result["attempts"]] == [
+        ["loom", "run", spec.workflow],
+        ["loom", "run", spec.workflow],
+    ]
 
 
 def test_campaign_does_not_parse_model_logs_to_authorize_retry(

--- a/applications/repo_map/repo_map_app.py
+++ b/applications/repo_map/repo_map_app.py
@@ -156,7 +156,6 @@ def main(
     output_dir: str = None,
     skill_output_dir: str = None,
     exclude_dirs: list[str] = None,
-    log_to_file: bool = False,
     resume: str | None = None,
 ) -> None:
     """
@@ -179,7 +178,6 @@ def main(
         exclude_dirs: Directory names/paths to exclude (relative to project_path).
                       Can be specified multiple times:
                         --exclude_dirs vendor --exclude_dirs third_party
-        log_to_file:  Deprecated. Kept for CLI compatibility.
         resume:       Deprecated. Incremental progress is driven by
                       analysis_progress.json in output_dir.
 
@@ -217,8 +215,6 @@ def main(
     if excl:
         print(f"[repo_map] Exclude: {excl}")
 
-    if log_to_file:
-        print("[repo_map] Note: log_to_file is deprecated in direct orchestration mode.")
     if resume:
         print("[repo_map] Note: --resume is ignored; rerun uses analysis_progress.json.")
 

--- a/applications/test_demo/workflows/test_checkpoint_complex_supervisor.yaml
+++ b/applications/test_demo/workflows/test_checkpoint_complex_supervisor.yaml
@@ -20,6 +20,7 @@ workflow: |
   Use shell_tool once to run this exact command:
     rm -rf /tmp/agentloom_ckpt_complex &&
     mkdir -p /tmp/agentloom_ckpt_complex/items &&
+    printf 'supervisor_setup\n' >> /tmp/agentloom_ckpt_side_effects.log &&
     printf 'alpha=11\n' > /tmp/agentloom_ckpt_complex/items/a.txt &&
     printf 'beta=22\n' > /tmp/agentloom_ckpt_complex/items/b.txt &&
     printf 'gamma=33\n' > /tmp/agentloom_ckpt_complex/items/c.txt &&
@@ -42,6 +43,7 @@ workflow: |
     grep -q 'beta=22' /tmp/agentloom_ckpt_complex/worker_report.txt &&
     grep -q 'gamma=33' /tmp/agentloom_ckpt_complex/worker_report.txt &&
     grep -q 'manifest_status=ready' /tmp/agentloom_ckpt_complex/worker_report.txt &&
+    printf 'supervisor_finalize\n' >> /tmp/agentloom_ckpt_side_effects.log &&
     printf 'checkpoint_complex=complete\nalpha=11\nbeta=22\ngamma=33\nworker_status=complete\n' > /tmp/agentloom_ckpt_complex/final_manifest.txt &&
     printf 'supervisor:complete\n' >> /tmp/agentloom_ckpt_complex/ledger.txt &&
     test -s /tmp/agentloom_ckpt_complex/final_manifest.txt

--- a/applications/test_demo/workflows/test_file_rewind_agent.yaml
+++ b/applications/test_demo/workflows/test_file_rewind_agent.yaml
@@ -12,7 +12,8 @@ description: |
   - Step 3: Edit original.txt again (second modification)
   - Step 4: Verify the file contains the third version of content
   - Step 5: Report that all edits completed — the test harness will
-            verify that file-history backups exist in .logs/
+            verify that file-history backups exist under
+            .agentloom/checkpoints/test_demo/<task_id>/file-history/
 
 model_type: "powerful"
 tool_call_type: "code_act"

--- a/applications/test_demo/workflows/worker_agents/test_checkpoint_complex_worker.yaml
+++ b/applications/test_demo/workflows/worker_agents/test_checkpoint_complex_worker.yaml
@@ -14,11 +14,14 @@ workflow: |
 
   1. Use shell_tool once to run:
        mkdir -p /tmp/agentloom_ckpt_complex/worker_progress &&
+       printf 'worker_step_1\n' >> /tmp/agentloom_ckpt_side_effects.log &&
        printf 'worker:started\n' > /tmp/agentloom_ckpt_complex/worker_progress/started.txt &&
        cat /tmp/agentloom_ckpt_complex/items/a.txt /tmp/agentloom_ckpt_complex/items/b.txt /tmp/agentloom_ckpt_complex/items/c.txt /tmp/agentloom_ckpt_complex/supervisor_manifest.txt > /tmp/agentloom_ckpt_complex/worker_progress/combined.txt
   2. Use shell_tool once to run:
+       printf 'worker_step_2\n' >> /tmp/agentloom_ckpt_side_effects.log &&
        printf 'worker_status=complete\nalpha=11\nbeta=22\ngamma=33\nmanifest_status=ready\n' > /tmp/agentloom_ckpt_complex/worker_report.txt
   3. Use shell_tool once to run:
+       printf 'worker_step_3\n' >> /tmp/agentloom_ckpt_side_effects.log &&
        grep -q 'worker_status=complete' /tmp/agentloom_ckpt_complex/worker_report.txt &&
        grep -q 'alpha=11' /tmp/agentloom_ckpt_complex/worker_report.txt &&
        grep -q 'beta=22' /tmp/agentloom_ckpt_complex/worker_report.txt &&

--- a/applications/test_shell_allowlist_matrix/workflows/test_shell_allowlist_matrix_agent.yaml
+++ b/applications/test_shell_allowlist_matrix/workflows/test_shell_allowlist_matrix_agent.yaml
@@ -6,7 +6,6 @@ tool_call_type: "code_act"
 
 tools:
   - name: "shell_tool"
-  - name: "read_file"
 
 shell_settings:
   allowed_commands:
@@ -27,10 +26,11 @@ workflow: |
   cat, echo, grep, ls, printf, pwd, wc. It allows only the "|" and "&&"
   operators.
 
-  The test only passes if the real shell outputs and real shell_audit.log
+  The test only passes if the real shell outputs and current run's audit/shell.jsonl
   contain the expected evidence. Do not mark PASS from expectation alone.
 
   ```python
+  import json
   import os
 
   rows = {}
@@ -72,67 +72,88 @@ workflow: |
 
   # Use ls only (no head) so the audit lookup obeys this workflow's allow-list.
   ls_output = shell_tool(
-      command="ls -dt .logs/test_shell_allowlist_matrix/*/shell_audit.log",
+      command="ls -dt .agentloom/runs/test_shell_allowlist_matrix/run_*/audit/shell.jsonl",
       timeout=10,
   )
   audit_path = ls_output.strip().splitlines()[0]
-  audit_content = read_file(file_path=audit_path)
+  audit_content = shell_tool(command=f"cat {audit_path}", timeout=10)
+  audit_events = []
+  for line in audit_content.splitlines():
+      try:
+          event = json.loads(line)
+      except json.JSONDecodeError:
+          continue
+      if isinstance(event, dict):
+          audit_events.append(event)
   print("AUDIT_PATH", audit_path)
   print(audit_content)
 
-  agent_ls_output = shell_tool(
-      command="ls -dt .logs/test_shell_allowlist_matrix/*/test_shell_allowlist_matrix.log",
-      timeout=10,
-  )
-  agent_log_path = agent_ls_output.strip().splitlines()[0]
-  same_parent = os.path.dirname(audit_path) == os.path.dirname(agent_log_path)
+  audit_run_dir = os.path.dirname(os.path.dirname(audit_path))
+  agent_log_path = os.path.join(audit_run_dir, "logs", "runtime.log")
+  same_parent = os.path.isfile(agent_log_path)
   record(
       "CO_LOCATION",
       "PASS" if same_parent else "FAIL",
       f"audit={audit_path}; agent={agent_log_path}",
   )
 
-  audit_checks = {
-      "POLICY_SNAPSHOT": [
-          "[POLICY_SNAPSHOT]",
-          "allowed_commands: cat, echo, grep, ls, printf, pwd, wc",
-          "allowed_operators: |, &&",
-          "command_success_logging: false",
-      ],
-      "AUDIT_DATE": ["[WHITELIST_REJECT]", "command: date", "allowed_commands"],
-      "AUDIT_WHOAMI": ["[WHITELIST_REJECT]", "command: whoami", "allowed_commands"],
-      "AUDIT_UNAME": ["[WHITELIST_REJECT]", "command: uname -a", "allowed_commands"],
-      "AUDIT_SEMICOLON": [
-          "[WHITELIST_REJECT]",
-          "command: echo first ; echo second",
-          "allowed_operators",
-      ],
-      "NO_OPERATOR_COMMAND_SUGGESTION": [],
-      "NO_SUCCESS_SPAM": [],
-  }
+  policy_event = next(
+      (event for event in audit_events if event.get("event_type") == "POLICY_SNAPSHOT"),
+      None,
+  )
+  policy_details = policy_event.get("details", {}) if policy_event else {}
+  policy_ok = (
+      policy_details.get("allowed_commands") == "cat, echo, grep, ls, printf, pwd, wc"
+      and policy_details.get("allowed_operators") == "|, &&"
+      and policy_details.get("command_success_logging") == "false"
+  )
+  record(
+      "POLICY_SNAPSHOT",
+      "PASS" if policy_ok else "FAIL",
+      json.dumps(policy_event, ensure_ascii=False) if policy_event else "missing event",
+  )
 
-  for name, required in audit_checks.items():
-      if name == "NO_OPERATOR_COMMAND_SUGGESTION":
-          forbidden = 'allowed_commands: [";", ...]'
-          record(
-              name,
-              "PASS" if forbidden not in audit_content else "FAIL",
-              f"{forbidden} absent",
-          )
-          continue
-      if name == "NO_SUCCESS_SPAM":
-          record(
-              name,
-              "PASS" if "[COMMAND_SUCCESS]" not in audit_content else "FAIL",
-              "COMMAND_SUCCESS absent because log_success=false",
-          )
-          continue
-      missing = [item for item in required if item not in audit_content]
+  def rejection(command):
+      return next(
+          (
+              event
+              for event in audit_events
+              if event.get("event_type") == "WHITELIST_REJECT"
+              and event.get("command") == command
+          ),
+          None,
+      )
+
+  for name, command, suggestion_key in [
+      ("AUDIT_DATE", "date", "allowed_commands"),
+      ("AUDIT_WHOAMI", "whoami", "allowed_commands"),
+      ("AUDIT_UNAME", "uname -a", "allowed_commands"),
+      ("AUDIT_SEMICOLON", "echo first ; echo second", "allowed_operators"),
+  ]:
+      event = rejection(command)
+      suggestion = str((event or {}).get("suggestion", ""))
       record(
           name,
-          "PASS" if not missing else "FAIL",
-          "missing=" + ", ".join(missing) if missing else "all required fields present",
+          "PASS" if event and suggestion_key in suggestion else "FAIL",
+          json.dumps(event, ensure_ascii=False) if event else "missing event",
       )
+
+  semicolon_event = rejection("echo first ; echo second")
+  semicolon_suggestion = str((semicolon_event or {}).get("suggestion", ""))
+  record(
+      "NO_OPERATOR_COMMAND_SUGGESTION",
+      "PASS"
+      if semicolon_event and "allowed_commands" not in semicolon_suggestion
+      else "FAIL",
+      semicolon_suggestion or "missing event",
+  )
+  record(
+      "NO_SUCCESS_SPAM",
+      "PASS"
+      if not any(event.get("event_type") == "COMMAND_SUCCESS" for event in audit_events)
+      else "FAIL",
+      "COMMAND_SUCCESS absent because log_success=false",
+  )
 
   ordered = [
       "ALLOW_ECHO",
@@ -156,8 +177,8 @@ workflow: |
 
   summary_lines = [
       f"Overall: {overall}",
-      f"shell_audit.log: {audit_path}",
-      f"agent log: {agent_log_path}",
+      f"shell.jsonl: {audit_path}",
+      f"runtime.log: {agent_log_path}",
       f"allowed commands evidence: {allowed_commands_text}",
       f"allowed operators evidence: {allowed_operators_text}",
       "",

--- a/applications/test_shell_audit/workflows/test_shell_audit_log_agent.yaml
+++ b/applications/test_shell_audit/workflows/test_shell_audit_log_agent.yaml
@@ -1,5 +1,5 @@
 name: "test_shell_audit_log"
-description: "Validate shell security audit log — verify that blocked commands produce audit entries in .logs/{agent_name}/{timestamp}/shell_audit.log"
+description: "Validate shell security audit log — verify that blocked commands produce JSONL events in the current .agentloom run"
 
 model_type: "powerful"
 tool_call_type: "code_act"
@@ -7,7 +7,6 @@ tool_call_type: "code_act"
 # Tools list declares which tools this agent uses.
 tools:
   - name: "shell_tool"
-  - name: "read_file"
   - name: "glob_search"
   - name: "grep_search"
 
@@ -21,10 +20,11 @@ workflow: |
 
   You are a testing agent. Execute the harness below in one Python code block.
   Do not replace the shell commands with alternatives. The harness catches
-  expected blocked shell_tool calls, reads the real shell_audit.log, and only
+  expected blocked shell_tool calls, reads the real audit/shell.jsonl, and only
   marks rows PASS when the audit file contains the expected evidence.
 
   ```python
+  import json
   import os
 
   rows = {}
@@ -53,69 +53,71 @@ workflow: |
   expect_block("OPERATOR_REJECT", "echo hello ; echo world", "Operator not allowed: ;")
 
   audit_path = shell_tool(
-      command="ls -dt .logs/test_shell_audit_log/*/shell_audit.log | head -1",
+      command="ls -dt .agentloom/runs/test_shell_audit/run_*/audit/shell.jsonl | head -1",
       timeout=10,
   ).strip().splitlines()[0]
-  audit_content = read_file(file_path=audit_path)
+  audit_content = shell_tool(command=f"cat {audit_path}", timeout=10)
+  audit_events = []
+  for line in audit_content.splitlines():
+      try:
+          event = json.loads(line)
+      except json.JSONDecodeError:
+          continue
+      if isinstance(event, dict):
+          audit_events.append(event)
   print("AUDIT_PATH", audit_path)
   print(audit_content)
 
-  agent_log_path = shell_tool(
-      command="ls -dt .logs/test_shell_audit_log/*/test_shell_audit_log.log | head -1",
-      timeout=10,
-  ).strip().splitlines()[0]
-  same_parent = os.path.dirname(audit_path) == os.path.dirname(agent_log_path)
+  audit_run_dir = os.path.dirname(os.path.dirname(audit_path))
+  agent_log_path = os.path.join(audit_run_dir, "logs", "runtime.log")
+  same_parent = os.path.isfile(agent_log_path)
   record(
       "CO_LOCATION",
       "PASS" if same_parent else "FAIL",
       f"audit={audit_path}; agent={agent_log_path}",
   )
 
-  def find_block(command_substr):
-      lines = audit_content.splitlines()
-      for index, line in enumerate(lines):
-          if "[WHITELIST_REJECT]" not in line:
-              continue
-          end = len(lines)
-          for next_index in range(index + 1, len(lines)):
-              if "[WHITELIST_REJECT]" in lines[next_index] and "agent=test_shell_audit_log" in lines[next_index]:
-                  end = next_index
-                  break
-          block = lines[index:end]
-          text = "\n".join(block)
-          if command_substr in text:
-              return index + 1, block, text
-      return 0, [], ""
+  def find_event(command_substr):
+      for event in audit_events:
+          if (
+              event.get("event_type") == "WHITELIST_REJECT"
+              and command_substr in str(event.get("command", ""))
+          ):
+              return event
+      return None
 
-  wget_line, wget_block, wget_text = find_block("wget http://example.com")
-  operator_line, operator_block, operator_text = find_block("echo hello ; echo world")
+  wget_event = find_event("wget http://example.com")
+  operator_event = find_event("echo hello ; echo world")
 
-  wget_required = [
-      "message: Command not allowed: wget.",
-      "Allowed commands: cat, echo, find, grep, head, ls, pwd, tail, wc",
-      "allowed_commands",
-  ]
-  operator_required = [
-      "message: Operator not allowed: ;.",
-      "Allowed operators: &&, |",
-      "allowed_operators",
-  ]
+  wget_message = str((wget_event or {}).get("message", ""))
+  wget_suggestion = str((wget_event or {}).get("suggestion", ""))
+  operator_message = str((operator_event or {}).get("message", ""))
+  operator_suggestion = str((operator_event or {}).get("suggestion", ""))
 
   record(
       "WGET_AUDIT_ENTRY",
-      "PASS" if wget_text and all(item in wget_text for item in wget_required) else "FAIL",
-      f"line={wget_line}; " + " | ".join(wget_block[:8]),
+      "PASS"
+      if (
+          wget_event
+          and "Command not allowed: wget." in wget_message
+          and "Allowed commands: cat, echo, find, grep, head, ls, pwd, tail, wc" in wget_message
+          and "allowed_commands" in wget_suggestion
+      )
+      else "FAIL",
+      json.dumps(wget_event, ensure_ascii=False) if wget_event else "missing event",
   )
   record(
       "OPERATOR_AUDIT_ENTRY",
       "PASS"
       if (
-          operator_text
-          and all(item in operator_text for item in operator_required)
-          and 'allowed_commands: [";", ...]' not in operator_text
+          operator_event
+          and "Operator not allowed: ;." in operator_message
+          and "Allowed operators: &&, |" in operator_message
+          and "allowed_operators" in operator_suggestion
+          and "allowed_commands" not in operator_suggestion
       )
       else "FAIL",
-      f"line={operator_line}; " + " | ".join(operator_block[:8]),
+      json.dumps(operator_event, ensure_ascii=False) if operator_event else "missing event",
   )
 
   ordered = [
@@ -129,8 +131,8 @@ workflow: |
   overall = "PASS" if all(rows.get(name) == "PASS" for name in ordered) else "FAIL"
   summary_lines = [
       f"Overall: {overall}",
-      f"shell_audit.log: {audit_path}",
-      f"agent log: {agent_log_path}",
+      f"shell.jsonl: {audit_path}",
+      f"runtime.log: {agent_log_path}",
       "",
       "| Step | Status | Evidence |",
       "|---|---|---|",

--- a/applications/test_shell_audit/workflows/test_shell_audit_signals_agent.yaml
+++ b/applications/test_shell_audit/workflows/test_shell_audit_signals_agent.yaml
@@ -6,7 +6,6 @@ tool_call_type: "code_act"
 
 tools:
   - name: "shell_tool"
-  - name: "read_file"
   - name: "check_background_task"
   - name: "kill_background_task"
   - name: "list_background_tasks"
@@ -35,11 +34,12 @@ workflow: |
 
   You are a testing agent. Execute the harness below in one Python code block.
   The harness intentionally catches blocked shell_tool calls, reads the real
-  shell_audit.log, and only marks rows PASS when the audit file contains the
+  audit/shell.jsonl, and only marks rows PASS when the audit file contains the
   expected evidence. After the harness returns, use its printed summary as your
   final answer. Do not invent PASS rows.
 
   ```python
+  import json
   import os
   import re
 
@@ -114,18 +114,24 @@ workflow: |
       sandbox_reasons.append(f"sandbox inspection failed: {exc}")
 
   audit_path = shell_tool(
-      command="ls -dt .logs/test_shell_audit_signals/*/shell_audit.log | head -1",
+      command="ls -dt .agentloom/runs/test_shell_audit/run_*/audit/shell.jsonl | head -1",
       timeout=10,
   ).strip().splitlines()[0]
-  audit_content = read_file(file_path=audit_path)
+  audit_content = shell_tool(command=f"cat {audit_path}", timeout=10)
+  audit_events = []
+  for line in audit_content.splitlines():
+      try:
+          event = json.loads(line)
+      except json.JSONDecodeError:
+          continue
+      if isinstance(event, dict):
+          audit_events.append(event)
   print("AUDIT_PATH", audit_path)
   print(audit_content)
 
-  agent_log_path = shell_tool(
-      command="ls -dt .logs/test_shell_audit_signals/*/test_shell_audit_signals.log | head -1",
-      timeout=10,
-  ).strip().splitlines()[0]
-  same_parent = os.path.dirname(audit_path) == os.path.dirname(agent_log_path)
+  audit_run_dir = os.path.dirname(os.path.dirname(audit_path))
+  agent_log_path = os.path.join(audit_run_dir, "logs", "runtime.log")
+  same_parent = os.path.isfile(agent_log_path)
   record(
       "CO_LOCATION",
       "PASS" if same_parent else "FAIL",
@@ -146,27 +152,20 @@ workflow: |
   def find_evidence(event, command_substr, required=None, forbidden=None):
       required = required or []
       forbidden = forbidden or []
-      lines = audit_content.splitlines()
-      for index, line in enumerate(lines):
-          if f"[{event}]" not in line:
+      for index, candidate in enumerate(audit_events):
+          if candidate.get("event_type") != event:
               continue
-          end = len(lines)
-          for next_index in range(index + 1, len(lines)):
-              if f"agent=test_shell_audit_signals" in lines[next_index] and "] [" in lines[next_index]:
-                  end = next_index
-                  break
-          block = lines[index:end]
-          text = "\n".join(block)
+          text = json.dumps(candidate, ensure_ascii=False, sort_keys=True)
           if command_substr not in text:
               continue
           if all(item in text for item in required) and not any(item in text for item in forbidden):
-              return "PASS", f"lines {index + 1}-{index + len(block)}: " + " | ".join(block[:8])
-          return "FAIL", f"lines {index + 1}-{index + len(block)} missing required/forbidden check: " + text
-      return "FAIL", f"No [{event}] block for {command_substr}"
+              return "PASS", f"event {index + 1}: {text}"
+          return "FAIL", f"event {index + 1} missing required/forbidden check: {text}"
+      return "FAIL", f"No {event} event for {command_substr}"
 
   for name, event, command_substr, required, forbidden in [
       ("WHITELIST_COMMAND", "WHITELIST_REJECT", "wget http://example.com", ["allowed_commands"], []),
-      ("WHITELIST_OPERATOR", "WHITELIST_REJECT", "echo hello ; echo world", ["allowed_operators"], ['allowed_commands: [";", ...]']),
+      ("WHITELIST_OPERATOR", "WHITELIST_REJECT", "echo hello ; echo world", ["allowed_operators"], ["allowed_commands"]),
       ("PATH_VIOLATION", "PATH_VIOLATION", "cat /etc/passwd", ["path_validation", "include_paths"], []),
       ("SECURITY_BLOCK", "SECURITY_BLOCK", "echo $(whoami)", ["command_substitution", "command_substitution: false"], []),
       ("BACKGROUND_PROMOTION", "BACKGROUND_PROMOTION", "audit_bg_started", ["timeout_seconds", "task_id"], []),
@@ -175,7 +174,7 @@ workflow: |
       status, evidence = find_evidence(event, command_substr, required, forbidden)
       record(name, status, evidence)
 
-  if "[SANDBOX_WRAP]" in audit_content:
+  if any(event.get("event_type") == "SANDBOX_WRAP" for event in audit_events):
       status, evidence = find_evidence("SANDBOX_WRAP", "", [], [])
       record("SANDBOX_WRAP", status, evidence)
   else:
@@ -198,8 +197,8 @@ workflow: |
 
   summary_lines = [
       f"Overall: {overall}",
-      f"shell_audit.log: {audit_path}",
-      f"agent log: {agent_log_path}",
+      f"shell.jsonl: {audit_path}",
+      f"runtime.log: {agent_log_path}",
       "",
       "| Signal | Status | Evidence |",
       "|---|---|---|",

--- a/applications/test_shell_audit/workflows/test_shell_policy_snapshot_agent.yaml
+++ b/applications/test_shell_audit/workflows/test_shell_policy_snapshot_agent.yaml
@@ -6,7 +6,6 @@ tool_call_type: "code_act"
 
 tools:
   - name: "shell_tool"
-  - name: "read_file"
 
 workflow: |
   # Shell Policy Snapshot Audit Validation
@@ -16,10 +15,11 @@ workflow: |
   `allowed_commands` and `allowed_operators` are both `"*"`.
 
   The test only passes if a successful, fully allowed shell run still creates a
-  real `shell_audit.log` containing a `POLICY_SNAPSHOT` entry. Do not mark PASS
+  real `audit/shell.jsonl` containing a `POLICY_SNAPSHOT` event. Do not mark PASS
   from expectation alone.
 
   ```python
+  import json
   import os
 
   rows = {}
@@ -44,32 +44,47 @@ workflow: |
   )
 
   audit_path = shell_tool(
-      command="ls -dt .logs/test_shell_policy_snapshot/*/shell_audit.log | head -1",
+      command="ls -dt .agentloom/runs/test_shell_audit/run_*/audit/shell.jsonl | head -1",
       timeout=10,
   ).strip().splitlines()[0]
-  audit_content = read_file(file_path=audit_path)
+  audit_content = shell_tool(command=f"cat {audit_path}", timeout=10)
+  audit_events = []
+  for line in audit_content.splitlines():
+      try:
+          event = json.loads(line)
+      except json.JSONDecodeError:
+          continue
+      if isinstance(event, dict):
+          audit_events.append(event)
   print("AUDIT_PATH", audit_path)
   print(audit_content)
 
-  agent_log_path = shell_tool(
-      command="ls -dt .logs/test_shell_policy_snapshot/*/test_shell_policy_snapshot.log | head -1",
-      timeout=10,
-  ).strip().splitlines()[0]
-  same_parent = os.path.dirname(audit_path) == os.path.dirname(agent_log_path)
+  audit_run_dir = os.path.dirname(os.path.dirname(audit_path))
+  agent_log_path = os.path.join(audit_run_dir, "logs", "runtime.log")
+  same_parent = os.path.isfile(agent_log_path)
   record(
       "CO_LOCATION",
       "PASS" if same_parent else "FAIL",
       f"audit={audit_path}; agent={agent_log_path}",
   )
 
-  required = [
-      "[POLICY_SNAPSHOT]",
-      "allowed_commands: * (all command names allowed)",
-      "allowed_operators: * (all shell operators allowed)",
-      "command_success_logging: false",
-      "sandbox_enabled:",
+  policy_event = next(
+      (event for event in audit_events if event.get("event_type") == "POLICY_SNAPSHOT"),
+      None,
+  )
+  details = policy_event.get("details", {}) if policy_event else {}
+  required = {
+      "allowed_commands": "* (all command names allowed)",
+      "allowed_operators": "* (all shell operators allowed)",
+      "command_success_logging": "false",
+  }
+  missing = [
+      f"{key}={value}"
+      for key, value in required.items()
+      if details.get(key) != value
   ]
-  missing = [item for item in required if item not in audit_content]
+  if "sandbox_enabled" not in details:
+      missing.append("sandbox_enabled")
   record(
       "POLICY_SNAPSHOT",
       "PASS" if not missing else "FAIL",
@@ -78,7 +93,9 @@ workflow: |
 
   record(
       "NO_SUCCESS_SPAM",
-      "PASS" if "[COMMAND_SUCCESS]" not in audit_content else "FAIL",
+      "PASS"
+      if not any(event.get("event_type") == "COMMAND_SUCCESS" for event in audit_events)
+      else "FAIL",
       "COMMAND_SUCCESS absent because log_success=false",
   )
 
@@ -93,8 +110,8 @@ workflow: |
 
   summary_lines = [
       f"Overall: {overall}",
-      f"shell_audit.log: {audit_path}",
-      f"agent log: {agent_log_path}",
+      f"shell.jsonl: {audit_path}",
+      f"runtime.log: {agent_log_path}",
       "",
       "| Check | Status | Evidence |",
       "|---|---|---|",

--- a/applications/test_shell_output_stress/workflows/test_shell_large_output_agent.yaml
+++ b/applications/test_shell_output_stress/workflows/test_shell_large_output_agent.yaml
@@ -33,7 +33,8 @@ workflow: |
     - HAS_LATE_12000=True.
     - HAS_BYTES_OMITTED=True.
     - HAS_SYSTEM_NOTICE=True.
-    - ARTIFACT_PATH is a real path under .logs/shell_outputs.
+    - ARTIFACT_PATH is a real path under
+      .agentloom/runs/test_shell_output_stress/<run_id>/artifacts/shell/.
   Verify: extract the saved full-output file path from the response.
 
   ## Step 2: Inspect the saved full-output artifact

--- a/applications/web_search/scripts/run_us_after_close_validation_batch.py
+++ b/applications/web_search/scripts/run_us_after_close_validation_batch.py
@@ -104,7 +104,7 @@ def _run_one(now_utc: str, timeout_seconds: int, skip_existing_ok: bool) -> dict
 
     code = (
         "from src.runner import run_app\n"
-        f"print(run_app({WORKFLOW!r}, task_override={TASK!r}, log_to_file=True))\n"
+        f"print(run_app({WORKFLOW!r}, task_override={TASK!r}, file_logging=True))\n"
     )
     started_at = datetime.now().astimezone().isoformat()
     timed_out = False

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -100,11 +100,19 @@ code_agent:
   # Additional built-in functions allowed during Python code execution; "*" means all callable builtins are allowed
   additional_functions: "*"
 
+runtime:
+  root_dir: ".agentloom"
+  successful_run_retention_days: 7
+  failed_run_retention_days: 30
+  artifact_retention_days: 3
+  cleanup_interval_hours: 24
+
 logging:
-  enabled: true
   level: "INFO"
-  file_path: null
-  dir: ".logs"
+  console_enabled: true
+  file_enabled: true
+  max_file_bytes: 26214400  # 25 MiB per segment
+  backup_count: 3
 
 # ============================================
 # Tool Access Control
@@ -187,7 +195,6 @@ checkpoint:
 # ============================================
 self_learning:
   enabled: true
-  root_dir: ".agentloom"
   # Runs/events are history only. They remain searchable but are never promoted
   # to memory by a deterministic fallback.
   events_retention_days: 90
@@ -376,9 +383,7 @@ shell_settings:
 
   # Per-agent shell security audit log.
   # Writes structured events (blocks, stalls, timeouts, path violations)
-  # to .logs/{agent_name}/{timestamp}/shell_audit.log (co-located with
-  # the agent run log) so users can quickly diagnose shell permissions.
-  # Log directory is controlled by the top-level logging.dir setting.
+  # to the active run's audit/shell.jsonl (10 MiB, 2 backups).
   audit_log:
     enabled: true           # Master switch (default: true)
     log_policy_snapshot: true  # Log effective shell policy once per run

--- a/docs/assets/agentloom-runtime-architecture.svg
+++ b/docs/assets/agentloom-runtime-architecture.svg
@@ -1,6 +1,6 @@
 <svg width="1200" height="640" viewBox="0 0 1200 640" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">AgentLoom runtime architecture</title>
-  <desc id="desc">A layered architecture diagram showing Codex and the framework skill creating YAML application specs, AgentLoom running a Supervisor and Worker Agents, shared capabilities, and runtime state.</desc>
+  <desc id="desc">A layered architecture diagram showing Codex and the framework skill creating YAML application specs, AgentLoom running a Supervisor and Worker Agents, and runtime state separated into run evidence and task checkpoints.</desc>
   <defs>
     <linearGradient id="bg" x1="90" y1="36" x2="1104" y2="610" gradientUnits="userSpaceOnUse">
       <stop stop-color="#06172A"/>
@@ -76,10 +76,10 @@
 
   <g filter="url(#softShadow)">
     <rect x="864" y="132" width="260" height="132" rx="24" fill="#F8FAFC" stroke="#C7DDEC"/>
-    <text x="896" y="170" class="text label">Run State</text>
-    <text x="896" y="200" class="text small">terminal output</text>
-    <text x="896" y="226" class="text small">.logs archive</text>
-    <text x="896" y="252" class="text small">checkpoints + UI</text>
+    <text x="896" y="170" class="text label">Runtime State</text>
+    <text x="896" y="200" class="text small">manifest + logs</text>
+    <text x="896" y="226" class="text small">audit + artifacts</text>
+    <text x="896" y="252" class="text small">task checkpoints</text>
   </g>
 
   <g filter="url(#shadow)">
@@ -126,7 +126,7 @@
   </g>
   <g filter="url(#softShadow)">
     <rect x="836" y="526" width="272" height="58" rx="19" fill="#F8FAFC" stroke="#C7DDEC"/>
-    <text x="972" y="562" text-anchor="middle" class="text label">Logs / Checkpoints</text>
+    <text x="972" y="562" text-anchor="middle" class="text label">Runs / Checkpoints</text>
   </g>
 
 </svg>

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -45,14 +45,16 @@ uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yam
 第一次运行后，你应该能看到：
 
 - 带 Agent 名称、Task ID、Step 耗时和 Token 统计的结构化终端日志；
-- `.logs/<agent>/<timestamp>/` 下归档的运行文件；
-- 开启 checkpoint 后可恢复的任务状态；
+- `.agentloom/runs/<application_id>/<run_id>/` 下本次执行 attempt 的 manifest、有界 runtime log、Shell audit 和原始 artifacts；
+- 开启 checkpoint 后位于 `.agentloom/checkpoints/<application_id>/<task_id>/` 的可恢复任务状态；
 - 可通过 `uv run loom ui` 打开的 Web 可视化面板；
 - 可通过 `uv run loom dashboard` 打开的终端任务监控面板。
 
+`run_id` 标识一次执行 attempt，resume 时会改变；`task_id` 标识同一个逻辑任务，resume 时保持不变。因此 resume 会写入新的 run 目录，同时继续使用原 checkpoint。Agent 可见的 `.runtime/` 工作区与框架 runtime 存储刻意保持独立。
+
 ## 以 Codex 为例快速创建多 Agent 应用
 
-最快的方式是让 Codex 使用仓库自带的 framework skill。Codex 不只是生成 YAML：它也可以直接运行 AgentLoom 应用，观察终端输出和 `.logs/`，查看 checkpoint 状态，并在 Worker 卡住或配置出错时继续修改应用。
+最快的方式是让 Codex 使用仓库自带的 framework skill。Codex 不只是生成 YAML：它也可以直接运行 AgentLoom 应用，检查 `.agentloom/` 下的 run 与 checkpoint 证据，并在 Worker 卡住或配置出错时继续修改应用。
 
 可以这样对 Codex 说：
 
@@ -83,7 +85,12 @@ uv run loom run applications/<app_name>/workflows/<app_name>_agent.yaml
 ```bash
 uv run loom list-tasks
 uv run loom dashboard
-ls .logs/
+
+manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
+run_dir=$(dirname "$manifest")
+sed -n '1,160p' "$manifest"
+tail -n 80 "$run_dir/logs/runtime.log"
+tail -n 80 "$run_dir/audit/shell.jsonl"
 ```
 
 如果你更习惯 Claude Code，也可以用同样的思路：先读 `agentloom-framework-skill/SKILL.md`，在 `applications/<app_name>/` 下创建应用，运行它，并总结成功和失败的地方。
@@ -111,7 +118,7 @@ ls .logs/
 | 复用编程助手知识 | 加载 Claude-style `SKILL.md` 包，支持按需加载或全文预加载。 |
 | 接入外部工具 | 注册本地 Python 工具、本地 `codex exec`，并通过 `mcp_servers` 接入 MCP servers。 |
 | 处理重复性工作 | 用 Worker `concurrency` 和 `tool.batch(tasks)` 并发处理独立输入。 |
-| 理解长任务状态 | 使用结构化日志、`.logs/` 归档、checkpoint、`loom ui` 和 `loom dashboard`。 |
+| 理解长任务状态 | 读取 run manifest、有界 runtime log、Shell audit、task checkpoint，并使用 `loom ui` 和 `loom dashboard`。 |
 
 ## 架构
 
@@ -135,7 +142,7 @@ ls .logs/
 | Agent-as-Tool 协作 | Worker 通过 `agent_function_schema` 导出为可调用工具，包含必填输入校验和字符串输出。 |
 | Skills、MCP 与工具 | Agent 可加载 `SKILL.md` 包、本地 Python 函数、内置文件/Shell/搜索/Git 工具、本地 Codex 工具，并通过 `mcp_servers` 接入 MCP Client 工具。 |
 | 并发重复任务 | Worker `concurrency: auto` 或固定并发配合 `.batch(tasks)` 处理大量独立输入。 |
-| 状态与可观测性 | Rich 终端日志、纯文本文件日志、每步耗时、Token 统计、`.logs/` 归档、checkpoint resume、Web UI 和 TUI dashboard。 |
+| 状态与可观测性 | Rich 终端日志、有界的 per-run 文件日志、每步耗时、Token 统计、run manifest、checkpoint resume、Web UI 和 TUI dashboard。 |
 
 ## 示例应用
 
@@ -208,6 +215,9 @@ AgentLoom 内置 `src.tools.codex.codex_tool.codex`，用于把本机 `codex exe
 | `uv run loom dashboard` | 打开终端任务监控面板。 |
 | `uv run loom list-tasks` | 列出可恢复的 checkpoint 任务。 |
 | `uv run loom clean-tasks` | 清理旧 checkpoint 数据。 |
+| `uv run loom clean-runtime` | 按配置的 retention 清理已结束 run 与 raw artifacts。 |
+| `uv run loom migrate-runtime --dry-run` | 只预览有效的旧 checkpoint 候选，不改磁盘状态。 |
+| `uv run loom migrate-runtime --apply` | 迁移有效 checkpoint，并归档整个旧 `.logs`。 |
 
 ## 文档
 

--- a/docs/cn/agent_config.md
+++ b/docs/cn/agent_config.md
@@ -1655,7 +1655,9 @@ workflow: |
 
 每个 Agent 执行 Shell 命令时，安全相关事件（拦截、路径违规、停滞检测、超时等）会自动写入独立的审计日志文件：
 
-**文件位置**：`.logs/{agent_name}/{timestamp}/shell_audit.log`（与 Agent 运行日志同目录）
+**文件位置**：`.agentloom/runs/<application_id>/<run_id>/audit/shell.jsonl`
+
+同一 attempt 的 manifest 和主日志分别是 `manifest.json` 与 `logs/runtime.log`。Audit 每段 10 MiB、保留 2 个备份；即使本次运行使用 `--no-file-log`，Shell audit 仍会写入。
 
 配置项（在 `config/system.yaml` 或 agent YAML 的 `shell_settings` 中）：
 
@@ -1666,31 +1668,26 @@ shell_settings:
     log_success: false    # 是否记录成功执行的命令（默认 false）
 ```
 
-每条审计记录包含时间戳、事件类型、Agent 名称、命令、详情，以及**可操作的修复建议**——直接告诉你该改哪个 YAML 配置项：
+每一行都是一个 JSON 对象，包含时间戳、事件类型、Agent 名称、命令、详情，以及**可操作的修复建议**：
 
-```
-[2026-04-08 13:41:46] [SECURITY_BLOCK] agent=code_reviewer
-  command: $(cat /etc/passwd)
-  check: command_substitution
-  message: Blocked: $() command substitution detected
-  suggestion: To disable this check for a specific agent, add the following
-    to the agent YAML:
-      shell_settings:
-        security_checks:
-          command_substitution: false
+```json
+{"timestamp":"2026-04-08T13:41:46+00:00","event_type":"SECURITY_BLOCK","agent":"code_reviewer","command":"$(cat /etc/passwd)","check_id":"command_substitution","message":"Blocked: $() command substitution detected","suggestion":"Review shell_settings.security_checks.command_substitution"}
 ```
 
 排查 Shell 权限问题时，先查看审计日志文件比翻阅主日志效率高得多：
 
 ```bash
-# 查找所有审计日志
-find .logs/ -name 'shell_audit.log' | sort
+# 查找所有 run manifest 与审计日志
+find .agentloom/runs -name manifest.json -o -name shell.jsonl
 
-# 查看某个 Agent 最新一次运行的审计日志
-ls -td .logs/my_agent/*/ | head -1 | xargs -I{} cat {}/shell_audit.log
+# 读取最新 attempt 的身份与审计
+manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
+run_dir=$(dirname "$manifest")
+sed -n '1,160p' "$manifest"
+tail -n 100 "$run_dir/audit/shell.jsonl"
 
 # 按事件类型搜索
-grep -r 'SECURITY_BLOCK\|WHITELIST_REJECT\|PATH_VIOLATION' .logs/my_agent/
+rg 'SECURITY_BLOCK|WHITELIST_REJECT|PATH_VIOLATION' "$run_dir/audit/shell.jsonl"
 ```
 
 ---

--- a/docs/cn/checkpoint.md
+++ b/docs/cn/checkpoint.md
@@ -1,158 +1,203 @@
-# 断点续跑与会话恢复
+# 断点续跑与运行时存储
 
 ## 概述
 
-AgentLoom 支持多 Agent 任务的**断点续跑**（Checkpoint & Resume）能力。当长时间运行的任务被中断（用户 Ctrl-C、进程崩溃、机器重启等）时，可以从上次中断处继续执行，而无需从头开始。
+AgentLoom 将“一次执行尝试”和“需要恢复的逻辑任务”分开管理：
 
-核心组件：
+- `run_id` 标识一次执行 attempt。正常运行和每次 resume 都生成新的 `run_id` 与 run 目录。
+- `task_id` 标识同一个逻辑任务。resume 保持 `task_id` 不变，继续使用原 checkpoint 目录。
 
-| 组件 | 说明 |
-|------|------|
-| **CheckpointManager** | 持久化层：原子 JSON 写入、任务树管理、checkpoint 文件组织 |
-| **CheckpointCoordinator** | 协调层：ContextVar 单例，管理 checkpoint 生命周期 |
-| **CheckpointSerializer** | 序列化层：smolagents MemoryStep 的序列化/反序列化 |
-| **ConversationRecovery** | 恢复管道：过滤未完成的 tool 调用、孤立思考步骤、空步骤 |
-| **FileHistoryManager** | 文件历史：编辑前备份、步骤快照、回滚到指定步骤 |
-| **SupervisorHeartbeat** | 心跳监控：Supervisor 进程存活检测 |
-| **WorkerHeartbeat** | 工作心跳：Worker 调用级别的存活检测 |
+因此，日志轮转或 run 清理不会破坏任务恢复状态；并发 Application 和任务也不会共用日志或 artifact 路径。
 
 ## 存储布局
 
-Checkpoint 数据写入每次运行的时间戳日志目录，与运行日志共存：
+`runtime.root_dir` 是框架运行时的唯一根目录，默认值为 `.agentloom`：
 
-```
-.logs/{agent_name}/
-├── .task_index.json                        # 索引：task_id → timestamp 映射（用于 --resume 快速查找）
-├── 20260413_104447/                        # 每次运行的时间戳目录
-│   ├── {agent_name}.log                    # 运行日志
-│   └── checkpoints/{task_id}/              # 该次运行的 checkpoint 数据
-│       ├── task_tree.json                  # 任务元数据（状态、worker 调用记录）
-│       ├── checkpoint.json                 # Supervisor Agent memory 快照
-│       ├── heartbeat.json                  # Supervisor 心跳（PID、时间戳）
-│       ├── file-history/                   # 文件编辑历史备份
-│       └── workers/{worker_name}/
-│           ├── checkpoint.json             # Worker Agent memory 快照
-│           └── heartbeat.json              # Worker 心跳
-└── 20260413_104837/
-    ├── {agent_name}.log
-    └── checkpoints/{task_id}/
-        └── ...
+```text
+.agentloom/
+├── runs/<application_id>/<run_id>/
+│   ├── manifest.json
+│   ├── logs/
+│   │   ├── runtime.log
+│   │   └── runtime.log.1 ... runtime.log.3
+│   ├── audit/
+│   │   ├── shell.jsonl
+│   │   └── shell.jsonl.1 ... shell.jsonl.2
+│   └── artifacts/
+│       ├── shell/
+│       ├── background/
+│       └── skills/
+├── checkpoints/<application_id>/<task_id>/
+│   ├── task_events.jsonl
+│   ├── task_tree.json
+│   ├── checkpoint.json
+│   ├── heartbeat.json
+│   ├── workers/<worker_name>/
+│   │   ├── calls/<call_index>/checkpoint.json
+│   │   └── heartbeat.json
+│   ├── context_store/
+│   └── file-history/
+├── sessions/
+├── learning/
+├── self_learning.db
+└── legacy/logs-v1-<timestamp>/
 ```
 
-**关键设计**：
-- Checkpoint 始终在首次创建时的时间戳目录下，resume 时不会迁移到新目录
-- `.task_index.json` 记录 `task_id → timestamp` 的映射，`--resume` 时 O(1) 定位
-- 如果索引丢失，系统会自动扫描所有时间戳目录作为降级回退
+关键边界：
+
+- `manifest.json` 用 `task_id` 反向关联逻辑任务；checkpoint 的 run 事件和 heartbeat 记录当前 `run_id`。
+- `task_events.jsonl` 是持久化的任务/Worker 事件源，`task_tree.json` 是便于查看的投影。
+- Checkpoint 直接按 `<application_id>/<task_id>` 定位，不依赖日志目录、`.task_index.json` 或历史 run 扫描。
+- 用户交付物仍由 Application 的 `output_dir` 管理，runtime 清理不会遍历 Application output 目录。
+- `.runtime/` 是 Agent 可见的 recall/todo 工作区，与 `.agentloom/` 刻意保持独立，不会被搬进 run artifacts。
 
 ## 配置
 
-在 `config/system.yaml` 中配置：
+在 `config/system.yaml` 中配置运行时存储、有界日志和 resume：
 
 ```yaml
+runtime:
+  root_dir: ".agentloom"
+  successful_run_retention_days: 7
+  failed_run_retention_days: 30
+  artifact_retention_days: 3
+  cleanup_interval_hours: 24
+
+logging:
+  level: "INFO"
+  console_enabled: true
+  file_enabled: true
+  max_file_bytes: 26214400  # runtime.log 每段 25 MiB
+  backup_count: 3
+
 checkpoint:
-  enabled: true              # 全局开关
-  cleanup_on_success: true   # 任务成功后自动清理 checkpoint
-  max_resume_age: 604800     # checkpoint 最大保留时间（秒），默认 7 天
-  heartbeat_interval: 5      # 心跳写入间隔（秒）
+  enabled: true
+  cleanup_on_success: true
+  max_resume_age: 604800
+  heartbeat_interval: 5
 ```
 
-## CLI 命令
+文件日志默认开启且有界：runtime log 保留当前 25 MiB 文件和 3 个备份；Shell audit 独立按每段 10 MiB、2 个备份轮转。
 
-### 运行任务
+`runtime.root_dir` 支持绝对路径和相对路径；相对路径从 AgentLoom 项目根目录解析。隔离验证时，在验证 checkout 的全局配置里把该字段指向临时绝对目录。
+
+## 运行与恢复
 
 ```bash
-# 正常运行
+# 新逻辑任务 + 新执行 attempt
 loom run applications/<app>/workflows/<agent>.yaml
 
-# 开启日志文件写入
-loom run applications/<app>/workflows/<agent>.yaml --log-to-file
+# 仅关闭本次执行的文件 runtime log；checkpoint 仍正常工作
+loom run applications/<app>/workflows/<agent>.yaml --no-file-log
 
-# 从 checkpoint 恢复
+# 新执行 attempt + 原逻辑任务/checkpoint
 loom run applications/<app>/workflows/<agent>.yaml --resume task_xxx
 ```
 
-### 查看可恢复的任务
+CLI 不再提供 `--log-to-file`。默认是否写文件由 `logging.file_enabled` 决定，`--no-file-log` 是单次运行的关闭开关。
+
+查看或清理 checkpoint：
 
 ```bash
 loom list-tasks
 loom list-tasks --detail
+loom clean-tasks
+loom clean-tasks --before 3
+loom clean-tasks --all
 ```
 
-### 清理旧 checkpoint
+`cleanup_on_success: true` 时，成功任务的整个 checkpoint 目录会被删除。关闭该清理时，completed checkpoint 会保留供检查，但它是终态，不能 resume。failed、interrupted 或 crashed 任务在 `max_resume_age` 内可恢复；其 ContextStore 和 file-history 与 task checkpoint 位于同一目录并共享生命周期。`loom list-tasks` 会列出所有仍保留的 checkpoint 及其状态。
+
+## 恢复行为
+
+Resume 的恢复链路为：
+
+```text
+加载已持久化的 MemorySteps
+  -> 移除未完成 tool use、孤立步骤和空步骤
+  -> 恢复 task-scoped ContextStore 与 file-history
+  -> 在原 call_index 下恢复未完成的 Worker memory
+  -> 输入哈希一致时复用已完成 Worker 结果
+  -> 使用新的 run_id 继续执行
+```
+
+每次 Worker 调用拥有独立的 `workers/<worker>/calls/<call_index>/checkpoint.json`，并发调用不会互相覆盖。Resume 会复用未完成的 call index，不会为同一段中断工作再创建一个重复调用。
+
+Supervisor 与 Worker heartbeat 都记录当前 `run_id`。崩溃检测会检查 heartbeat 是否缺失/停止、PID 是否存活以及时间戳是否过期。Resume 后会在同一个 task checkpoint 中写入新 attempt 的 `run_id`。
+
+回放会跳过损坏或只写了一半的 JSONL 尾行，避免一次异常退出让前面的有效 task events 全部不可读。
+
+## Runtime 保留策略
+
+自动 runtime 清理最多每 `runtime.cleanup_interval_hours` 执行一次（默认 24 小时），且只遍历 `.agentloom/runs`：
+
+- 成功 run：默认保留 7 天；
+- 失败/中断 run：默认保留 30 天；
+- 原始 `artifacts/`：默认保留 3 天；
+- manifest 状态为 running 或未知：保留；
+- `.agentloom/legacy/`、checkpoints、`.runtime/` 和 Application outputs：run 清理永不删除。
+
+也可以显式执行同一策略：
 
 ```bash
-loom clean-tasks          # 清理过期的 checkpoint
-loom clean-tasks --all    # 清理所有 checkpoint
+loom clean-runtime
 ```
 
-## 恢复管道
+Checkpoint 过期与删除保持 task-scoped：`max_resume_age` 决定任务是否还能 resume，`cleanup_on_success` 删除成功任务状态，`loom clean-tasks` 提供显式 checkpoint 清理。
 
-当使用 `--resume` 恢复时，系统执行以下管道（移植自参考实现）：
+## 从 `.logs` 一次性迁移
 
-```
-加载已持久化的 MemoryStep
-  → filter_unresolved_tool_uses()    # 移除未完成的 tool 调用
-  → filter_orphaned_thinking()       # 移除孤立的思考步骤
-  → filter_empty_steps()             # 移除完全空白的步骤
-  → detect_turn_interruption()       # 检测中断类型
-  → 注入已清理的步骤到 Agent 内存
-  → 继续执行
+先预览：
+
+```bash
+loom migrate-runtime --dry-run
 ```
 
-### 中断检测
+扫描会完全忽略旧 `.task_index.json`，直接读取真实 checkpoint 目录及 task events/tree；测试任务、过期任务会被排除，只选择仍有可恢复 memory、ContextStore 或 file-history 进度的任务。
 
-| 中断类型 | 说明 |
-|---------|------|
-| `none` | 任务正常完成（有 final_answer 或已完成的 tool 调用） |
-| `interrupted_turn` | 任务在执行中被中断（有 tool_calls 但无 observations） |
+确认候选后应用：
 
-## 文件历史（File History）
-
-文件历史功能自动在 Agent 编辑文件之前创建备份，支持回滚到任意步骤：
-
-- **自动触发**：通过 `PRE_TOOL_USE` hook 自动拦截 `edit_file`、`write_file`、`create_file` 等工具
-- **三阶段锁安全**：检查 → I/O → 提交，最小化锁持有时间
-- **快照管理**：最多保留 100 个快照，超出自动淘汰最旧的
-- **Null-backup**：文件不存在时记录空备份，回滚时自动删除
-
-存储结构：
-
-```
-.logs/{agent_name}/{timestamp}/checkpoints/{task_id}/file-history/
-    {sha256_hash}@v1    # 编辑前备份
-    {sha256_hash}@v2    # 步骤后快照
-    snapshots.json       # 持久化索引
+```bash
+loom migrate-runtime --apply
 ```
 
-## Worker 跳过机制
+Apply 会经过 staging，校验 checksum 和可恢复进度，再原子 rename 到 `.agentloom/checkpoints/<application_id>/<task_id>/`。全部候选验证成功后，整个旧 `.logs` 会被原子归档到 `.agentloom/legacy/logs-v1-<timestamp>/`；新运行时不会双读该归档。
 
-多 Agent 任务中，已完成的 Worker 在恢复时会被自动跳过：
+迁移完成后，应对每个重要任务执行真实 resume，并验证旧 ContextRef retrieve 与 file-history 状态，再把迁移判定为通过。
 
-1. Worker 启动时计算输入的 SHA256 哈希
-2. 完成后将结果和哈希存入 checkpoint
-3. 恢复时检查哈希匹配，命中则直接返回缓存结果
+## 检查真实运行证据
 
-## 崩溃检测
+不要只看退出码或 final answer。必须读取该 attempt 的 manifest、runtime log 和 Shell audit：
 
-通过心跳文件实现崩溃检测：
+```bash
+manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
+run_dir=$(dirname "$manifest")
 
-- Supervisor 和 Worker 每 5 秒写入心跳文件（PID + 时间戳）
-- 恢复时检查：
-  - 心跳文件不存在 → 崩溃
-  - 心跳状态为 stopped/exited → 崩溃
-  - PID 不存在 → 崩溃
-  - 时间戳超过 30 秒未更新 → 崩溃
+sed -n '1,160p' "$manifest"
+tail -n 100 "$run_dir/logs/runtime.log"
+tail -n 100 "$run_dir/audit/shell.jsonl"
+```
+
+对 resume 任务，确认新 manifest 使用新的 `run_id`、原来的 `task_id`，再检查：
+
+```bash
+find .agentloom/checkpoints/<application_id>/<task_id> -maxdepth 5 -type f -print
+```
 
 ## 故障排除
 
-### 恢复失败："No checkpoint found"
+### Resume 失败：`No checkpoint found`
 
-确认 `.logs/{agent_name}/{timestamp}/checkpoints/` 目录下存在对应的 task_id 目录。使用 `loom list-tasks` 查看可用任务。
+运行 `loom list-tasks --detail`，确认 task 位于本次 workflow 对应的同一 `application_id` 下。Checkpoint 查找具有 Application scope。
 
-### 恢复失败："Checkpoint expired"
+### Resume 失败：`Checkpoint expired`
 
-checkpoint 超过了 `max_resume_age` 配置的保留时间（默认 7 天）。
+该逻辑任务原始 `created_at` 已超过 `checkpoint.max_resume_age`。迁移和 resume 不会重写 `created_at` 来复活过期任务。
 
-### 恢复失败："checkpoint is disabled"
+### 没有 `runtime.log`
 
-检查 `config/system.yaml` 中 `checkpoint.enabled` 是否为 `true`。
+检查 `logging.file_enabled`，以及本次运行是否使用了 `--no-file-log`。关闭文件日志不会关闭 checkpoint 或 Shell audit。
+
+### `.logs` 仍然存在
+
+新运行不会再写 `.logs`。先用 `loom migrate-runtime --dry-run` 检查，再用 `--apply` 归档旧目录；验证可恢复任务之前不要直接删除它。

--- a/docs/cn/config-overview.md
+++ b/docs/cn/config-overview.md
@@ -47,6 +47,32 @@ flowchart TD
 单个 Agent 的 YAML 文件除了定义自身的工作流外，还可以覆盖系统的部分配置。支持覆盖的白名单字段（`_WORKFLOW_OVERLAY_KEYS`）包含：
 - `system`, `model_request_headers`, `smart_summary`, `context_engine`, `tool_access_control`, `execution_env`, `code_agent`, `tools`, `prompt`, `shell_settings`, `tools_mapping`, `default_toolsets`, `toolsets`, `mcp_servers`, `self_learning`。
 
+### Runtime 存储归属
+
+`runtime` 与 `logging` 只能写在全局 `config/system.yaml`；Application 级 `config/system.yaml` 和 Agent YAML 不能移动 runtime root 或替换日志策略。这样，一个进程只有一套任务发现与保留边界。
+
+隔离子进程可用 `AGENTLOOM_RUNTIME_ROOT` 覆盖整套 runtime home；该覆盖不会只移动 self-learning。
+
+```yaml
+runtime:
+  root_dir: ".agentloom"
+  successful_run_retention_days: 7
+  failed_run_retention_days: 30
+  artifact_retention_days: 3
+  cleanup_interval_hours: 24
+
+logging:
+  level: "INFO"
+  console_enabled: true
+  file_enabled: true
+  max_file_bytes: 26214400
+  backup_count: 3
+```
+
+每次 attempt 写入 `.agentloom/runs/<application_id>/<run_id>/{manifest.json,logs,audit,artifacts}`。Resume 会创建新的 `run_id`，但保持逻辑任务的 `task_id` 和 `.agentloom/checkpoints/<application_id>/<task_id>/` 不变。Agent 可见的 `.runtime/` 工作区与 Application 自有 `output_dir` 属于独立存储域。
+
+文件日志由 `logging.file_enabled` 控制，并按大小和备份数有界轮转。`loom run --no-file-log` 只关闭本次 attempt 的文件日志，不会关闭 checkpoint 或 Shell audit。`loom clean-runtime` 应用 run retention；`loom migrate-runtime --dry-run|--apply` 用于一次性迁移旧 `.logs`。
+
 ## 3. LLM 配置的完全隔离
 
 在 AgentLoom 中，**LLM 配置（`llm.yaml`）与系统配置（`system.yaml`）是物理隔离的**。

--- a/docs/cn/system_config.md
+++ b/docs/cn/system_config.md
@@ -25,7 +25,7 @@
 - [5.5 mcp_servers — MCP 外部工具集成](#55-mcp_servers--mcp-外部工具集成)
 - [6. execution_env — 执行环境配置](#6-execution_env--执行环境配置)
 - [6. code_agent — CodeAgent 代码执行权限](#6-code_agent--codeagent-代码执行权限)
-- [7. logging — 日志配置](#7-logging--日志配置)
+- [7. runtime 与 logging — 运行时存储与日志](#7-runtime-与-logging--运行时存储与日志)
 - [8. tools — 工具系统配置](#8-tools--工具系统配置)
 - [9. tool_access_control — 工具访问控制](#9-tool_access_control--工具访问控制)
 - [10. tool_metadata — 工具元数据配置](#10-tool_metadata--工具元数据配置)
@@ -92,13 +92,24 @@ code_agent:
   additional_functions: "*"
 
 # ============================================
+# 运行时存储与保留策略
+# ============================================
+runtime:
+  root_dir: ".agentloom"
+  successful_run_retention_days: 7
+  failed_run_retention_days: 30
+  artifact_retention_days: 3
+  cleanup_interval_hours: 24
+
+# ============================================
 # 日志配置
 # ============================================
 logging:
-  enabled: true
   level: "INFO"
-  file_path: null
-  dir: ".logs"
+  console_enabled: true
+  file_enabled: true
+  max_file_bytes: 26214400
+  backup_count: 3
 
 # ============================================
 # 默认加载 Toolsets
@@ -776,65 +787,55 @@ code_agent:
 
 ---
 
-## 7. logging — 日志配置
+## 7. runtime 与 logging — 运行时存储与日志
 
-控制系统日志的详细程度和输出位置。日志公共入口统一为 `src.lib.logging`，按"每个 Python 进程生命周期一个日志文件"管理。
+`runtime` 定义框架唯一的存储根目录和有界保留策略；`logging` 控制控制台与 run-scoped 文件 backend。Logger 状态绑定当前 run，不再复用进程全局输出路径。
 
-**YAML 路径**：`logging.*`
+这两个配置段只能写在全局 `config/system.yaml`。Application 级 `config/system.yaml` 或 Agent YAML 一旦包含任一配置段就会校验失败，避免错误位置的配置被静默忽略，让用户误以为任务发现已经移动到另一个 runtime root。
+
+隔离子进程或验证任务可设置 `AGENTLOOM_RUNTIME_ROOT`；它覆盖的是整个 canonical runtime home（runs、checkpoints、sessions、learning 与 `self_learning.db` 一起移动），不存在 self-learning 专用 root 覆盖。
+
+**YAML 路径**：`runtime.*`、`logging.*`
 
 | 参数 | 类型 | 默认值 | 必选 | 说明 |
 |------|------|--------|------|------|
-| `logging.enabled` | `bool` | `true` | ❌ 否 | 是否开启日志系统 |
-| `logging.level` | `str` | `"INFO"` | ❌ 否 | 日志过滤等级（不区分大小写） |
-| `logging.file_path` | `str` \| `null` | `null` | ❌ 否 | 指定日志文件路径。`null` 时自动生成 |
-| `logging.dir` | `str` | `".logs"` | ❌ 否 | 自动生成日志时的根目录 |
+| `runtime.root_dir` | `str` | `".agentloom"` | ❌ 否 | 框架运行时唯一根目录；相对路径从项目根解析，也支持绝对路径 |
+| `runtime.successful_run_retention_days` | `int` | `7` | ❌ 否 | 成功 run 目录保留天数 |
+| `runtime.failed_run_retention_days` | `int` | `30` | ❌ 否 | 失败/中断 run 目录保留天数 |
+| `runtime.artifact_retention_days` | `int` | `3` | ❌ 否 | 已保留 run 内原始 `artifacts/` 的保留天数 |
+| `runtime.cleanup_interval_hours` | `int` | `24` | ❌ 否 | 两次自动清理之间的最小间隔 |
+| `logging.level` | `str` \| `int` | `"INFO"` | ❌ 否 | 日志过滤等级（不区分大小写） |
+| `logging.console_enabled` | `bool` | `true` | ❌ 否 | 是否向控制台输出格式化运行日志 |
+| `logging.file_enabled` | `bool` | `true` | ❌ 否 | 是否把当前 attempt 写入 `logs/runtime.log` |
+| `logging.max_file_bytes` | `int` | `26214400` | ❌ 否 | 每个 runtime log 分段的最大字节数（25 MiB） |
+| `logging.backup_count` | `int` | `3` | ❌ 否 | runtime log 轮转备份数 |
 
-### 7.1 logging.level 详解
+### 7.1 Canonical 路径与生命周期
 
-框架使用 `LogLevelParser` 读取 `logging.level`，支持标准 `logging` 级别以及特殊值 `OFF`：
+每个 attempt 写入 `.agentloom/runs/<application_id>/<run_id>/`：
 
-| 值 | 含义 | 适用场景 |
-|----|------|----------|
-| `"DEBUG"` | 放行所有框架底层流转细节 | 排查错误、查看底层请求 |
-| `"INFO"` | **(默认)** 显示核心运行状态和 Step 提示 | 日常使用 |
-| `"WARNING"` / `"WARN"` | 屏蔽普通流转，仅暴露危险项与告警 | 简化输出 |
-| `"ERROR"` | 仅捕捉异常和错误 | 生产环境 |
-| `"CRITICAL"` | 仅捕捉严重异常 | 极度精简 |
-| `"OFF"` | 彻底关闭日志（实际设置为 `CRITICAL + 10`） | 静默模式 |
-
-此外也支持**整数值**（如 `10` = DEBUG, `20` = INFO, `30` = WARNING）。
-
-### 7.2 logging.file_path 与 logging.dir
-
-- 当 `file_path` 指定了具体路径时，当前进程全程写入该文件
-- 当 `file_path` 为 `null` 时，框架自动在 `dir` 目录下生成日志文件，命名规则为：
-  - `{logging.dir}/{app_name}/{timestamp}/{app_name}.log`
-  - 同一运行的 Shell 审计日志也会放在同一时间戳目录下：`{logging.dir}/{app_name}/{timestamp}/shell_audit.log`
-  - 若同一秒内启动多次，时间戳目录名会自动追加后缀 `_1`、`_2` 以避免覆盖
-
-**示例**：
-
-```yaml
-# 默认配置（自动日志文件）
-logging:
-  enabled: true
-  level: "INFO"
-  file_path: null
-  dir: ".logs"
-
-# 调试模式（指定日志文件）
-logging:
-  enabled: true
-  level: "DEBUG"
-  file_path: "/tmp/agent_loom_debug.log"
-
-# 静默模式
-logging:
-  enabled: true
-  level: "OFF"
+```text
+manifest.json
+logs/runtime.log[.1-.3]
+audit/shell.jsonl[.1-.2]
+artifacts/{shell,background,skills}/
 ```
 
-> **注意**：由于安全和配置隔离机制，在 Agent YAML 或应用级的 `system.yaml` 中配置 `logging` 都是无效的（会被系统过滤忽略）。所有的日志策略必须在顶层全局的 `config/system.yaml` 中统一配置。
+Shell audit 独立按每段 10 MiB、2 个备份轮转。Resume 为同一任务创建新的 `run_id` 和 run 目录，同时继续使用原 `task_id` 与 `.agentloom/checkpoints/<application_id>/<task_id>/`。可以只关闭文件日志，而不关闭 checkpoint 或 Shell audit：
+
+```bash
+loom run applications/<app>/workflows/<agent>.yaml --no-file-log
+```
+
+框架不再保留 `--log-to-file`、`logging.enabled`、`logging.dir` 或 `logging.file_path` 兼容路径。
+
+### 7.2 保留策略与存储边界
+
+自动清理最多按配置间隔执行一次；`loom clean-runtime` 可显式应用同一策略。它只删除符合条件的 run 目录或其中的 raw artifacts，永不遍历 checkpoints、`.agentloom/legacy/`、`.runtime/` 或 Application 自有 output 目录。
+
+`.runtime/` 仍是 Agent 可见的 recall/todo 工作区，与 `.agentloom/` 语义独立。`loom migrate-runtime --dry-run` 预览有效的旧 checkpoint 候选；`loom migrate-runtime --apply` 完成迁移，并把整个旧 `.logs` 归档到 `.agentloom/legacy/`。
+
+验证真实 attempt 时必须读取 `manifest.json`、`logs/runtime.log` 与 `audit/shell.jsonl`，不能只看退出码。
 
 ---
 
@@ -1224,7 +1225,7 @@ tool_output_limits:
 
 ---
 
-## 10. checkpoint — 断点续跑与心跳配置
+## 12. checkpoint — 断点续跑与心跳配置
 
 控制 Agent 任务的**断点续跑**、**心跳监控**与**崩溃检测**能力。框架默认全局开启，任何基于 AgentLoom 创建的应用均自动享有该能力，无需额外配置。
 
@@ -1237,32 +1238,43 @@ tool_output_limits:
 | `checkpoint.max_resume_age` | `int`（秒） | `604800` | ❌ 否 | checkpoint 最大保留时长（7 天）。超过该时长的 checkpoint 被视为过期，不可恢复 |
 | `checkpoint.heartbeat_interval` | `int`（秒） | `5` | ❌ 否 | 心跳文件写入频率。框架守护线程每隔该间隔将进程状态（PID、步骤数、时间戳）写入磁盘 |
 
-### 10.1 运行时目录结构
+### 12.1 运行时目录结构
 
-checkpoint 数据写入每次运行的时间戳日志目录下，与运行日志共存：
+Run 证据与 task 恢复状态在同一个 runtime root 下保持独立生命周期：
 
+```text
+.agentloom/
+├── runs/<application_id>/<run_id>/
+│   ├── manifest.json
+│   ├── logs/runtime.log[.1-.3]
+│   ├── audit/shell.jsonl[.1-.2]
+│   └── artifacts/{shell,background,skills}/
+└── checkpoints/<application_id>/<task_id>/
+    ├── task_events.jsonl
+    ├── task_tree.json
+    ├── checkpoint.json
+    ├── heartbeat.json
+    ├── workers/<worker_name>/calls/<call_index>/checkpoint.json
+    ├── context_store/
+    └── file-history/
 ```
-.logs/{supervisor_name}/{timestamp}/
-├── {supervisor_name}.log     # 运行日志
-└── checkpoints/{task_id}/
-    ├── task_tree.json        # 任务元数据（状态、worker 调用记录、创建时间）
-    ├── checkpoint.json       # Supervisor Agent 的 memory steps 快照
-    ├── heartbeat.json        # Supervisor 心跳（PID、时间戳、步骤数、状态）
-    └── workers/{worker_name}/
-        ├── checkpoint.json   # Worker Agent 每次调用的 memory 快照
-        └── heartbeat.json    # Worker 心跳（聚合所有并发调用的状态）
-```
 
-此外，在 agent 根目录下维护一个轻量索引文件 `.task_index.json`，记录 `task_id → timestamp` 的映射关系，便于 `--resume` 时快速定位 checkpoint 所在的时间戳目录。
+关键设计：
 
-### 10.2 心跳机制与崩溃检测
+- 每个 attempt 都更换 `run_id`，resume 时 `task_id` 保持不变
+- Run manifest 记录 `task_id`；checkpoint run event 和 heartbeat 记录当前 `run_id`
+- Checkpoint 直接按 Application/task canonical 路径定位，不依赖日志、`.task_index.json` 或 legacy 扫描
+- 日志关闭、轮转和 runtime retention 不会删除 checkpoint
+- `.runtime/` 仍是独立的 Agent 可见工作区；Application `output_dir` 仍由 Application 管理
+
+### 12.2 心跳机制与崩溃检测
 
 框架维护两级心跳：
 
 | 级别 | 文件位置 | Payload 字段 |
 |------|----------|--------------|
-| **Supervisor 心跳** | `{task_id}/heartbeat.json` | `pid`, `timestamp`, `timestamp_iso`, `status`, `step`, `agent_name` |
-| **Worker 心跳** | `{task_id}/workers/{name}/heartbeat.json` | `agent_name`, `pid`, `timestamp`, `calls`（各并发调用的 `status`、`step`、`started_at`、`finished_at`） |
+| **Supervisor 心跳** | `{task_id}/heartbeat.json` | `pid`, `run_id`, `timestamp`, `timestamp_iso`, `status`, `step`, `agent_name` |
+| **Worker 心跳** | `{task_id}/workers/{name}/heartbeat.json` | `agent_name`, `run_id`, `pid`, `timestamp`, `calls`（各并发调用的 `status`、`step`、`started_at`、`finished_at`） |
 
 **崩溃检测逻辑**（`HEARTBEAT_STALE_THRESHOLD = 30` 秒）：
 
@@ -1272,15 +1284,16 @@ checkpoint 数据写入每次运行的时间戳日志目录下，与运行日志
 4. 心跳时间戳超过 30 秒未刷新 → `crashed`
 5. 以上均不满足 → `running`
 
-### 10.3 断点续跑流程
+### 12.3 断点续跑流程
 
 当检测到某 `task_id` 的 checkpoint 未超过 `max_resume_age`，且状态为非正常结束（`crashed`/`interrupted`）时，框架自动：
 
 1. 从 `checkpoint.json` 恢复 Supervisor 的 memory steps（跳过已完成的思考步骤）
-2. 对每个 Worker 调用，检查 `task_tree.json` 中的 `input_hash` 缓存——若输入一致且已完成，直接返回缓存结果（跳过重复执行）
-3. 从中断点继续运行，直到任务完成
+2. 恢复 task-scoped ContextStore 与 file-history index
+3. 对每个 Worker 调用，在原 `call_index` 下恢复未完成 memory；已完成且 `input_hash` 一致时直接返回缓存结果
+4. 创建新 run 目录，使用新的 `run_id` 从中断点继续执行
 
-### 10.4 配置示例
+### 12.4 配置示例
 
 ```yaml
 # 调试场景：保留 checkpoint、缩短 resume 窗口
@@ -1310,6 +1323,8 @@ checkpoint:
 | `system.*` | `SystemSettings` | `src/lib/config/config_validation.py` |
 | `model_request_headers.*` | `ModelRequestHeadersSettings` | `src/lib/config/config_validation.py` |
 | `tool_access_control.*` | `ToolAccessControlSettings` | `src/lib/config/config_validation.py` |
+| `runtime.*` | `RuntimeSettings` | `src/lib/config/config_validation.py` |
+| `logging.*` | `LoggingSettings` | `src/lib/config/config_validation.py` |
 
 **`RootSettings` 完整字段定义**：
 
@@ -1318,6 +1333,8 @@ checkpoint:
 | `system` | `SystemSettings` | `SystemSettings()` |
 | `model_request_headers` | `ModelRequestHeadersSettings` | `ModelRequestHeadersSettings()` |
 | `tool_access_control` | `ToolAccessControlSettings` | `ToolAccessControlSettings()` |
+| `runtime` | `RuntimeSettings` | `RuntimeSettings()` |
+| `logging` | `LoggingSettings` | `LoggingSettings()` |
 | `smart_summary` | `bool` | `True` |
 | `model` | `dict[str, Any]` | `{}` |
 | `execution_env` | `dict[str, Any]` | `{}` |
@@ -1326,13 +1343,13 @@ checkpoint:
 | `tool_metadata` | `dict[str, Any]` | `{}` |
 | `tool_output_limits` | `dict[str, Any]` | `{}` |
 
-> 所有模型均设置 `extra="allow"`，允许扩展字段。`prompt` 就是这类顶层 extra key 之一，会通过 overlay 合并透传到最终配置，但不作为 `RootSettings` 的显式字段。
+> `RootSettings` 允许扩展字段，因此 `prompt` 等顶层字段仍可参与 overlay 合并。`RuntimeSettings` 与 `LoggingSettings` 刻意使用 `extra="forbid"`；已删除的 runtime/logging key 会直接校验失败，不会静默启用第二套存储路径。
 
 **容错解析工具集**：
 
 | 解析器 | 用途 | 位于 |
 |--------|------|------|
-| `BoolParser` | 兼容布尔输入归一化，实际用于 `logging.enabled`、Skill 的 `allow-scripts` / `allow-network` 解析、以及部分 LLM 配置开关 | `config_validation.py` / `src/lib/logging/logger_manager.py` / `src/lib/smolagents/agent/base_agent.py` / `src/lib/config/llm_config.py` |
+| `BoolParser` | 兼容布尔输入归一化，实际用于 `logging.console_enabled` / `logging.file_enabled`、Skill 的 `allow-scripts` / `allow-network` 解析，以及部分 LLM 配置开关 | `config_validation.py` / `src/lib/logging/logger_manager.py` / `src/lib/smolagents/agent/base_agent.py` / `src/lib/config/llm_config.py` |
 | `IntParser` | 兼容整数与旁路字符串输入，实际用于模型配置里的 `max_tokens`（支持 `"max"`） | `config_validation.py` / `src/lib/config/llm_config.py` |
 | `FloatParser` | 兼容浮点与整数字符串输入，实际用于模型配置里的 `temperature`、`retry_delay`、`max_retry_delay` | `config_validation.py` / `src/lib/config/llm_config.py` |
 | `EnumParser` | 通用枚举归一化辅助函数，当前未在 system.yaml 主链路中直接消费 | `config_validation.py` |
@@ -1390,7 +1407,9 @@ applications/my_app/
 | `system` | ✅ 支持 | ✅ 支持 | ✅ 支持 |
 | `smart_summary` | ✅ 支持 | ✅ 支持 | ✅ 支持 |
 | `skills` | ✅ 支持 | ✅ 支持 | ✅ 支持 (Agent私有) |
-| `logging` | ✅ 支持 | ❌ 忽略 | ❌ 忽略 |
+| `runtime` | ✅ 支持 | ❌ 拒绝 | ❌ 拒绝 |
+| `logging` | ✅ 支持 | ❌ 拒绝 | ❌ 拒绝 |
+| `checkpoint` | ✅ 支持 | ✅ 支持 | ❌ 忽略 |
 | `tool_access_control` | ✅ 支持 | ✅ 支持 | ✅ 支持 |
 | `execution_env` | ✅ 支持 | ✅ 支持 | ✅ 支持 |
 | `code_agent` | ✅ 支持 | ✅ 支持 | ✅ 支持 |
@@ -1416,28 +1435,3 @@ tool_access_control:
 - `system.name`：保持 `"AgentLoom"` ✅ 继承全局
 - `logging.level`：保持 `"INFO"` ✅ 继承全局
 - 所有其他字段：保持全局配置值 ✅
-
----
-
-## 12. checkpoint — 断点续跑与心跳配置
-
-控制任务的断点续跑和心跳监控行为。详细说明请参考 [checkpoint.md](checkpoint.md)。
-
-**YAML 路径**：`checkpoint.*`
-
-| 参数 | 类型 | 默认值 | 必选 | 说明 |
-|------|------|--------|------|------|
-| `checkpoint.enabled` | `bool` | `true` | ❌ 否 | 全局开关：是否启用断点续跑 |
-| `checkpoint.cleanup_on_success` | `bool` | `true` | ❌ 否 | 任务成功完成后自动删除 checkpoint 目录 |
-| `checkpoint.max_resume_age` | `int` | `604800` | ❌ 否 | checkpoint 最大保留时长（秒），默认 7 天 |
-| `checkpoint.heartbeat_interval` | `float` | `5.0` | ❌ 否 | 心跳写入频率（秒），用于崩溃检测 |
-
-**示例**：
-
-```yaml
-checkpoint:
-  enabled: true
-  cleanup_on_success: true
-  max_resume_age: 604800
-  heartbeat_interval: 5
-```

--- a/docs/en/agent_config.md
+++ b/docs/en/agent_config.md
@@ -1620,7 +1620,9 @@ The `security_checks` dictionary supports 10 independent toggles. Undeclared key
 
 When an agent executes shell commands, security-related events (blocks, path violations, stall detection, timeouts, etc.) are automatically written to a dedicated audit log file:
 
-**File location**: `.logs/{agent_name}/{timestamp}/shell_audit.log`
+**File location**: `.agentloom/runs/<application_id>/<run_id>/audit/shell.jsonl`
+
+The same attempt's manifest and main log are `manifest.json` and `logs/runtime.log`. The audit file rotates at 10 MiB with two backups and remains available even when this run uses `--no-file-log`.
 
 Configuration (in `config/system.yaml` or agent YAML `shell_settings`):
 
@@ -1631,31 +1633,26 @@ shell_settings:
     log_success: false    # Also log successful executions (default: false)
 ```
 
-Each audit entry includes timestamp, event type, agent name, command, details, and an **actionable suggestion** that tells you exactly which YAML setting to change:
+Each line is one JSON object with a timestamp, event type, agent name, command, details, and an **actionable suggestion** that tells you exactly which YAML setting to change:
 
-```
-[2026-04-08 13:41:46] [SECURITY_BLOCK] agent=code_reviewer
-  command: $(cat /etc/passwd)
-  check: command_substitution
-  message: Blocked: $() command substitution detected
-  suggestion: To disable this check for a specific agent, add the following
-    to the agent YAML:
-      shell_settings:
-        security_checks:
-          command_substitution: false
+```json
+{"timestamp":"2026-04-08T13:41:46+00:00","event_type":"SECURITY_BLOCK","agent":"code_reviewer","command":"$(cat /etc/passwd)","check_id":"command_substitution","message":"Blocked: $() command substitution detected","suggestion":"Review shell_settings.security_checks.command_substitution"}
 ```
 
 When troubleshooting shell permission issues, checking the audit log is much more efficient than searching through the main application log:
 
 ```bash
-# Find all audit logs
-find .logs/ -name 'shell_audit_*.log' | sort
+# Find all run manifests and audit logs
+find .agentloom/runs -name manifest.json -o -name shell.jsonl
 
-# View the latest audit log for an agent
-ls -t .logs/my_agent/shell_audit_*.log | head -1 | xargs cat
+# Read the latest attempt's identity and audit
+manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
+run_dir=$(dirname "$manifest")
+sed -n '1,160p' "$manifest"
+tail -n 100 "$run_dir/audit/shell.jsonl"
 
 # Search by event type
-grep 'SECURITY_BLOCK\|WHITELIST_REJECT\|PATH_VIOLATION' .logs/my_agent/shell_audit_*.log
+rg 'SECURITY_BLOCK|WHITELIST_REJECT|PATH_VIOLATION' "$run_dir/audit/shell.jsonl"
 ```
 
 ---

--- a/docs/en/checkpoint.md
+++ b/docs/en/checkpoint.md
@@ -1,180 +1,203 @@
-# Checkpoint & Resume
+# Checkpoint, Resume, and Runtime Storage
 
 ## Overview
 
-AgentLoom supports **Checkpoint & Resume** for multi-Agent tasks. When a long-running task is interrupted (user Ctrl-C, process crash, machine restart, etc.), it can continue from where it left off without starting over.
+AgentLoom separates one execution attempt from the logical task being recovered:
 
-Core components:
+- `run_id` identifies one execution attempt. Every normal run and every resume gets a new `run_id` and a new run directory.
+- `task_id` identifies one logical task. Resume keeps the same `task_id` and continues the same checkpoint directory.
 
-| Component | Description |
-|-----------|-------------|
-| **CheckpointManager** | Persistence layer: append-only task events, task tree projection, checkpoint file organization |
-| **CheckpointCoordinator** | Coordination layer: ContextVar singleton, manages checkpoint lifecycle |
-| **CheckpointSerializer** | Serialization layer: smolagents MemoryStep serialization/deserialization |
-| **ConversationRecovery** | Recovery pipeline: filters unresolved tool calls, orphaned thinking steps, empty steps |
-| **FileHistoryManager** | File history: pre-edit backup, step snapshots, rewind to any step |
-| **SupervisorHeartbeat** | Heartbeat monitor: Supervisor process liveness detection |
-| **WorkerHeartbeat** | Worker heartbeat: per-call liveness detection |
+This boundary prevents log rotation or run cleanup from damaging resumable state. It also keeps concurrent Applications and tasks from sharing logger or artifact paths.
 
 ## Storage Layout
 
-Checkpoint data is written inside each run's timestamp log directory, co-located with the run log:
+`runtime.root_dir` is the only framework runtime root. Its default is `.agentloom`:
 
-```
-.logs/{agent_name}/
-├── .task_index.json                        # Index: task_id → timestamp mapping (for fast --resume lookup)
-├── 20260413_104447/                        # Per-run timestamp directory
-│   ├── {agent_name}.log                    # Run log
-│   └── checkpoints/{task_id}/              # Checkpoint data for this run
-│       ├── task_events.jsonl               # Source of truth: append-only task/worker events
-│       ├── task_tree.json                  # Compatibility projection rebuilt from events
-│       ├── checkpoint.json                 # Supervisor Agent memory snapshot
-│       ├── heartbeat.json                  # Supervisor heartbeat (PID, timestamp)
-│       ├── file-history/                   # File edit history backups
-│       └── workers/{worker_name}/
-│           ├── calls/{call_index}/
-│           │   └── checkpoint.json         # Worker Agent memory snapshot for one call
-│           ├── checkpoint.json             # Legacy worker checkpoint path, still readable
-│           └── heartbeat.json              # Worker heartbeat
-└── 20260413_104837/
-    ├── {agent_name}.log
-    └── checkpoints/{task_id}/
-        └── ...
+```text
+.agentloom/
+├── runs/<application_id>/<run_id>/
+│   ├── manifest.json
+│   ├── logs/
+│   │   ├── runtime.log
+│   │   └── runtime.log.1 ... runtime.log.3
+│   ├── audit/
+│   │   ├── shell.jsonl
+│   │   └── shell.jsonl.1 ... shell.jsonl.2
+│   └── artifacts/
+│       ├── shell/
+│       ├── background/
+│       └── skills/
+├── checkpoints/<application_id>/<task_id>/
+│   ├── task_events.jsonl
+│   ├── task_tree.json
+│   ├── checkpoint.json
+│   ├── heartbeat.json
+│   ├── workers/<worker_name>/
+│   │   ├── calls/<call_index>/checkpoint.json
+│   │   └── heartbeat.json
+│   ├── context_store/
+│   └── file-history/
+├── sessions/
+├── learning/
+├── self_learning.db
+└── legacy/logs-v1-<timestamp>/
 ```
 
-**Key design decisions**:
-- Checkpoints always remain in the timestamp directory where they were first created; they are not migrated on resume
-- `.task_index.json` records the `task_id → timestamp` mapping for O(1) lookup during `--resume`
-- If the index is lost, the system automatically scans all timestamp directories as a degraded fallback
-- `task_events.jsonl` is the durable state source. `task_tree.json` is a compatibility projection for older tools and quick inspection
-- Malformed or half-written JSONL event lines are skipped during replay, so a crash-tail line does not make the whole checkpoint unreadable
-- Old checkpoints without `task_events.jsonl` continue to load from legacy `task_tree.json`
+Important boundaries:
+
+- `manifest.json` links the attempt back to its `task_id`; checkpoint run events and heartbeat records include the current `run_id`.
+- `task_events.jsonl` is the durable task/Worker event source. `task_tree.json` is its inspectable projection.
+- Checkpoint lookup uses the canonical `<application_id>/<task_id>` path. It does not depend on a log directory, `.task_index.json`, or a scan of historical runs.
+- User deliverables remain under the Application's configured `output_dir`. Runtime cleanup never traverses Application output directories.
+- `.runtime/` is an Agent-visible workspace for recall/todo state. It is intentionally independent from `.agentloom/` and is not moved into run artifacts.
 
 ## Configuration
 
-Configure in `config/system.yaml`:
+Configure runtime storage, bounded logs, and resume behavior in `config/system.yaml`:
 
 ```yaml
+runtime:
+  root_dir: ".agentloom"
+  successful_run_retention_days: 7
+  failed_run_retention_days: 30
+  artifact_retention_days: 3
+  cleanup_interval_hours: 24
+
+logging:
+  level: "INFO"
+  console_enabled: true
+  file_enabled: true
+  max_file_bytes: 26214400  # 25 MiB per runtime.log segment
+  backup_count: 3
+
 checkpoint:
-  enabled: true              # Global switch
-  cleanup_on_success: true   # Auto-delete checkpoint after successful task completion
-  max_resume_age: 604800     # Max checkpoint retention (seconds), default 7 days
-  heartbeat_interval: 5      # Heartbeat write interval (seconds)
+  enabled: true
+  cleanup_on_success: true
+  max_resume_age: 604800
+  heartbeat_interval: 5
 ```
 
-## CLI Commands
+File logging is enabled by default and bounded. The runtime log keeps the active 25 MiB segment plus three backups. Shell audit uses an independent 10 MiB segment with two backups.
 
-### Running Tasks
+`runtime.root_dir` may be absolute or relative. A relative value resolves from the AgentLoom project root. For isolated validation, point this global key at a temporary absolute directory in the validation checkout.
+
+## Running and Resuming
 
 ```bash
-# Normal run
+# New logical task and new execution attempt
 loom run applications/<app>/workflows/<agent>.yaml
 
-# Enable log file writing
-loom run applications/<app>/workflows/<agent>.yaml --log-to-file
+# Disable only the file runtime log for this attempt; checkpoint remains available
+loom run applications/<app>/workflows/<agent>.yaml --no-file-log
 
-# Resume from checkpoint
+# New execution attempt, same logical task/checkpoint
 loom run applications/<app>/workflows/<agent>.yaml --resume task_xxx
 ```
 
-### Listing Resumable Tasks
+There is no `--log-to-file` flag. File logging follows `logging.file_enabled` by default, and `--no-file-log` is the per-run opt-out.
+
+To list or remove checkpoint state:
 
 ```bash
 loom list-tasks
 loom list-tasks --detail
+loom clean-tasks
+loom clean-tasks --before 3
+loom clean-tasks --all
 ```
 
-### Cleaning Old Checkpoints
+When `cleanup_on_success: true`, a successfully completed task's entire checkpoint directory is removed. With cleanup disabled, a completed checkpoint remains visible for inspection but is terminal and cannot be resumed. Failed, interrupted, or crashed tasks remain recoverable until `max_resume_age`; their ContextStore and file history share the same task directory and lifecycle. `loom list-tasks` lists every retained checkpoint and its status.
+
+## Recovery Behavior
+
+Resume performs this recovery pipeline:
+
+```text
+load persisted MemorySteps
+  -> remove unresolved tool uses and orphaned/empty steps
+  -> restore task-scoped ContextStore and file history
+  -> restore incomplete Worker call memory under the existing call_index
+  -> reuse completed Worker results with matching input hashes
+  -> continue execution under a new run_id
+```
+
+Each Worker call has its own `workers/<worker>/calls/<call_index>/checkpoint.json`, so concurrent calls do not overwrite one another. Resume reuses the incomplete call index; it does not create a duplicate call for the same interrupted work.
+
+The Supervisor and Worker heartbeat payloads include the active `run_id`. Crash detection considers missing/stopped heartbeats, dead PIDs, and stale timestamps. Resume writes the next heartbeat to the same task checkpoint with the new attempt's `run_id`.
+
+Malformed or half-written trailing JSONL lines are skipped during replay, so a crash-tail record does not make the earlier durable task events unreadable.
+
+## Runtime Retention
+
+Automatic runtime cleanup is throttled to at most once per `runtime.cleanup_interval_hours` (24 hours by default). It only traverses `.agentloom/runs`:
+
+- completed runs: 7 days by default;
+- failed/interrupted runs: 30 days by default;
+- raw `artifacts/`: 3 days by default;
+- running or unknown-status manifests: preserved;
+- `.agentloom/legacy/`, checkpoints, `.runtime/`, and Application outputs: never deleted by run cleanup.
+
+Run the same policy explicitly with:
 
 ```bash
-loom clean-tasks          # Clean expired checkpoints
-loom clean-tasks --all    # Clean all checkpoints
+loom clean-runtime
 ```
 
-## Recovery Pipeline
+Checkpoint expiry and deletion remain task-scoped: `max_resume_age` controls whether a task may resume, `cleanup_on_success` removes completed task state, and `loom clean-tasks` provides explicit checkpoint cleanup.
 
-When resuming with `--resume`, the system executes the following pipeline (ported from reference implementation):
+## One-Time Migration from `.logs`
 
-```
-Load persisted MemorySteps
-  → filter_unresolved_tool_uses()    # Remove incomplete tool calls
-  → filter_orphaned_thinking()       # Remove orphaned thinking steps
-  → filter_empty_steps()             # Remove completely blank steps
-  → detect_turn_interruption()       # Detect interruption type
-  → Inject cleaned steps into Agent memory
-  → Continue execution
+Preview the migration first:
+
+```bash
+loom migrate-runtime --dry-run
 ```
 
-### Interruption Detection
+The scan ignores every legacy `.task_index.json`. It reads real checkpoint directories and their task events/tree, excludes tests and expired tasks, and selects only tasks with resumable memory, ContextStore, or file-history progress.
 
-| Interruption Type | Description |
-|-------------------|-------------|
-| `none` | Task completed normally (has final_answer or completed tool calls) |
-| `interrupted_turn` | Task was interrupted mid-execution (has tool_calls but no observations) |
+Apply after reviewing the candidates:
 
-## File History
-
-The file history feature automatically creates backups before Agent edits files, supporting rewind to any step:
-
-- **Auto-triggered**: Intercepted via `PRE_TOOL_USE` hook for `edit_file`, `write_file`, `create_file`, etc.
-- **Three-phase lock safety**: Check → I/O → Commit, minimizing lock hold time
-- **Snapshot management**: Up to 100 snapshots retained; oldest are automatically evicted
-- **Null-backup**: Non-existent files get a null backup; on rewind the file is deleted
-- **Immutable original backup**: later snapshots inherit or append versions; they must never overwrite an earlier `@v1` original backup
-
-Storage structure:
-
-```
-.logs/{agent_name}/{timestamp}/checkpoints/{task_id}/file-history/
-    {sha256_hash}@v1    # Pre-edit backup
-    {sha256_hash}@v2    # Post-step snapshot
-    snapshots.json       # Persisted index
+```bash
+loom migrate-runtime --apply
 ```
 
-## Worker Resume / Skip Mechanism
+Apply copies each candidate through staging, verifies checksums and resumable progress, and atomically renames it into `.agentloom/checkpoints/<application_id>/<task_id>/`. After all candidates validate, the complete old `.logs` tree is atomically archived under `.agentloom/legacy/logs-v1-<timestamp>/`. New runtime code does not dual-read that archive.
 
-In multi-Agent tasks, Worker calls are checkpointed per call:
+After migration, run a real resume for each important task and verify both an old ContextRef retrieval and file-history state before treating the migration as accepted.
 
-1. Worker computes SHA256 hash of input at startup
-2. Worker calls are atomically assigned a per-worker `call_index`
-3. During execution, the Worker memory is saved to the per-call checkpoint after each Worker step
-4. On interruption, incomplete Worker calls can be resumed by reusing the same `call_index` and restoring Worker memory with `reset=False`
-5. On completion, result and hash are stored in both `task_events.jsonl` and the per-call Worker checkpoint
-6. On resume, completed calls with the same hash are skipped and the cached result is returned directly
+## Inspecting Real Run Evidence
 
-Incomplete Worker call reuse is enabled only during `--resume`; normal concurrent Worker calls still receive unique call indexes.
+Do not treat an exit code or final answer alone as proof. Read the attempt manifest, runtime log, and Shell audit:
 
-Worker checkpoint layout:
+```bash
+manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
+run_dir=$(dirname "$manifest")
 
-```
-.logs/{agent_name}/{timestamp}/checkpoints/{task_id}/workers/{worker_name}/
-    calls/{call_index}/checkpoint.json
-    heartbeat.json
+sed -n '1,160p' "$manifest"
+tail -n 100 "$run_dir/logs/runtime.log"
+tail -n 100 "$run_dir/audit/shell.jsonl"
 ```
 
-The legacy path `workers/{worker_name}/checkpoint.json` is still readable for old checkpoint data.
+For a resumed task, confirm that the new manifest has a new `run_id` and the original `task_id`, then inspect:
 
-## Crash Detection
-
-Crash detection is implemented via heartbeat files:
-
-- Supervisor and Worker write heartbeat files every 5 seconds (PID + timestamp)
-- On resume, the following checks are performed:
-  - Heartbeat file missing → crashed
-  - Heartbeat status is stopped/exited → crashed
-  - PID no longer exists → crashed
-  - Timestamp older than 30 seconds → crashed
+```bash
+find .agentloom/checkpoints/<application_id>/<task_id> -maxdepth 5 -type f -print
+```
 
 ## Troubleshooting
 
-### Resume fails: "No checkpoint found"
+### Resume fails: `No checkpoint found`
 
-Confirm that a `task_id` directory exists under `.logs/{agent_name}/{timestamp}/checkpoints/`. Use `loom list-tasks` to see available tasks.
+Run `loom list-tasks --detail` and confirm the task is under the same `application_id` as the workflow being resumed. Checkpoint lookup is Application-scoped.
 
-### Resume fails: "Checkpoint expired"
+### Resume fails: `Checkpoint expired`
 
-The checkpoint has exceeded the `max_resume_age` retention period (default 7 days).
+The logical task's original `created_at` exceeds `checkpoint.max_resume_age`. Migration and resume do not rewrite `created_at` to revive expired work.
 
-### Resume fails: "checkpoint is disabled"
+### `runtime.log` is absent
 
-Check that `checkpoint.enabled` is set to `true` in `config/system.yaml`.
+Check `logging.file_enabled` and whether the attempt used `--no-file-log`. A missing file log does not disable checkpoints or the Shell audit.
+
+### `.logs` still exists
+
+New runs do not write `.logs`. Use `loom migrate-runtime --dry-run`, review the result, then `--apply` to archive the legacy tree. Do not delete it before validating resumable tasks.

--- a/docs/en/config-overview.md
+++ b/docs/en/config-overview.md
@@ -57,6 +57,32 @@ context_engine:
 
 Do not add a second retrieval path or a disable switch around ContextEngine. Large tool/worker output should be restored through `loom_retrieve_context` and `ContextRef`.
 
+### Runtime storage ownership
+
+`runtime` and `logging` are global-only sections in `config/system.yaml`; Application-level `config/system.yaml` files and Agent YAML cannot move the runtime root or replace the logging policy. This preserves one task-discovery and retention boundary per process.
+
+Isolated subprocesses may override the complete runtime home with `AGENTLOOM_RUNTIME_ROOT`; the override never moves self-learning alone.
+
+```yaml
+runtime:
+  root_dir: ".agentloom"
+  successful_run_retention_days: 7
+  failed_run_retention_days: 30
+  artifact_retention_days: 3
+  cleanup_interval_hours: 24
+
+logging:
+  level: "INFO"
+  console_enabled: true
+  file_enabled: true
+  max_file_bytes: 26214400
+  backup_count: 3
+```
+
+Every attempt writes `.agentloom/runs/<application_id>/<run_id>/{manifest.json,logs,audit,artifacts}`. Resume creates a new `run_id` but keeps the logical task's `task_id` and `.agentloom/checkpoints/<application_id>/<task_id>/`. The Agent-visible `.runtime/` workspace and Application-owned `output_dir` are separate storage domains.
+
+File logging follows `logging.file_enabled` and is bounded by size/backup count. `loom run --no-file-log` disables only the current attempt's file log; it does not disable checkpoints or Shell audit. `loom clean-runtime` applies run retention, while `loom migrate-runtime --dry-run|--apply` handles one-time legacy `.logs` migration.
+
 ## 3. Complete Isolation of LLM Configuration
 
 In AgentLoom, **LLM configuration (`llm.yaml`) is physically isolated from system configuration (`system.yaml`)**.

--- a/docs/en/system_config.md
+++ b/docs/en/system_config.md
@@ -24,7 +24,7 @@ The configuration loading order is `config/system.yaml` → `config/llm.yaml` �
 - [5. lsp_servers — LSP Language Server Configuration](#5-lsp_servers--lsp-language-server-configuration)
 - [6. execution_env — Execution Environment Configuration](#6-execution_env--execution-environment-configuration)
 - [6. code_agent — CodeAgent Code Execution Permissions](#6-code_agent--codeagent-code-execution-permissions)
-- [7. logging — Logging Configuration](#7-logging--logging-configuration)
+- [7. runtime and logging — Runtime Storage and Logging](#7-runtime-and-logging--runtime-storage-and-logging)
 - [8. tools — Tool System Configuration](#8-tools--tool-system-configuration)
 - [9. tool_access_control — Tool Access Control](#9-tool_access_control--tool-access-control)
 - [10. tool_metadata — Tool Metadata Configuration](#10-tool_metadata--tool-metadata-configuration)
@@ -92,13 +92,24 @@ code_agent:
   additional_functions: "*"
 
 # ============================================
+# Runtime Storage and Retention
+# ============================================
+runtime:
+  root_dir: ".agentloom"
+  successful_run_retention_days: 7
+  failed_run_retention_days: 30
+  artifact_retention_days: 3
+  cleanup_interval_hours: 24
+
+# ============================================
 # Logging Configuration
 # ============================================
 logging:
-  enabled: true
   level: "INFO"
-  file_path: null
-  dir: ".logs"
+  console_enabled: true
+  file_enabled: true
+  max_file_bytes: 26214400
+  backup_count: 3
 
 # ============================================
 # Default Toolsets
@@ -752,65 +763,55 @@ code_agent:
 
 ---
 
-## 7. logging — Logging Configuration
+## 7. runtime and logging — Runtime Storage and Logging
 
-Controls the verbosity and output destination of system logs. The unified logging entry point is `src.lib.logging`, managed as "one log file per Python process lifecycle".
+`runtime` defines the single framework-owned storage root and bounded retention. `logging` controls the console and the run-scoped file backend. Logger state is bound to the current run; it is not shared as a process-global output path.
 
-**YAML path**: `logging.*`
+Both sections are global-only. Application-level `config/system.yaml` and Agent YAML containing either section are rejected, so a typo or misplaced override cannot silently fragment—or pretend to move—task discovery across runtime roots.
+
+An isolated subprocess or validation harness may set `AGENTLOOM_RUNTIME_ROOT`. It overrides the complete canonical runtime home—runs, checkpoints, sessions, learning, and `self_learning.db` move together; there is no self-learning-only root override.
+
+**YAML paths**: `runtime.*`, `logging.*`
 
 | Parameter | Type | Default | Required | Description |
 |------|------|--------|------|------|
-| `logging.enabled` | `bool` | `true` | ❌ No | Whether to enable the logging system |
-| `logging.level` | `str` | `"INFO"` | ❌ No | Log filtering level (case-insensitive) |
-| `logging.file_path` | `str` \| `null` | `null` | ❌ No | Specify log file path. Auto-generated when `null` |
-| `logging.dir` | `str` | `".logs"` | ❌ No | Root directory for auto-generated logs |
+| `runtime.root_dir` | `str` | `".agentloom"` | ❌ No | Only root for framework runtime state. Relative paths resolve from the project root; absolute paths are accepted |
+| `runtime.successful_run_retention_days` | `int` | `7` | ❌ No | Retention for completed run directories |
+| `runtime.failed_run_retention_days` | `int` | `30` | ❌ No | Retention for failed/interrupted run directories |
+| `runtime.artifact_retention_days` | `int` | `3` | ❌ No | Retention for raw `artifacts/` inside a retained run |
+| `runtime.cleanup_interval_hours` | `int` | `24` | ❌ No | Minimum interval between automatic cleanup attempts |
+| `logging.level` | `str` \| `int` | `"INFO"` | ❌ No | Log filtering level (case-insensitive) |
+| `logging.console_enabled` | `bool` | `true` | ❌ No | Write formatted runtime messages to the console |
+| `logging.file_enabled` | `bool` | `true` | ❌ No | Write the current attempt to `logs/runtime.log` |
+| `logging.max_file_bytes` | `int` | `26214400` | ❌ No | Maximum bytes per runtime log segment (25 MiB) |
+| `logging.backup_count` | `int` | `3` | ❌ No | Number of rotated runtime log segments |
 
-### 7.1 logging.level Details
+### 7.1 Canonical paths and lifecycle
 
-The framework uses `LogLevelParser` to read `logging.level`, supporting standard `logging` levels and the special value `OFF`:
+Each attempt writes under `.agentloom/runs/<application_id>/<run_id>/`:
 
-| Value | Meaning | Use Case |
-|----|------|----------|
-| `"DEBUG"` | Pass through all framework internal flow details | Troubleshooting, inspecting underlying requests |
-| `"INFO"` | **(Default)** Display core runtime status and step prompts | Daily use |
-| `"WARNING"` / `"WARN"` | Suppress normal flow, only expose warnings and alerts | Simplified output |
-| `"ERROR"` | Only capture exceptions and errors | Production environments |
-| `"CRITICAL"` | Only capture severe exceptions | Extremely minimal |
-| `"OFF"` | Completely disable logging (actually sets to `CRITICAL + 10`) | Silent mode |
-
-Integer values are also supported (e.g., `10` = DEBUG, `20` = INFO, `30` = WARNING).
-
-### 7.2 logging.file_path and logging.dir
-
-- When `file_path` specifies a concrete path, the current process writes to that file throughout its lifetime
-- When `file_path` is `null`, the framework auto-generates log files under the `dir` directory, with naming convention:
-  - `{logging.dir}/{app_name}/{timestamp}/{app_name}.log`
-  - Shell audit logs from the same run are co-located in the same timestamp directory: `{logging.dir}/{app_name}/{timestamp}/shell_audit.log`
-  - If multiple runs start within the same second, the timestamp directory name automatically appends a suffix `_1`, `_2` to avoid overwriting
-
-**Examples**:
-
-```yaml
-# Default configuration (auto log file)
-logging:
-  enabled: true
-  level: "INFO"
-  file_path: null
-  dir: ".logs"
-
-# Debug mode (specified log file)
-logging:
-  enabled: true
-  level: "DEBUG"
-  file_path: "/tmp/agent_loom_debug.log"
-
-# Silent mode
-logging:
-  enabled: true
-  level: "OFF"
+```text
+manifest.json
+logs/runtime.log[.1-.3]
+audit/shell.jsonl[.1-.2]
+artifacts/{shell,background,skills}/
 ```
 
-> **Note**: Due to security and configuration isolation mechanisms, configuring `logging` in Agent YAML or application-level `system.yaml` is ineffective (it will be filtered and ignored by the system). All logging policies must be configured uniformly in the top-level global `config/system.yaml`.
+The Shell audit uses its own fixed 10 MiB segments and two backups. A resumed task receives a new `run_id` and run directory while keeping its original `task_id` and `.agentloom/checkpoints/<application_id>/<task_id>/` state. File logging can be disabled without disabling the checkpoint or Shell audit:
+
+```bash
+loom run applications/<app>/workflows/<agent>.yaml --no-file-log
+```
+
+There is no `--log-to-file`, `logging.enabled`, `logging.dir`, or `logging.file_path` compatibility path.
+
+### 7.2 Retention and storage boundaries
+
+Automatic cleanup runs at most once per configured interval. `loom clean-runtime` applies the policy explicitly. It only deletes eligible run directories or their raw artifacts; it never traverses checkpoints, `.agentloom/legacy/`, `.runtime/`, or Application-owned output directories.
+
+`.runtime/` remains the Agent-visible recall/todo workspace and is semantically independent from `.agentloom/`. `loom migrate-runtime --dry-run` previews valid legacy checkpoint candidates; `loom migrate-runtime --apply` migrates them and archives the complete old `.logs` tree under `.agentloom/legacy/`.
+
+To verify a real attempt, read `manifest.json`, `logs/runtime.log`, and `audit/shell.jsonl`; an exit code alone is not sufficient.
 
 ---
 
@@ -1197,7 +1198,7 @@ tool_output_limits:
 
 ---
 
-## 10. checkpoint — Checkpoint, Resume & Heartbeat
+## 12. checkpoint — Checkpoint, Resume & Heartbeat
 
 Controls Agent task **checkpoint/resume**, **heartbeat monitoring**, and **crash detection**. Enabled globally by default — every application built on AgentLoom gains this capability automatically with no extra configuration required.
 
@@ -1210,44 +1211,44 @@ Controls Agent task **checkpoint/resume**, **heartbeat monitoring**, and **crash
 | `checkpoint.max_resume_age` | `int` (sec) | `604800` | ❌ No | Maximum checkpoint retention period (7 days). Checkpoints older than this are treated as expired and cannot be resumed |
 | `checkpoint.heartbeat_interval` | `int` (sec) | `5` | ❌ No | Heartbeat file write interval. A daemon thread writes process state (PID, step count, timestamp) to disk at this frequency for crash detection |
 
-### 10.1 Runtime Directory Structure
+### 12.1 Runtime Directory Structure
 
-Checkpoint data is written inside each run's timestamp log directory, co-located with the run log:
+Run evidence and task recovery state have independent lifecycles under the same runtime root:
 
-```
-.logs/{supervisor_name}/
-├── .task_index.json                        # Index: task_id → timestamp mapping (for fast --resume lookup)
-├── 20260413_104447/                        # Per-run timestamp directory
-│   ├── {supervisor_name}.log               # Run log
-│   └── checkpoints/{task_id}/              # Checkpoint data for this run
-│       ├── task_tree.json                  # Task metadata (status, worker call records, created_at)
-│       ├── checkpoint.json                 # Supervisor Agent memory steps snapshot
-│       ├── heartbeat.json                  # Supervisor heartbeat (pid, timestamp, step, status)
-│       ├── file-history/                   # File edit history backups
-│       └── workers/{worker_name}/
-│           ├── checkpoint.json             # Worker Agent memory snapshot per call
-│           └── heartbeat.json              # Worker heartbeat (aggregated across concurrent calls)
-└── 20260413_104837/
-    ├── {supervisor_name}.log
-    └── checkpoints/{task_id}/
-        └── ...
+```text
+.agentloom/
+├── runs/<application_id>/<run_id>/
+│   ├── manifest.json
+│   ├── logs/runtime.log[.1-.3]
+│   ├── audit/shell.jsonl[.1-.2]
+│   └── artifacts/{shell,background,skills}/
+└── checkpoints/<application_id>/<task_id>/
+    ├── task_events.jsonl
+    ├── task_tree.json
+    ├── checkpoint.json
+    ├── heartbeat.json
+    ├── workers/<worker_name>/calls/<call_index>/checkpoint.json
+    ├── context_store/
+    └── file-history/
 ```
 
 **Key design decisions**:
-- Checkpoints always remain in the timestamp directory where they were first created; they are not migrated on resume
-- `.task_index.json` records the `task_id → timestamp` mapping for O(1) lookup during `--resume`
-- If the index is lost, the system automatically scans all timestamp directories as a degraded fallback
+- `run_id` changes for every attempt; `task_id` remains stable across resume
+- The run manifest records `task_id`; checkpoint run events and heartbeat record the current `run_id`
+- Checkpoint lookup uses the canonical Application/task path and never depends on logs, `.task_index.json`, or a legacy scan
+- Log closing, rotation, and runtime retention cannot remove checkpoint state
+- `.runtime/` remains a separate Agent-visible workspace; Application `output_dir` remains Application-owned
 
 > For the full Checkpoint & Resume reference, see [Checkpoint & Resume](checkpoint.md).
 
-### 10.2 Heartbeat Mechanism & Crash Detection
+### 12.2 Heartbeat Mechanism & Crash Detection
 
 The framework maintains two levels of heartbeat:
 
 | Level | File Location | Payload Fields |
 |-------|--------------|----------------|
-| **Supervisor** | `{task_id}/heartbeat.json` | `pid`, `timestamp`, `timestamp_iso`, `status`, `step`, `agent_name` |
-| **Worker** | `{task_id}/workers/{name}/heartbeat.json` | `agent_name`, `pid`, `timestamp`, `calls` (per concurrent call: `status`, `step`, `started_at`, `finished_at`) |
+| **Supervisor** | `{task_id}/heartbeat.json` | `pid`, `run_id`, `timestamp`, `timestamp_iso`, `status`, `step`, `agent_name` |
+| **Worker** | `{task_id}/workers/{name}/heartbeat.json` | `agent_name`, `run_id`, `pid`, `timestamp`, `calls` (per concurrent call: `status`, `step`, `started_at`, `finished_at`) |
 
 **Crash detection logic** (`HEARTBEAT_STALE_THRESHOLD = 30` seconds):
 
@@ -1257,15 +1258,16 @@ The framework maintains two levels of heartbeat:
 4. Heartbeat timestamp older than 30 seconds → `crashed`
 5. None of the above → `running`
 
-### 10.3 Resume Flow
+### 12.3 Resume Flow
 
 When a checkpoint for a `task_id` is found within `max_resume_age` and its status is non-normal (`crashed`/`interrupted`), the framework automatically:
 
 1. Restores Supervisor memory steps from `checkpoint.json` (skipping already-completed reasoning steps)
-2. For each Worker call, checks the `input_hash` cache in `task_tree.json` — if the input matches and the call completed, returns the cached result (skips re-execution)
-3. Continues execution from the interruption point until the task completes
+2. Restores the task-scoped ContextStore and file-history index
+3. For each Worker call, resumes incomplete memory under the same `call_index`, or returns a completed cached result when `input_hash` matches
+4. Creates a new run directory and continues with a new `run_id` until the task completes
 
-### 10.4 Configuration Examples
+### 12.4 Configuration Examples
 
 ```yaml
 # Debug scenario: retain checkpoints, shorten resume window
@@ -1295,6 +1297,8 @@ The framework uses Pydantic to validate system configuration. The following show
 | `system.*` | `SystemSettings` | `src/lib/config/config_validation.py` |
 | `model_request_headers.*` | `ModelRequestHeadersSettings` | `src/lib/config/config_validation.py` |
 | `tool_access_control.*` | `ToolAccessControlSettings` | `src/lib/config/config_validation.py` |
+| `runtime.*` | `RuntimeSettings` | `src/lib/config/config_validation.py` |
+| `logging.*` | `LoggingSettings` | `src/lib/config/config_validation.py` |
 
 **`RootSettings` complete field definitions**:
 
@@ -1303,6 +1307,8 @@ The framework uses Pydantic to validate system configuration. The following show
 | `system` | `SystemSettings` | `SystemSettings()` |
 | `model_request_headers` | `ModelRequestHeadersSettings` | `ModelRequestHeadersSettings()` |
 | `tool_access_control` | `ToolAccessControlSettings` | `ToolAccessControlSettings()` |
+| `runtime` | `RuntimeSettings` | `RuntimeSettings()` |
+| `logging` | `LoggingSettings` | `LoggingSettings()` |
 | `smart_summary` | `bool` | `True` |
 | `model` | `dict[str, Any]` | `{}` |
 | `execution_env` | `dict[str, Any]` | `{}` |
@@ -1311,13 +1317,13 @@ The framework uses Pydantic to validate system configuration. The following show
 | `tool_metadata` | `dict[str, Any]` | `{}` |
 | `tool_output_limits` | `dict[str, Any]` | `{}` |
 
-> All models are set with `extra="allow"`, allowing extension fields. `prompt` is one such top-level extra key, passed through via overlay merging to the final configuration, but not as an explicit `RootSettings` field.
+> `RootSettings` allows extension fields, so top-level fields such as `prompt` can participate in overlay merging. `RuntimeSettings` and `LoggingSettings` deliberately use `extra="forbid"`; removed runtime/logging keys fail validation instead of silently selecting a second storage path.
 
 **Fault-tolerant parsing tool set**:
 
 | Parser | Purpose | Located in |
 |--------|------|------|
-| `BoolParser` | Compatible boolean input normalization, used for `logging.enabled`, Skill `allow-scripts` / `allow-network` parsing, and some LLM config switches | `config_validation.py` / `src/lib/logging/logger_manager.py` / `src/lib/smolagents/agent/base_agent.py` / `src/lib/config/llm_config.py` |
+| `BoolParser` | Compatible boolean input normalization, used for `logging.console_enabled` / `logging.file_enabled`, Skill `allow-scripts` / `allow-network`, and some LLM config switches | `config_validation.py` / `src/lib/logging/logger_manager.py` / `src/lib/smolagents/agent/base_agent.py` / `src/lib/config/llm_config.py` |
 | `IntParser` | Compatible integer and bypass string input, used for `max_tokens` in model config (supports `"max"`) | `config_validation.py` / `src/lib/config/llm_config.py` |
 | `FloatParser` | Compatible float and integer string input, used for `temperature`, `retry_delay`, `max_retry_delay` in model config | `config_validation.py` / `src/lib/config/llm_config.py` |
 | `EnumParser` | General-purpose enum normalization helper, not currently consumed directly in the system.yaml main pipeline | `config_validation.py` |
@@ -1375,7 +1381,9 @@ The following table shows the support status of each configuration key at differ
 | `system` | ✅ Supported | ✅ Supported | ✅ Supported |
 | `smart_summary` | ✅ Supported | ✅ Supported | ✅ Supported |
 | `skills` | ✅ Supported | ✅ Supported | ✅ Supported (Agent private) |
-| `logging` | ✅ Supported | ❌ Ignored | ❌ Ignored |
+| `runtime` | ✅ Supported | ❌ Rejected | ❌ Rejected |
+| `logging` | ✅ Supported | ❌ Rejected | ❌ Rejected |
+| `checkpoint` | ✅ Supported | ✅ Supported | ❌ Ignored |
 | `tool_access_control` | ✅ Supported | ✅ Supported | ✅ Supported |
 | `execution_env` | ✅ Supported | ✅ Supported | ✅ Supported |
 | `code_agent` | ✅ Supported | ✅ Supported | ✅ Supported |
@@ -1401,28 +1409,3 @@ tool_access_control:
 - `system.name`: Remains `"AgentLoom"` ✅ Inherited from global
 - `logging.level`: Remains `"INFO"` ✅ Inherited from global
 - All other fields: Remain at global configuration values ✅
-
----
-
-## 12. checkpoint — Checkpoint, Resume & Heartbeat
-
-Controls task checkpoint/resume and heartbeat monitoring behavior. See [checkpoint.md](../cn/checkpoint.md) for detailed documentation.
-
-**YAML path**: `checkpoint.*`
-
-| Parameter | Type | Default | Required | Description |
-|------|------|--------|------|------|
-| `checkpoint.enabled` | `bool` | `true` | ❌ No | Global switch: enable/disable checkpoint & resume |
-| `checkpoint.cleanup_on_success` | `bool` | `true` | ❌ No | Auto-delete checkpoint directory after successful completion |
-| `checkpoint.max_resume_age` | `int` | `604800` | ❌ No | Max checkpoint retention in seconds (default 7 days) |
-| `checkpoint.heartbeat_interval` | `float` | `5.0` | ❌ No | Heartbeat write interval (seconds) for crash detection |
-
-**Example**:
-
-```yaml
-checkpoint:
-  enabled: true
-  cleanup_on_success: true
-  max_resume_age: 604800
-  heartbeat_interval: 5
-```

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -110,21 +110,30 @@ _RUN_EPILOG = """\
 \b
 Examples:
   loom run applications/test_demo/workflows/test_agent.yaml
-  loom run applications/test_demo/workflows/test_agent.yaml --log-to-file
+  loom run applications/test_demo/workflows/test_agent.yaml --no-file-log
   loom run applications/test_demo/workflows/test_agent.yaml --resume task_xxx
 """
 
 
 @main.command(epilog=_RUN_EPILOG)
 @click.argument("yaml_path")
-@click.option("--log-to-file", is_flag=True, default=False, help="Persist logs to a file.")
+@click.option(
+    "--no-file-log",
+    is_flag=True,
+    default=False,
+    help="Disable this run's file log (configuration is used by default).",
+)
 @click.option("--resume", "resume_task_id", default=None, help="Resume from a checkpoint task ID.")
-def run(yaml_path: str, log_to_file: bool, resume_task_id: str | None):
+def run(yaml_path: str, no_file_log: bool, resume_task_id: str | None):
     """Run a supervisor agent from a YAML configuration."""
     from src.runner import run_app
 
     try:
-        result = run_app(yaml_path, log_to_file=log_to_file, resume_task_id=resume_task_id)
+        result = run_app(
+            yaml_path,
+            file_logging=False if no_file_log else None,
+            resume_task_id=resume_task_id,
+        )
         click.echo(result)
     except KeyboardInterrupt as exc:
         click.echo("\nInterrupted. Use --resume to continue.", err=True)
@@ -143,15 +152,31 @@ def run(yaml_path: str, log_to_file: bool, resume_task_id: str | None):
 # loom list-tasks
 # ─────────────────────────────────────────────
 
+def _configured_runtime_home():
+    from src.lib.config import C
+    from src.lib.runtime import resolve_runtime_home
+
+    return resolve_runtime_home(C.raw, agent_root=C.agent_root)
+
+
+def _configured_checkpoints_root():
+    try:
+        return _configured_runtime_home().checkpoints_root
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 @main.command("list-tasks")
 @click.option("--detail", is_flag=True, default=False, help="Show worker-level details.")
 def list_tasks(detail: bool):
-    """List all resumable checkpoint tasks."""
+    """List all retained checkpoint tasks."""
     from src.lib.checkpoint.checkpoint_manager import list_all_tasks
 
-    tasks = list_all_tasks()
+    tasks = list_all_tasks(
+        checkpoints_root=_configured_checkpoints_root()
+    )
     if not tasks:
-        click.echo("No resumable tasks found.")
+        click.echo("No checkpoint tasks found.")
         return
 
     _ICONS = {"interrupted": "⏸", "failed": "❌", "running": "🔄", "completed": "✅", "crashed": "💥"}
@@ -193,39 +218,121 @@ def list_tasks(detail: bool):
 @click.option("--before", "before_days", type=int, default=None, help="Remove checkpoints older than N days.")
 def clean_tasks(clean_all: bool, before_days: int | None):
     """Clean old checkpoint data."""
-    from src.lib.checkpoint.checkpoint_manager import _resolve_checkpoint_base_dir
+    from pathlib import Path as _Path
 
-    base_dir = _resolve_checkpoint_base_dir()
-    if not base_dir.exists():
+    from src.lib.checkpoint import (
+        cleanup_expired_tasks,
+        delete_checkpoint_task_if_inactive,
+    )
+    from src.lib.checkpoint.checkpoint_manager import list_all_tasks
+
+    checkpoints_root = _configured_checkpoints_root()
+    tasks = list_all_tasks(checkpoints_root=checkpoints_root)
+    if not tasks:
         click.echo("No checkpoints to clean.")
         return
 
-    total_removed = 0
-    for agent_dir in base_dir.iterdir():
-        if not agent_dir.is_dir():
-            continue
-        # Check if any child contains checkpoint data (v2 or legacy layout).
-        has_ckpt = False
-        for child in agent_dir.iterdir():
-            if not child.is_dir() or child.name.startswith("."):
-                continue
-            if child.name == "checkpoints":
-                has_ckpt = True
-                break
-            if (child / "checkpoints").is_dir():
-                has_ckpt = True
-                break
-        if not has_ckpt:
-            continue
-        from src.lib.checkpoint import CheckpointManager
-        cm = CheckpointManager(agent_dir.name, base_dir=base_dir)
-        if clean_all:
-            total_removed += cm.cleanup_old_tasks(max_age_seconds=0)
-        elif before_days is not None:
-            total_removed += cm.cleanup_old_tasks(max_age_seconds=before_days * 86400)
-        else:
-            total_removed += cm.cleanup_old_tasks()  # default: 7 days
+    max_age_seconds = (before_days if before_days is not None else 7) * 86400
+    if clean_all:
+        total_removed = sum(
+            int(delete_checkpoint_task_if_inactive(_Path(str(task["checkpoint_dir"]))))
+            for task in tasks
+        )
+    else:
+        total_removed = cleanup_expired_tasks(
+            checkpoints_root=checkpoints_root,
+            max_age_seconds=max_age_seconds,
+        )
     click.echo(f"Cleaned {total_removed} checkpoint(s).")
+
+
+# ─────────────────────────────────────────────
+# loom clean-runtime / migrate-runtime
+# ─────────────────────────────────────────────
+
+@main.command("clean-runtime")
+def clean_runtime_command() -> None:
+    """Apply bounded retention to run directories and raw artifacts."""
+    from src.lib.config import C
+    from src.lib.runtime.retention import clean_runtime
+
+    runtime_config = C.get("runtime", {})
+    if not isinstance(runtime_config, dict):
+        runtime_config = {}
+    home = _configured_runtime_home()
+    try:
+        home.validate_root()
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    result = clean_runtime(
+        home.root_dir,
+        config=runtime_config,
+    )
+    if result.skipped:
+        reason = result.skip_reason or "runtime cleanup did not run"
+        raise click.ClickException(f"runtime cleanup skipped: {reason}")
+    click.echo(
+        "Cleaned runtime: "
+        f"runs={result.removed_run_count}, "
+        f"artifacts={result.removed_artifact_count}, "
+        f"reclaimed_bytes={result.reclaimed_bytes}."
+    )
+    for error in result.errors:
+        click.echo(f"warning: {error}", err=True)
+
+
+@main.command("migrate-runtime")
+@click.option(
+    "--dry-run/--apply",
+    default=True,
+    show_default=True,
+    help="Preview candidates or atomically migrate and archive legacy .logs.",
+)
+def migrate_runtime_command(dry_run: bool) -> None:
+    """One-time migration of valid legacy checkpoints into runtime home."""
+    from datetime import timedelta as _timedelta
+    from pathlib import Path as _Path
+
+    from src.lib.config import C
+    from src.lib.runtime.migration import migrate_runtime
+
+    max_age = _timedelta(days=7)
+
+    home = _configured_runtime_home()
+    try:
+        home.validate_root()
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    legacy_logs = _Path(C.agent_root) / ".logs"
+    try:
+        result = migrate_runtime(
+            legacy_logs,
+            home.root_dir,
+            dry_run=dry_run,
+            archive_legacy=not dry_run,
+            agent_root=C.agent_root,
+            max_age=max_age,
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(
+        f"Runtime migration ({'dry-run' if dry_run else 'apply'}): "
+        f"candidates={result.plan.candidate_count}, "
+        f"skipped={result.plan.skipped_count}, "
+        f"migrated={result.migrated_count}, "
+        f"already_migrated={result.already_migrated_count}."
+    )
+    for candidate in result.plan.candidates:
+        progress = ",".join(candidate.progress_kinds)
+        click.echo(
+            f"  migrate {candidate.task_id} -> {candidate.application_id} "
+            f"[{progress}]"
+        )
+    for skipped in result.plan.skipped:
+        click.echo(f"  skip {skipped.task_id}: {skipped.reason}")
+    if result.archive_dir is not None:
+        click.echo(f"Archived legacy logs: {result.archive_dir}")
 
 
 # ─────────────────────────────────────────────
@@ -514,7 +621,7 @@ def skill_proposals_archive(proposal_id: str):
 @main.command("dashboard")
 def dashboard():
     """Launch the terminal TUI task monitoring dashboard (Textual)."""
-    from src.framework.ui.dashboard import run_dashboard
+    from src.ui.dashboard import run_dashboard
 
     run_dashboard()
 

--- a/src/extensions/self_learning/paths.py
+++ b/src/extensions/self_learning/paths.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Any
 
@@ -31,20 +30,39 @@ def _config_section() -> dict[str, Any]:
         return {}
 
 
+def _runtime_config_section() -> dict[str, Any]:
+    try:
+        from src.lib.config import C
+
+        section = C.get("runtime", {})
+        return section if isinstance(section, dict) else {}
+    except Exception:
+        return {}
+
+
 def self_learning_root(root: str | Path | None = None) -> Path:
     """Return the durable state root, defaulting to ``.agentloom``."""
     if root is not None:
         return Path(root).expanduser().resolve()
 
-    env_root = os.environ.get("AGENTLOOM_SELF_LEARNING_ROOT", "").strip()
-    if env_root:
-        return Path(env_root).expanduser().resolve()
+    # A running Application has one canonical runtime home.  Do not let a
+    # legacy standalone/test override split sessions or memory from that run's
+    # logs and checkpoints.
+    try:
+        from src.lib.runtime import get_current_run_context
 
-    configured = _config_section().get("root_dir", ".agentloom")
-    path = Path(str(configured)).expanduser()
-    if not path.is_absolute():
-        path = project_root() / path
-    return path.resolve()
+        runtime_context = get_current_run_context()
+        if runtime_context is not None:
+            return runtime_context.root_dir
+    except Exception:
+        pass
+
+    from src.lib.runtime import resolve_runtime_home
+
+    return resolve_runtime_home(
+        {"runtime": _runtime_config_section()},
+        agent_root=project_root(),
+    ).root_dir
 
 
 def config_bool(name: str, default: bool = True) -> bool:

--- a/src/lib/checkpoint/__init__.py
+++ b/src/lib/checkpoint/__init__.py
@@ -8,7 +8,11 @@ Provides:
 """
 
 from src.lib.checkpoint.serializer import CheckpointSerializer
-from src.lib.checkpoint.checkpoint_manager import CheckpointManager
+from src.lib.checkpoint.checkpoint_manager import (
+    CheckpointManager,
+    cleanup_expired_tasks,
+    delete_checkpoint_task_if_inactive,
+)
 from src.lib.checkpoint.coordinator import CheckpointCoordinator
 from src.lib.checkpoint.conversation_recovery import (
     TurnInterruptionState,
@@ -17,6 +21,8 @@ from src.lib.checkpoint.conversation_recovery import (
 
 __all__ = [
     "CheckpointManager",
+    "cleanup_expired_tasks",
+    "delete_checkpoint_task_if_inactive",
     "CheckpointSerializer",
     "CheckpointCoordinator",
     "TurnInterruptionState",

--- a/src/lib/checkpoint/checkpoint_manager.py
+++ b/src/lib/checkpoint/checkpoint_manager.py
@@ -1,24 +1,19 @@
 """
 Checkpoint persistence manager.
 
-Manages the on-disk checkpoint tree under::
+Manages one canonical task checkpoint tree under::
 
-    {logging.dir}/{supervisor_name}/{timestamp}/checkpoints/{task_id}/
+    {runtime.root_dir}/checkpoints/{application_id}/{task_id}/
         task_events.jsonl
         task_tree.json
         heartbeat.json
         checkpoint.json                          # supervisor
         workers/{worker_name}/calls/{call_index}/checkpoint.json
 
-Checkpoint data lives inside the per-run timestamp log directory so that
-all artefacts for a single run (log, checkpoint, file-history) are
-co-located.  A lightweight index file (``.task_index.json``) under each
-agent directory maps ``task_id`` to the ``timestamp`` directory name,
-enabling fast lookup during ``--resume``.
-
-The base directory defaults to the ``logging.dir`` setting from
-``config/system.yaml`` (typically ``.logs``).  Override via ``base_dir``
-constructor arg or the ``AGENT_LOOM_RUNTIME_ROOT`` env var.
+The directory is task-scoped and deliberately independent from run logs.
+Each resume attempt writes a new run directory while continuing to use this
+same task directory.  Lookup is therefore a direct path operation: there is
+no task index, log-directory scan, or legacy runtime fallback.
 
 All writes are **atomic**: data is flushed to a ``.tmp`` file first and
 then renamed, so a crash mid-write never corrupts the checkpoint.
@@ -26,78 +21,114 @@ then renamed, so a crash mid-write never corrupts the checkpoint.
 
 from __future__ import annotations
 
+import fcntl
 import json
+import math
 import os
 import shutil
 import time
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from src.lib.checkpoint.serializer import CheckpointSerializer
 from src.lib.heartbeat.status import (
     detect_crashed_status as _detect_crashed_status,
+)
+from src.lib.heartbeat.status import (
     detect_worker_call_crashed as _detect_worker_call_crashed,
 )
 from src.lib.logging import get_logger
+from src.lib.runtime import SecureDirectory, portable_runtime_component
 
 _logger = get_logger(__name__)
 
 
-# =========================================================================
-# Runtime-root resolution
-# =========================================================================
+@dataclass(frozen=True, slots=True)
+class WorkerCallPreparation:
+    """Atomic decision for one worker invocation in the current attempt."""
 
-def _find_agent_loom_root() -> Path:
-    """Derive the AgentLoom project root directory.
-
-    Resolution order mirrors ``skills/agent-recall-with-files/scripts/common.py``.
-    """
-    env_root = os.environ.get("AGENT_LOOM_RUNTIME_ROOT", "").strip()
-    if env_root:
-        return Path(env_root)
-
-    current = Path(__file__).resolve().parent
-    while current != current.parent:
-        if (current / "config" / "llm.yaml").exists():
-            return current
-        current = current.parent
-
-    candidate = Path(__file__).resolve().parent.parent.parent.parent
-    if (candidate / "pyproject.toml").exists():
-        return candidate
-
-    return Path.cwd()
+    call_index: int
+    should_execute: bool
+    cached_result: Any = None
 
 
-def _resolve_checkpoint_base_dir() -> Path:
-    """Return the base directory for all checkpoint data.
+def _require_safe_path_component(value: Any, *, field: str) -> str:
+    """Validate an identifier before it participates in a filesystem path."""
+    if (
+        not isinstance(value, str)
+        or not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or "\x00" in value
+    ):
+        raise ValueError(f"{field} must be one safe path component")
+    return value
 
-    Resolution order:
-    1. ``AGENT_LOOM_RUNTIME_ROOT`` env var  →  ``{value}/.logs``
-       (allows tests and CI to redirect all runtime artefacts)
-    2. ``logging.dir`` from ``config/system.yaml``
-    3. Fallback: ``{project_root}/.logs``
 
-    The result is that checkpoint files live alongside agent run logs
-    under the same root directory (typically ``.logs/``).
-    """
-    # 1. Env-var override (tests / CI).
-    env_root = os.environ.get("AGENT_LOOM_RUNTIME_ROOT", "").strip()
-    if env_root:
-        return Path(env_root).resolve()
+def _require_call_index(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError("call_index must be a non-negative integer")
+    return value
 
-    # 2. Config-driven.
-    try:
-        from src.lib.config import C
-        log_dir = C.get_nested("logging", "dir", default=".logs")
-    except Exception:
-        log_dir = ".logs"
 
-    base = Path(log_dir)
-    if not base.is_absolute():
-        base = _find_agent_loom_root() / base
-    return base.resolve()
+class CheckpointTaskLease:
+    """Exclusive process lease for one logical task checkpoint directory."""
+
+    def __init__(self, task_dir: Path, *, require_exists: bool = False) -> None:
+        self._task_dir = task_dir
+        self._require_exists = require_exists
+        self._fd: int | None = None
+
+    def acquire(self) -> CheckpointTaskLease:
+        if self._fd is not None:
+            return self
+        if self._task_dir.is_symlink():
+            raise RuntimeError(f"checkpoint task directory is a symlink: {self._task_dir}")
+        if self._require_exists:
+            if not self._task_dir.is_dir():
+                raise FileNotFoundError(
+                    f"checkpoint task directory does not exist: {self._task_dir}"
+                )
+        else:
+            self._task_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            fd = os.open(
+                self._task_dir,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
+        except FileNotFoundError:
+            # A concurrent cleaner may win between the existence check and
+            # open.  Resume must fail without recreating an empty checkpoint.
+            raise
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (BlockingIOError, OSError) as exc:
+            os.close(fd)
+            raise RuntimeError(
+                f"checkpoint task is already active: {self._task_dir.name}"
+            ) from exc
+        self._fd = fd
+        return self
+
+    def release(self) -> None:
+        fd, self._fd = self._fd, None
+        if fd is None:
+            return
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+    def __enter__(self) -> CheckpointTaskLease:
+        return self.acquire()
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.release()
 
 
 # =========================================================================
@@ -119,14 +150,12 @@ def _migrate_task_tree_workers(tree: dict) -> dict:
     workers = tree.get("workers")
     if not isinstance(workers, dict):
         return tree
-    migrated = False
     for name, entry in list(workers.items()):
         if isinstance(entry, dict):
             # v1 → v2: wrap single dict in a list
             entry.setdefault("call_index", 0)
             entry.setdefault("input_hash", "")
             workers[name] = [entry]
-            migrated = True
     return tree
 
 
@@ -162,6 +191,19 @@ def _apply_task_event(tree: dict | None, event: dict, fallback_task_id: str = ""
         replaced = event.get("tree") or {}
         if not isinstance(replaced, dict):
             replaced = {}
+        if isinstance(tree, dict):
+            for field in (
+                "task_id",
+                "yaml_path",
+                "agent_name",
+                "task_text",
+                "created_at",
+                "run_id",
+                "last_run_at",
+                "runs",
+            ):
+                if field not in replaced and field in tree:
+                    replaced[field] = tree[field]
         return _migrate_task_tree_workers(_jsonable(replaced))
 
     if tree is None:
@@ -199,6 +241,24 @@ def _apply_task_event(tree: dict | None, event: dict, fallback_task_id: str = ""
         if status == "interrupted":
             tree["interrupted_at"] = event.get("interrupted_at", timestamp)
 
+    elif event_type in {"run_started", "run_resumed"}:
+        run_id = event.get("run_id")
+        if run_id:
+            tree["run_id"] = run_id
+            tree["last_run_at"] = timestamp
+            attempts = tree.setdefault("runs", [])
+            if not isinstance(attempts, list):
+                attempts = []
+                tree["runs"] = attempts
+            attempts.append(
+                {
+                    "run_id": run_id,
+                    "event": event_type,
+                    "started_at": timestamp,
+                }
+            )
+        tree["status"] = "running"
+
     elif event_type == "worker_call_started":
         worker_name = event.get("agent_name") or event.get("worker_name")
         if worker_name:
@@ -222,6 +282,51 @@ def _apply_task_event(tree: dict | None, event: dict, fallback_task_id: str = ""
                     "started_at": event.get("started_at", timestamp),
                 }
             )
+            if event.get("run_id"):
+                call["attempt_run_id"] = event["run_id"]
+            workers[worker_name] = _sorted_worker_calls(calls)
+
+    elif event_type == "worker_call_resume_claimed":
+        worker_name = event.get("agent_name") or event.get("worker_name")
+        if worker_name:
+            calls = workers.setdefault(worker_name, [])
+            if not isinstance(calls, list):
+                calls = [calls]
+                workers[worker_name] = calls
+            call_index = _coerce_call_index(event.get("call_index"), len(calls))
+            call = _find_worker_call(calls, call_index)
+            if call is None:
+                call = {"call_index": call_index, "agent_name": worker_name}
+                calls.append(call)
+            call.update(
+                {
+                    "input_hash": event.get("input_hash", call.get("input_hash", "")),
+                    "agent_name": worker_name,
+                    "status": "running",
+                    "task_input": event.get("task_input", call.get("task_input", "")),
+                    "result": None,
+                    "attempt_run_id": event.get("run_id", ""),
+                    "resume_claimed_at": event.get("claimed_at", timestamp),
+                }
+            )
+            workers[worker_name] = _sorted_worker_calls(calls)
+
+    elif event_type == "worker_call_cached_result_claimed":
+        worker_name = event.get("agent_name") or event.get("worker_name")
+        if worker_name:
+            calls = workers.setdefault(worker_name, [])
+            if not isinstance(calls, list):
+                calls = [calls]
+                workers[worker_name] = calls
+            call_index = _coerce_call_index(event.get("call_index"), len(calls))
+            call = _find_worker_call(calls, call_index)
+            if call is None:
+                call = {"call_index": call_index, "agent_name": worker_name}
+                calls.append(call)
+            # Claiming a cached result is an execution-attempt cursor only.  It
+            # must not change the original call's completed status or result.
+            call["cached_claim_run_id"] = event.get("run_id", "")
+            call["cached_claimed_at"] = event.get("claimed_at", timestamp)
             workers[worker_name] = _sorted_worker_calls(calls)
 
     elif event_type == "worker_call_finished":
@@ -273,116 +378,109 @@ def _project_task_tree_from_events(events: list[dict], fallback_task_id: str = "
 
 
 class CheckpointManager:
-    """Manages checkpoint files for a single supervisor agent.
+    """Manage checkpoint files under a canonical runtime task path.
 
-    Checkpoint layout (v2 — per-run timestamp directory)::
+    Active execution should pass ``checkpoint_dir`` from
+    :class:`src.lib.runtime.RuntimeContext`.  Management and tests may pass an
+    application-level ``checkpoints_root`` and address its tasks by id.
 
-        {base_dir}/{supervisor_name}/{timestamp}/checkpoints/{task_id}/
+    Checkpoint layout::
+
+        {runtime.root_dir}/checkpoints/{application_id}/{task_id}/
             task_events.jsonl
             task_tree.json
             heartbeat.json
             checkpoint.json
             workers/{worker_name}/calls/{call_index}/checkpoint.json
 
-    A lightweight index file keeps the ``task_id → timestamp`` mapping::
-
-        {base_dir}/{supervisor_name}/.task_index.json
-
     Args:
         supervisor_name: The YAML ``name`` field of the supervisor agent.
-        base_dir: Override the logging root (mainly for tests).
-            Defaults to ``logging.dir`` from system config.
-        run_log_dir: The per-run timestamp log directory for the current
-            execution (e.g. ``.logs/agent/20260413_104447/``).  When
-            provided, new checkpoints are stored under this directory.
-            When *None* (e.g. for ``list-tasks`` / ``clean-tasks``),
-            the manager operates in **scan-only** mode and resolves
-            task directories via the index file or directory scan.
+        checkpoint_dir: Canonical path for exactly one logical task.
+        checkpoints_root: Canonical application checkpoint root.  This is
+            intended for task enumeration and isolated tests.
+        run_id: Current execution-attempt id, persisted in run events and
+            exposed to worker heartbeat writers.
     """
 
     def __init__(
         self,
         supervisor_name: str,
-        base_dir: Path | None = None,
-        run_log_dir: Path | None = None,
-    ):
+        *,
+        checkpoint_dir: Path | None = None,
+        checkpoints_root: Path | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        if (checkpoint_dir is None) == (checkpoints_root is None):
+            raise ValueError(
+                "pass exactly one of checkpoint_dir or checkpoints_root"
+            )
         self._supervisor_name = supervisor_name
-        self._explicit_base_dir = base_dir is not None
-        if base_dir is None:
-            base_dir = _resolve_checkpoint_base_dir()
-        self._base_dir = base_dir
-        # Agent-level root: .logs/{supervisor_name}/
-        self._agent_root = base_dir / supervisor_name
-
-        # Per-run checkpoint root.
-        if run_log_dir is not None:
-            run_log_dir = Path(run_log_dir).resolve()
-            if os.environ.get("AGENT_LOOM_RUNTIME_ROOT", "").strip():
-                try:
-                    run_log_dir.relative_to(self._agent_root)
-                except ValueError:
-                    run_log_dir = self._agent_root / run_log_dir.name
-            self._checkpoints_root: Path | None = run_log_dir / "checkpoints"
-        elif self._explicit_base_dir:
-            # Legacy / test mode: caller passed base_dir explicitly but no
-            # run_log_dir.  Fall back to the v1 flat layout for backward
-            # compatibility (tests, CLI scan-then-write).
-            self._checkpoints_root = self._agent_root / "checkpoints"
+        self._run_id = run_id
+        if checkpoint_dir is not None:
+            self._checkpoint_dir = Path(
+                os.path.abspath(os.fspath(Path(checkpoint_dir).expanduser()))
+            )
+            self._checkpoints_root = self._checkpoint_dir.parent
+            self._bound_task_id: str | None = self._checkpoint_dir.name
         else:
-            # Production scan-only mode (list-tasks, clean-tasks).
-            self._checkpoints_root = None
+            self._checkpoints_root = Path(
+                os.path.abspath(os.fspath(Path(checkpoints_root).expanduser()))
+            )
+            self._checkpoint_dir = None
+            self._bound_task_id = None
 
         import threading
         self._tree_lock = threading.Lock()
-        self._index_lock = threading.Lock()
+        self._task_storages: dict[Path, SecureDirectory] = {}
+        if self._checkpoint_dir is not None and self._checkpoint_dir.is_dir():
+            self._task_storages[self._checkpoint_dir] = SecureDirectory(
+                self._checkpoint_dir,
+                create=False,
+            )
+
+    @property
+    def run_id(self) -> str | None:
+        return self._run_id
+
+    @property
+    def checkpoint_dir(self) -> Path | None:
+        return self._checkpoint_dir
+
+    def task_lease(self, *, require_exists: bool = False) -> CheckpointTaskLease:
+        """Return an exclusive lease for this manager's bound task."""
+        if self._checkpoint_dir is None:
+            raise RuntimeError("task_lease requires a manager bound to checkpoint_dir")
+        return CheckpointTaskLease(
+            self._checkpoint_dir,
+            require_exists=require_exists,
+        )
 
     # ── path helpers ─────────────────────────────────────────────────────
 
     def _task_dir(self, task_id: str) -> Path:
-        """Return the on-disk directory for *task_id*.
-
-        Resolution order:
-        1. If ``_checkpoints_root`` is set (active run or legacy/test mode),
-           return ``{_checkpoints_root}/{task_id}/`` directly.
-        2. Otherwise (scan-only mode) consult the task index for a previously
-           saved mapping.
-        3. Fall back to scanning all timestamp directories.
-        4. Also check the legacy flat layout under ``{agent_root}/checkpoints/``.
-        """
-        if self._checkpoints_root is not None:
-            return self._checkpoints_root / task_id
-
-        # Scan-only mode: resolve via index or directory scan.
-        idx_dir = self._resolve_task_run_dir(task_id)
-        if idx_dir is not None:
-            return idx_dir / "checkpoints" / task_id
-
-        # Check legacy flat layout: {agent_root}/checkpoints/{task_id}/
-        legacy = self._agent_root / "checkpoints" / task_id
-        if legacy.is_dir():
-            return legacy
-
-        # Should not normally reach here for known tasks.
-        raise FileNotFoundError(
-            f"Cannot locate checkpoint directory for task {task_id} "
-            f"under {self._agent_root}/"
-        )
+        """Return the direct canonical directory for ``task_id``."""
+        task_id = _require_safe_path_component(task_id, field="task_id")
+        if self._bound_task_id is not None:
+            if task_id != self._bound_task_id:
+                raise ValueError(
+                    f"manager is bound to task {self._bound_task_id}, got {task_id}"
+                )
+            assert self._checkpoint_dir is not None
+            return self._checkpoint_dir
+        return self._checkpoints_root / task_id
 
     def _supervisor_ckpt(self, task_id: str) -> Path:
         return self._task_dir(task_id) / "checkpoint.json"
 
-    def _worker_ckpt(self, task_id: str, worker_name: str) -> Path:
-        return self._task_dir(task_id) / "workers" / worker_name / "checkpoint.json"
+    def worker_dir(self, task_id: str, worker_name: str) -> Path:
+        """Return the canonical directory for one validated worker name."""
+        worker_name = _require_safe_path_component(worker_name, field="worker_name")
+        worker_component = portable_runtime_component(worker_name, fallback="worker")
+        return self._task_dir(task_id) / "workers" / worker_component
 
     def _worker_call_ckpt(self, task_id: str, worker_name: str, call_index: int) -> Path:
-        return (
-            self._task_dir(task_id)
-            / "workers"
-            / worker_name
-            / "calls"
-            / str(call_index)
-            / "checkpoint.json"
-        )
+        call_index = _require_call_index(call_index)
+        return self.worker_dir(task_id, worker_name) / "calls" / str(call_index) / "checkpoint.json"
 
     def _task_tree_path(self, task_id: str) -> Path:
         return self._task_dir(task_id) / "task_tree.json"
@@ -396,115 +494,108 @@ class CheckpointManager:
     def context_store_dir(self, task_id: str) -> Path:
         return self._task_dir(task_id) / "context_store"
 
-    # ── task index (task_id → timestamp directory) ───────────────────────
+    def file_history_dir(self, task_id: str) -> Path:
+        return self._task_dir(task_id) / "file-history"
 
-    def _index_path(self) -> Path:
-        """Return path to ``.task_index.json`` under the agent root."""
-        return self._agent_root / ".task_index.json"
+    def task_storage(self, task_id: str) -> SecureDirectory:
+        """Return an independently owned handle to the canonical task inode."""
 
-    def _load_index(self) -> dict:
-        """Load the full task index (thread-safe)."""
-        with self._index_lock:
-            return self._read_json(self._index_path()) or {}
+        task_dir = self._task_dir(task_id)
+        storage, _ = self._task_storage_for_path(
+            task_dir / ".storage-anchor",
+            create=True,
+        )
+        return storage.duplicate()
 
-    def _save_index(self, index: dict) -> None:
-        """Persist the full task index atomically (thread-safe)."""
-        with self._index_lock:
-            self._atomic_write(self._index_path(), index)
+    def directory_storage(self, task_id: str, directory: Path) -> SecureDirectory:
+        """Derive a stable child-directory handle from the task inode."""
 
-    def save_task_to_index(self, task_id: str) -> None:
-        """Record the mapping ``task_id → current run_log_dir`` in the index.
-
-        Must be called during task creation (not resume).  Requires that
-        ``run_log_dir`` was provided at construction time.
-        """
-        if self._checkpoints_root is None:
-            return  # scan-only mode — nothing to index.
-        run_dir_name = self._checkpoints_root.parent.name
-        with self._index_lock:
-            index = self._read_json(self._index_path()) or {}
-            index[task_id] = {
-                "run_dir": run_dir_name,
-                "created_at": datetime.now().astimezone().isoformat(),
-            }
-            self._atomic_write(self._index_path(), index)
-
-    def remove_task_from_index(self, task_id: str) -> None:
-        """Remove a task entry from the index (e.g. after cleanup)."""
-        with self._index_lock:
-            index = self._read_json(self._index_path()) or {}
-            if task_id in index:
-                del index[task_id]
-                self._atomic_write(self._index_path(), index)
-
-    def _resolve_task_run_dir(self, task_id: str) -> Path | None:
-        """Find the timestamp run-dir that contains *task_id*.
-
-        1. Consult the index file first (fast O(1) lookup).
-        2. Fall back to scanning all timestamp directories (slow).
-        """
-        # 1. Index lookup.
-        index = self._load_index()
-        entry = index.get(task_id)
-        if entry:
-            run_dir_name = entry.get("run_dir", "")
-            candidate = self._agent_root / run_dir_name
-            if (candidate / "checkpoints" / task_id).is_dir():
-                return candidate
-
-        # 2. Full directory scan.
-        return self._scan_for_task(task_id)
-
-    def _scan_for_task(self, task_id: str) -> Path | None:
-        """Scan all timestamp directories for *task_id* (slow fallback).
-
-        Only searches the v2 layout (timestamp dirs containing ``checkpoints/``).
-        The legacy flat layout is handled separately in ``_task_dir``.
-        """
-        if not self._agent_root.is_dir():
-            return None
-        for child in sorted(self._agent_root.iterdir(), reverse=True):
-            if not child.is_dir() or child.name.startswith("."):
-                continue
-            if child.name == "checkpoints":
-                continue  # Skip legacy flat directory.
-            candidate = child / "checkpoints" / task_id
-            if candidate.is_dir():
-                return child
-        return None
+        task_dir = self._task_dir(task_id)
+        absolute = Path(os.path.abspath(os.fspath(directory)))
+        try:
+            relative = absolute.relative_to(task_dir)
+        except ValueError as exc:
+            raise RuntimeError(f"checkpoint directory escapes task: {absolute}") from exc
+        if not relative.parts:
+            return self.task_storage(task_id)
+        task_storage = self.task_storage(task_id)
+        try:
+            return task_storage.child(relative, create=True)
+        finally:
+            task_storage.close()
 
     # ── atomic write ─────────────────────────────────────────────────────
 
+    def _task_storage_for_path(
+        self,
+        path: Path,
+        *,
+        create: bool,
+    ) -> tuple[SecureDirectory, Path]:
+        absolute = Path(os.path.abspath(os.fspath(Path(path).expanduser())))
+        if self._checkpoint_dir is not None:
+            task_root = self._checkpoint_dir
+        else:
+            try:
+                relative = absolute.relative_to(self._checkpoints_root)
+            except ValueError as exc:
+                raise RuntimeError(f"checkpoint path escapes root: {absolute}") from exc
+            if not relative.parts:
+                raise RuntimeError(f"checkpoint path does not identify a task: {absolute}")
+            task_root = self._checkpoints_root / relative.parts[0]
+        try:
+            relative_path = absolute.relative_to(task_root)
+        except ValueError as exc:
+            raise RuntimeError(f"checkpoint path escapes task: {absolute}") from exc
+        if not relative_path.parts:
+            raise RuntimeError("checkpoint operation requires a file below the task root")
+        storage = self._task_storages.get(task_root)
+        if storage is None or storage.closed:
+            storage = SecureDirectory(task_root, create=create)
+            self._task_storages[task_root] = storage
+        return storage, relative_path
+
+    def _write_json(self, path: Path, data: dict) -> None:
+        storage, relative = self._task_storage_for_path(path, create=True)
+        storage.atomic_write_json(relative, data)
+
     @staticmethod
     def _atomic_write(path: Path, data: dict) -> None:
-        """Write *data* as JSON atomically (tmp + rename)."""
-        path.parent.mkdir(parents=True, exist_ok=True)
-        # Use PID+thread to avoid tmp-file collisions under concurrency.
-        import threading
-        tid = threading.get_ident()
-        tmp = path.with_suffix(f".{os.getpid()}.{tid}.tmp")
-        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
-        tmp.replace(path)
+        """Write JSON atomically through an anchored parent descriptor."""
+        with SecureDirectory(path.parent, create=True) as storage:
+            storage.atomic_write_json(path.name, data)
 
-    @staticmethod
-    def _read_json(path: Path) -> dict | None:
+    def _read_json(self, path: Path) -> dict | None:
         """Read a JSON file, returning *None* when absent or corrupt."""
-        if not path.exists():
-            return None
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+            storage, relative = self._task_storage_for_path(path, create=False)
+            value = storage.read_json(relative)
+            return value if isinstance(value, dict) else None
+        except (
+            FileNotFoundError,
+            UnicodeError,
+            json.JSONDecodeError,
+            OSError,
+            RuntimeError,
+        ):
             return None
 
-    @staticmethod
-    def _read_task_events_from_path(path: Path) -> list[dict]:
+    def _read_task_events_from_path(self, path: Path) -> list[dict]:
         """Read append-only task events, skipping malformed crash-tail lines."""
-        if not path.exists():
-            return []
         events: list[dict] = []
         try:
-            for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-                raw = line.strip()
+            storage, relative = self._task_storage_for_path(path, create=False)
+            payload = storage.read_bytes(relative)
+            for line_no, line in enumerate(payload.splitlines(), start=1):
+                try:
+                    raw = line.decode("utf-8").strip()
+                except UnicodeDecodeError:
+                    _logger.warning(
+                        "Skipping undecodable checkpoint event %s:%d",
+                        path,
+                        line_no,
+                    )
+                    continue
                 if not raw:
                     continue
                 try:
@@ -516,7 +607,7 @@ class CheckpointManager:
                     _logger.warning("Skipping invalid checkpoint event %s:%d", path, line_no)
                     continue
                 events.append(event)
-        except OSError as exc:
+        except (FileNotFoundError, OSError, RuntimeError) as exc:
             _logger.warning("Failed reading checkpoint events %s: %s", path, exc)
         return events
 
@@ -525,22 +616,12 @@ class CheckpointManager:
         event = _jsonable(event)
         event.setdefault("timestamp", datetime.now().astimezone().isoformat())
         path = self._task_events_path(task_id)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        needs_leading_newline = False
-        try:
-            if path.exists() and path.stat().st_size > 0:
-                with path.open("rb") as existing:
-                    existing.seek(-1, os.SEEK_END)
-                    needs_leading_newline = existing.read(1) != b"\n"
-        except OSError:
-            needs_leading_newline = False
-        with path.open("ab") as f:
-            if needs_leading_newline:
-                f.write(b"\n")
-            f.write(json.dumps(event, ensure_ascii=False, default=str).encode("utf-8"))
-            f.write(b"\n")
-            f.flush()
-            os.fsync(f.fileno())
+        storage, relative = self._task_storage_for_path(path, create=True)
+        storage.append_text(
+            relative,
+            json.dumps(event, ensure_ascii=False, default=str) + "\n",
+            ensure_line_boundary=True,
+        )
 
     def _load_task_tree_unlocked(self, task_id: str) -> dict | None:
         """Load task tree projection. Caller must hold ``_tree_lock``."""
@@ -572,7 +653,7 @@ class CheckpointManager:
     def _write_task_tree_projection_unlocked(self, task_id: str, tree: dict) -> Path:
         """Persist the compatibility projection. Caller must hold ``_tree_lock``."""
         p = self._task_tree_path(task_id)
-        self._atomic_write(p, _migrate_task_tree_workers(_jsonable(tree)))
+        self._write_json(p, _migrate_task_tree_workers(_jsonable(tree)))
         return p
 
     def _append_event_and_refresh_projection_unlocked(self, task_id: str, event: dict) -> dict:
@@ -651,6 +732,27 @@ class CheckpointManager:
                 },
             )
 
+    def _record_run_event(self, task_id: str, event_type: str) -> dict:
+        if not self._run_id:
+            raise ValueError("run_id is required to record checkpoint run events")
+        with self._tree_lock:
+            return self._append_event_and_refresh_projection_unlocked(
+                task_id,
+                {
+                    "type": event_type,
+                    "task_id": task_id,
+                    "run_id": self._run_id,
+                },
+            )
+
+    def record_run_started(self, task_id: str) -> dict:
+        """Record the first execution attempt for a logical task."""
+        return self._record_run_event(task_id, "run_started")
+
+    def record_run_resumed(self, task_id: str) -> dict:
+        """Record a new execution attempt reusing an existing task."""
+        return self._record_run_event(task_id, "run_resumed")
+
     def record_task_status_changed(
         self,
         task_id: str,
@@ -682,41 +784,149 @@ class CheckpointManager:
         task_input: str,
         reuse_incomplete: bool = False,
     ) -> int:
-        """Atomically allocate and record a worker call index."""
+        """Allocate or claim an executable worker call.
+
+        Runtime execution uses :meth:`prepare_worker_call`, which also makes
+        completed-result reuse an atomic decision.  This lower-level method is
+        retained for event-model callers that always intend to execute.
+        """
+        preparation = self._prepare_worker_call(
+            task_id,
+            worker_name,
+            input_hash=input_hash,
+            task_input=task_input,
+            resume=reuse_incomplete,
+            allow_completed_cache=False,
+        )
+        return preparation.call_index
+
+    def prepare_worker_call(
+        self,
+        task_id: str,
+        worker_name: str,
+        *,
+        input_hash: str,
+        task_input: str,
+        resume: bool,
+    ) -> WorkerCallPreparation:
+        """Atomically decide whether one invocation executes or uses cache.
+
+        A resumed attempt first claims unfinished matching work, then claims
+        one completed matching result, both in call-index order.  Each prior
+        call can be claimed only once per run attempt.  A fresh run never
+        reuses checkpoint results.
+        """
+        return self._prepare_worker_call(
+            task_id,
+            worker_name,
+            input_hash=input_hash,
+            task_input=task_input,
+            resume=resume,
+            allow_completed_cache=True,
+        )
+
+    def _prepare_worker_call(
+        self,
+        task_id: str,
+        worker_name: str,
+        *,
+        input_hash: str,
+        task_input: str,
+        resume: bool,
+        allow_completed_cache: bool,
+    ) -> WorkerCallPreparation:
+        self.worker_dir(task_id, worker_name)
+        if resume and not self._run_id:
+            raise ValueError("run_id is required to prepare resumed worker calls")
         with self._tree_lock:
-            tree = self._load_task_tree_unlocked(task_id) or {
-                "task_id": task_id,
-                "agent_name": self._supervisor_name,
-                "status": "running",
-                "workers": {},
-            }
-            workers = tree.setdefault("workers", {})
-            calls = workers.setdefault(worker_name, [])
-            if not isinstance(calls, list):
-                calls = [calls]
-                workers[worker_name] = calls
-            if reuse_incomplete:
-                reusable_statuses = {"running", "interrupted", "crashed"}
-                for call in calls:
-                    if (
-                        call.get("input_hash") == input_hash
-                        and call.get("status") in reusable_statuses
-                    ):
-                        return _coerce_call_index(call.get("call_index"), 0)
-            existing = [_coerce_call_index(c.get("call_index"), -1) for c in calls]
-            call_index = (max(existing) + 1) if existing else 0
-            self._append_event_and_refresh_projection_unlocked(
-                task_id,
-                {
+            events_path = self._task_events_path(task_id)
+            storage, relative = self._task_storage_for_path(events_path, create=True)
+            # ``_tree_lock`` is manager-local.  Lock the event source of truth
+            # as well so independent managers cannot select the same call.
+            with storage.advisory_file_lock(relative, create=True):
+                tree = self._load_task_tree_unlocked(task_id) or {
+                    "task_id": task_id,
+                    "agent_name": self._supervisor_name,
+                    "status": "running",
+                    "workers": {},
+                }
+                workers = tree.setdefault("workers", {})
+                calls = workers.setdefault(worker_name, [])
+                if not isinstance(calls, list):
+                    calls = [calls]
+                    workers[worker_name] = calls
+                if resume:
+                    reusable_statuses = {"running", "interrupted", "crashed"}
+                    for call in _sorted_worker_calls(calls):
+                        if (
+                            call.get("input_hash") == input_hash
+                            and call.get("status") in reusable_statuses
+                            and call.get("attempt_run_id") != self._run_id
+                        ):
+                            call_index = _coerce_call_index(call.get("call_index"), 0)
+                            self._append_event_and_refresh_projection_unlocked(
+                                task_id,
+                                {
+                                    "type": "worker_call_resume_claimed",
+                                    "agent_name": worker_name,
+                                    "call_index": call_index,
+                                    "input_hash": input_hash,
+                                    "task_input": str(task_input),
+                                    "run_id": self._run_id,
+                                    "claimed_at": datetime.now().astimezone().isoformat(),
+                                },
+                            )
+                            return WorkerCallPreparation(
+                                call_index=call_index,
+                                should_execute=True,
+                            )
+                    if allow_completed_cache:
+                        for call in _sorted_worker_calls(calls):
+                            if (
+                                call.get("input_hash") == input_hash
+                                and call.get("status") == "completed"
+                                and call.get("attempt_run_id") != self._run_id
+                                and call.get("cached_claim_run_id") != self._run_id
+                            ):
+                                call_index = _coerce_call_index(
+                                    call.get("call_index"),
+                                    0,
+                                )
+                                self._append_event_and_refresh_projection_unlocked(
+                                    task_id,
+                                    {
+                                        "type": "worker_call_cached_result_claimed",
+                                        "agent_name": worker_name,
+                                        "call_index": call_index,
+                                        "input_hash": input_hash,
+                                        "run_id": self._run_id,
+                                        "claimed_at": datetime.now()
+                                        .astimezone()
+                                        .isoformat(),
+                                    },
+                                )
+                                return WorkerCallPreparation(
+                                    call_index=call_index,
+                                    should_execute=False,
+                                    cached_result=call.get("result"),
+                                )
+                existing = [_coerce_call_index(c.get("call_index"), -1) for c in calls]
+                call_index = (max(existing) + 1) if existing else 0
+                event: dict[str, Any] = {
                     "type": "worker_call_started",
                     "agent_name": worker_name,
                     "call_index": call_index,
                     "input_hash": input_hash,
                     "task_input": str(task_input),
                     "started_at": datetime.now().astimezone().isoformat(),
-                },
-            )
-            return call_index
+                }
+                if self._run_id:
+                    event["run_id"] = self._run_id
+                self._append_event_and_refresh_projection_unlocked(task_id, event)
+                return WorkerCallPreparation(
+                    call_index=call_index,
+                    should_execute=True,
+                )
 
     def record_worker_finished(
         self,
@@ -731,6 +941,8 @@ class CheckpointManager:
         error: str | None = None,
     ) -> dict:
         """Record terminal state for one worker call."""
+        self.worker_dir(task_id, worker_name)
+        call_index = _require_call_index(call_index)
         event: dict[str, Any] = {
             "type": "worker_call_finished",
             "agent_name": worker_name,
@@ -774,6 +986,8 @@ class CheckpointManager:
             "memory_steps": CheckpointSerializer.serialize_memory_steps(memory_steps),
             "saved_at": datetime.now().astimezone().isoformat(),
         }
+        if self._run_id:
+            data["run_id"] = self._run_id
         if config_snapshot:
             data["config_snapshot"] = config_snapshot
         if result is not None:
@@ -783,7 +997,7 @@ class CheckpointManager:
         if context_store is not None:
             data["context_store"] = context_store
         p = self._supervisor_ckpt(task_id)
-        self._atomic_write(p, data)
+        self._write_json(p, data)
         return p
 
     def load_supervisor_checkpoint(self, task_id: str) -> dict | None:
@@ -814,6 +1028,8 @@ class CheckpointManager:
             "status": status,
             "saved_at": datetime.now().astimezone().isoformat(),
         }
+        if self._run_id:
+            data["run_id"] = self._run_id
         if memory_steps:
             data["step_count"] = len(memory_steps)
             data["memory_steps"] = CheckpointSerializer.serialize_memory_steps(memory_steps)
@@ -822,7 +1038,7 @@ class CheckpointManager:
         if error is not None:
             data["error"] = error
         p = self._worker_call_ckpt(task_id, worker_name, call_index)
-        self._atomic_write(p, data)
+        self._write_json(p, data)
         return p
 
     def load_worker_checkpoint(
@@ -833,18 +1049,14 @@ class CheckpointManager:
     ) -> dict | None:
         """Load a worker checkpoint.
 
-        New checkpoints are stored per call under
+        Checkpoints are stored per call under
         ``workers/{worker_name}/calls/{call_index}/checkpoint.json``.  When
         *call_index* is omitted, the latest call for the worker is returned.
-        The legacy single-file layout remains readable for old checkpoints.
         """
         if call_index is not None:
-            data = self._read_json(self._worker_call_ckpt(task_id, worker_name, call_index))
-            if data is not None:
-                return data
-            if call_index == 0:
-                return self._read_json(self._worker_ckpt(task_id, worker_name))
-            return None
+            return self._read_json(
+                self._worker_call_ckpt(task_id, worker_name, call_index)
+            )
 
         latest_index: int | None = None
         try:
@@ -860,49 +1072,41 @@ class CheckpointManager:
             latest_index = None
 
         if latest_index is None:
-            calls_dir = self._task_dir(task_id) / "workers" / worker_name / "calls"
-            if calls_dir.is_dir():
+            calls_dir = self.worker_dir(task_id, worker_name) / "calls"
+            try:
+                storage, relative = self._task_storage_for_path(
+                    calls_dir / ".placeholder",
+                    create=False,
+                )
                 indexes = [
-                    _coerce_call_index(child.name, -1)
-                    for child in calls_dir.iterdir()
-                    if child.is_dir()
+                    _coerce_call_index(name, -1)
+                    for name in storage.directory_names(relative.parent)
                 ]
                 indexes = [idx for idx in indexes if idx >= 0]
                 latest_index = max(indexes) if indexes else None
+            except (FileNotFoundError, OSError, RuntimeError):
+                latest_index = None
 
         if latest_index is not None:
-            data = self._read_json(self._worker_call_ckpt(task_id, worker_name, latest_index))
-            if data is not None:
-                return data
+            return self._read_json(
+                self._worker_call_ckpt(task_id, worker_name, latest_index)
+            )
 
-        return self._read_json(self._worker_ckpt(task_id, worker_name))
+        return None
 
     # ── listing / enumeration ────────────────────────────────────────────
 
     def _iter_all_task_dirs(self) -> list[Path]:
-        """Return every ``checkpoints/{task_id}/`` directory under the agent root.
-
-        Scans all timestamp sub-directories for their ``checkpoints/`` children.
-        Also checks the legacy flat layout (``{agent_root}/checkpoints/``) for
-        backward compatibility with tests and explicit ``base_dir`` usage.
-        """
-        if not self._agent_root.is_dir():
+        """Return task directories directly managed by this instance."""
+        if self._checkpoint_dir is not None:
+            return [self._checkpoint_dir] if self._checkpoint_dir.is_dir() else []
+        if not self._checkpoints_root.is_dir():
             return []
-        seen: set[str] = set()
-        task_dirs: list[Path] = []
-        for child in sorted(self._agent_root.iterdir()):
-            if not child.is_dir() or child.name.startswith("."):
-                continue
-            # Check both the timestamp layout ({timestamp}/checkpoints/)
-            # and the legacy flat layout (checkpoints/ directly under agent root).
-            ckpt_root = child / "checkpoints" if child.name != "checkpoints" else child
-            if not ckpt_root.is_dir():
-                continue
-            for td in sorted(ckpt_root.iterdir()):
-                if td.is_dir() and td.name not in seen:
-                    seen.add(td.name)
-                    task_dirs.append(td)
-        return task_dirs
+        return [
+            child
+            for child in sorted(self._checkpoints_root.iterdir())
+            if _is_checkpoint_task_dir(child)
+        ]
 
     def list_tasks(self) -> list[dict]:
         """Return metadata for every checkpoint under this supervisor.
@@ -927,6 +1131,7 @@ class CheckpointManager:
                     "status": tree.get("status", "unknown"),
                     "created_at": tree.get("created_at", ""),
                     "interrupted_at": tree.get("interrupted_at", ""),
+                    "run_id": tree.get("run_id", ""),
                 }
             else:
                 # Fallback: derive from supervisor checkpoint
@@ -938,6 +1143,7 @@ class CheckpointManager:
                         "status": sup.get("status", "unknown"),
                         "created_at": sup.get("saved_at", ""),
                         "interrupted_at": sup.get("saved_at", ""),
+                        "run_id": sup.get("run_id", ""),
                     }
                 else:
                     continue
@@ -979,10 +1185,14 @@ class CheckpointManager:
             workers_detail: list[dict] = []
             tree_workers = (tree or {}).get("workers", {})
             for w_name, w_calls in tree_workers.items():
+                try:
+                    worker_dir = self.worker_dir(task_dir.name, w_name)
+                except ValueError:
+                    continue
                 if not isinstance(w_calls, list):
                     w_calls = [w_calls]
                 # Try to read the per-worker heartbeat file.
-                w_hb_path = task_dir / "workers" / w_name / "heartbeat.json"
+                w_hb_path = worker_dir / "heartbeat.json"
                 w_hb = self._read_json(w_hb_path)
                 for w_call in w_calls:
                     ci = w_call.get("call_index", 0)
@@ -1016,6 +1226,7 @@ class CheckpointManager:
                         w_detail["heartbeat_age"] = None
                     workers_detail.append(w_detail)
             entry["workers"] = workers_detail
+            entry["checkpoint_dir"] = str(task_dir)
 
             entries.append(entry)
         return entries
@@ -1023,76 +1234,427 @@ class CheckpointManager:
     # ── cleanup ──────────────────────────────────────────────────────────
 
     def delete_task(self, task_id: str) -> bool:
-        """Delete all checkpoint files for *task_id* and remove from index."""
-        try:
-            d = self._task_dir(task_id)
-        except FileNotFoundError:
-            self.remove_task_from_index(task_id)
+        """Delete all checkpoint files for *task_id*."""
+        d = self._task_dir(task_id)
+        if d.is_symlink() or not d.is_dir():
             return False
-        if d.exists():
+        try:
+            storage = self._task_storages.get(d)
+            if storage is None:
+                storage = SecureDirectory(d, create=False)
+                self._task_storages[d] = storage
+            if not storage.matches_path():
+                return False
+            storage.close()
+            self._task_storages.pop(d, None)
             shutil.rmtree(d)
-            self.remove_task_from_index(task_id)
             return True
-        return False
+        except (FileNotFoundError, OSError, RuntimeError):
+            return False
 
-    def cleanup_old_tasks(self, max_age_seconds: int = 7 * 86400) -> int:
-        """Remove checkpoints older than *max_age_seconds*.  Returns count."""
-        all_task_dirs = self._iter_all_task_dirs()
-        if not all_task_dirs:
-            return 0
+    def close(self) -> None:
+        for storage in list(self._task_storages.values()):
+            storage.close()
+        self._task_storages.clear()
 
-        cutoff = time.time() - max_age_seconds
-        removed = 0
-        for task_dir in all_task_dirs:
-            try:
-                mtime = task_dir.stat().st_mtime
-            except OSError:
-                continue
-            if mtime < cutoff:
-                task_id = task_dir.name
-                shutil.rmtree(task_dir, ignore_errors=True)
-                self.remove_task_from_index(task_id)
-                removed += 1
-        return removed
-
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
 # =========================================================================
 # Cross-supervisor listing (for CLI ``list-tasks``)
 # =========================================================================
 
 
-def list_all_tasks(base_dir: Path | None = None) -> list[dict]:
-    """Scan **all** supervisor directories for checkpoint tasks.
+_TASK_MARKERS = ("task_events.jsonl", "task_tree.json", "checkpoint.json")
+_EXPIRABLE_TASK_STATUSES = frozenset(
+    {
+        "cancelled",
+        "completed",
+        "crashed",
+        "error",
+        "failed",
+        "interrupted",
+        "success",
+        "succeeded",
+    }
+)
 
-    Used by ``loom list-tasks``.  Scans every agent directory and its
-    timestamp sub-directories for checkpoint data.  Also checks the legacy
-    flat layout (``{agent}/checkpoints/``).
+
+def _is_checkpoint_task_dir(path: Path) -> bool:
+    if path.is_symlink() or not path.is_dir():
+        return False
+    return any(
+        marker_path.is_file() and not marker_path.is_symlink()
+        for marker_path in (path / marker for marker in _TASK_MARKERS)
+    )
+
+
+def _has_symlink_component(path: Path, root: Path) -> bool:
+    """Return whether *path* reaches *root* through a symlinked component."""
+    current = path
+    while current != root:
+        if current.is_symlink():
+            return True
+        if current.parent == current:
+            return True
+        current = current.parent
+    return False
+
+
+def iter_checkpoint_task_dirs(checkpoints_root: Path) -> list[Path]:
+    """Discover canonical task directories without consulting any index."""
+    configured_root = Path(checkpoints_root).expanduser()
+    if configured_root.is_symlink():
+        return []
+    root = configured_root.resolve()
+    if not root.is_dir():
+        return []
+    try:
+        candidates = root.rglob("*")
+        return sorted(
+            path
+            for path in candidates
+            if not _has_symlink_component(path, root)
+            and _is_checkpoint_task_dir(path)
+            and not _has_checkpoint_task_ancestor(path, root)
+        )
+    except OSError:
+        return []
+
+
+def _iter_direct_checkpoint_task_dirs(checkpoints_root: Path) -> list[Path]:
+    """Return only task children owned by one exact Application root."""
+
+    if checkpoints_root.is_symlink() or not checkpoints_root.is_dir():
+        return []
+    try:
+        return sorted(
+            child
+            for child in checkpoints_root.iterdir()
+            if not child.is_symlink() and _is_checkpoint_task_dir(child)
+        )
+    except OSError:
+        return []
+
+
+def _has_checkpoint_task_ancestor(path: Path, root: Path) -> bool:
+    """Reject nested worker checkpoints beneath an already identified task."""
+    current = path.parent
+    while current != root:
+        if current.parent == current:
+            return True
+        if _is_checkpoint_task_dir(current):
+            return True
+        current = current.parent
+    return False
+
+
+def _task_events_are_intact(path: Path) -> bool:
+    """Validate events, tolerating one crash-truncated final append.
+
+    Appends are not atomic: SIGKILL may leave only the final JSON object
+    truncated.  A valid canonical task tree plus an inactive task lease is
+    sufficient deletion evidence in that case.  Malformation before the tail
+    remains ambiguous and is retained.
     """
-    if base_dir is None:
-        base_dir = _resolve_checkpoint_base_dir()
-    if not base_dir.exists():
+    if not path.exists():
+        return True
+    if path.is_symlink():
+        return False
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return False
+    saw_event = False
+    nonempty = [line.strip() for line in lines if line.strip()]
+    for index, raw in enumerate(nonempty):
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            return saw_event and index == len(nonempty) - 1
+        if not isinstance(event, dict) or not event.get("type"):
+            return False
+        saw_event = True
+    return saw_event
+
+
+def _read_heartbeat_for_cleanup(path: Path) -> tuple[str, dict | None]:
+    """Return ``missing``, ``valid``, or ``unknown`` plus the payload."""
+    if not path.exists():
+        return "missing", None
+    if path.is_symlink():
+        return "unknown", None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return "unknown", None
+    if not isinstance(payload, dict):
+        return "unknown", None
+    return "valid", payload
+
+
+def _heartbeat_process_state(payload: dict) -> str:
+    """Classify a structurally valid writer payload as live/inactive/unknown."""
+    pid = payload.get("pid")
+    timestamp = payload.get("timestamp")
+    if (
+        isinstance(pid, bool)
+        or not isinstance(pid, int)
+        or pid <= 0
+        or isinstance(timestamp, bool)
+        or not isinstance(timestamp, (int, float))
+        or not math.isfinite(float(timestamp))
+    ):
+        return "unknown"
+    return "live" if _detect_crashed_status(payload) == "running" else "inactive"
+
+
+def _task_heartbeat_state(task_dir: Path) -> str:
+    """Return live/inactive/unknown, preserving ambiguity instead of deleting."""
+    state, payload = _read_heartbeat_for_cleanup(task_dir / "heartbeat.json")
+    if state == "unknown":
+        return "unknown"
+    if payload is not None:
+        status = payload.get("status")
+        if status == "running":
+            process_state = _heartbeat_process_state(payload)
+            if process_state != "inactive":
+                return process_state
+        elif status not in {"stopped", "exited"}:
+            return "unknown"
+
+    workers_root = task_dir / "workers"
+    if not workers_root.exists():
+        return "inactive"
+    if workers_root.is_symlink():
+        return "unknown"
+    try:
+        worker_heartbeats = list(workers_root.rglob("heartbeat.json"))
+    except OSError:
+        return "unknown"
+    for heartbeat_path in worker_heartbeats:
+        if _has_symlink_component(heartbeat_path, task_dir):
+            return "unknown"
+        worker_state, worker_payload = _read_heartbeat_for_cleanup(heartbeat_path)
+        if worker_state == "unknown":
+            return "unknown"
+        if worker_payload is None:
+            continue
+        calls = worker_payload.get("calls")
+        if not isinstance(calls, dict):
+            return "unknown"
+        if any(
+            isinstance(call, dict) and call.get("status") == "running"
+            for call in calls.values()
+        ):
+            process_state = _heartbeat_process_state(worker_payload)
+            if process_state != "inactive":
+                return process_state
+    return "inactive"
+
+
+def list_all_tasks(*, checkpoints_root: Path) -> list[dict]:
+    """Scan the canonical ``checkpoints/<application>/<task>`` tree."""
+    configured_root = Path(checkpoints_root).expanduser()
+    if configured_root.is_symlink():
+        return []
+    root = configured_root.resolve()
+    if not root.exists():
         return []
 
     all_entries: list[dict] = []
-    for agent_dir in sorted(base_dir.iterdir()):
-        if not agent_dir.is_dir():
-            continue
-        # Check if any child contains checkpoint data (v2 timestamp layout
-        # or legacy flat layout).
-        has_checkpoints = False
-        for child in agent_dir.iterdir():
-            if not child.is_dir() or child.name.startswith("."):
-                continue
-            # Legacy flat: {agent}/checkpoints/
-            if child.name == "checkpoints":
-                has_checkpoints = True
-                break
-            # v2: {agent}/{timestamp}/checkpoints/
-            if (child / "checkpoints").is_dir():
-                has_checkpoints = True
-                break
-        if not has_checkpoints:
-            continue
-        cm = CheckpointManager(agent_dir.name, base_dir=base_dir)
-        all_entries.extend(cm.list_tasks())
+    for task_dir in iter_checkpoint_task_dirs(root):
+        application_dir = task_dir.parent
+        application_id = application_dir.relative_to(root).as_posix()
+        manager = CheckpointManager(
+            application_id,
+            checkpoint_dir=task_dir,
+        )
+        for entry in manager.list_tasks():
+            entry["application_id"] = application_id
+            all_entries.append(entry)
     return all_entries
+
+
+def _acquire_task_cleanup_lease(task_dir: Path) -> int | None:
+    """Try to exclude an active run attempt before destructive cleanup."""
+    if task_dir.is_symlink():
+        return None
+    try:
+        fd = os.open(task_dir, os.O_RDONLY)
+    except OSError:
+        return None
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        os.close(fd)
+        return None
+    return fd
+
+
+def _release_task_cleanup_lease(fd: int) -> None:
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _cleanup_expired_task(
+    task_dir: Path,
+    *,
+    current: datetime,
+    ttl: float,
+) -> bool:
+    task_lock_fd = _acquire_task_cleanup_lease(task_dir)
+    if task_lock_fd is None:
+        return False
+    try:
+        # An acquired task lease proves no canonical writer remains. Stale
+        # framework temporary files therefore cannot extend task lifetime.
+        if not _task_events_are_intact(task_dir / "task_events.jsonl"):
+            return False
+        if _task_heartbeat_state(task_dir) != "inactive":
+            return False
+
+        manager = CheckpointManager(
+            task_dir.parent.name,
+            checkpoint_dir=task_dir,
+        )
+        tree = manager._load_task_tree_from_dir(task_dir)
+        if not isinstance(tree, dict):
+            return False
+        task_id = tree.get("task_id")
+        if task_id != task_dir.name:
+            return False
+        status = str(tree.get("status", "")).strip().lower()
+        if status == "running":
+            status = "crashed"
+        if status not in _EXPIRABLE_TASK_STATUSES:
+            return False
+
+        raw_created_at = tree.get("created_at")
+        if not isinstance(raw_created_at, str) or not raw_created_at.strip():
+            return False
+        try:
+            created_at = datetime.fromisoformat(
+                raw_created_at.strip().replace("Z", "+00:00")
+            )
+        except ValueError:
+            return False
+        if created_at.tzinfo is None:
+            return False
+        age = (current.astimezone(created_at.tzinfo) - created_at).total_seconds()
+        if age <= ttl:
+            return False
+
+        # The task lease closes the pre-heartbeat and cross-process race; the
+        # second heartbeat check still protects non-run legacy writers.
+        if _task_heartbeat_state(task_dir) != "inactive":
+            return False
+        return manager.delete_task(task_id)
+    except (OSError, ValueError, TypeError):
+        return False
+    finally:
+        _release_task_cleanup_lease(task_lock_fd)
+
+
+def delete_checkpoint_task_if_inactive(task_dir: Path) -> bool:
+    """Delete one checkpoint only when no run or heartbeat still owns it."""
+
+    task_path = Path(task_dir).expanduser()
+    task_lock_fd = _acquire_task_cleanup_lease(task_path)
+    if task_lock_fd is None:
+        return False
+    try:
+        if _task_heartbeat_state(task_path) != "inactive":
+            return False
+        manager = CheckpointManager(
+            task_path.parent.name,
+            checkpoint_dir=task_path,
+        )
+        tree = manager._load_task_tree_from_dir(task_path)
+        if not isinstance(tree, dict) or tree.get("task_id") != task_path.name:
+            return False
+        return manager.delete_task(task_path.name)
+    except (OSError, ValueError, TypeError):
+        return False
+    finally:
+        _release_task_cleanup_lease(task_lock_fd)
+
+
+def cleanup_expired_tasks(
+    *,
+    checkpoints_root: Path,
+    max_age_seconds: int | float,
+    now: datetime | None = None,
+    recursive: bool = True,
+) -> int:
+    """Delete terminal checkpoints whose logical task age exceeds the TTL.
+
+    ``created_at`` is the lifecycle anchor.  Filesystem mtimes, heartbeats,
+    ContextStore writes, and file-history writes must not revive an expired
+    task.  A task whose heartbeat still identifies a live process is preserved
+    even when its original creation time is old.
+
+    Invalid or missing timestamps are retained for manual inspection; guessing
+    an age would make automated cleanup destructive.
+    """
+    if isinstance(max_age_seconds, bool):
+        raise ValueError("max_age_seconds must be a finite number")
+    try:
+        ttl = float(max_age_seconds)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("max_age_seconds must be a finite number") from exc
+    if not math.isfinite(ttl):
+        raise ValueError("max_age_seconds must be finite")
+    # This matches resume semantics: non-positive max_resume_age means that
+    # task checkpoints do not expire.
+    if ttl <= 0:
+        return 0
+
+    current = now or datetime.now().astimezone()
+    if current.tzinfo is None:
+        current = current.astimezone()
+
+    configured_root = Path(checkpoints_root).expanduser()
+    if configured_root.is_symlink():
+        return 0
+    root = configured_root.resolve()
+    if not root.is_dir():
+        return 0
+
+    lock_fd: int | None = None
+    lock_acquired = False
+    try:
+        lock_fd = os.open(root, os.O_RDONLY)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return 0
+        lock_acquired = True
+
+        removed = 0
+        task_dirs = (
+            iter_checkpoint_task_dirs(root)
+            if recursive
+            else _iter_direct_checkpoint_task_dirs(root)
+        )
+        for task_dir in task_dirs:
+            if _cleanup_expired_task(task_dir, current=current, ttl=ttl):
+                removed += 1
+        return removed
+    except OSError:
+        return 0
+    finally:
+        if lock_fd is not None:
+            try:
+                if lock_acquired:
+                    try:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    except OSError:
+                        pass
+            finally:
+                os.close(lock_fd)

--- a/src/lib/checkpoint/coordinator.py
+++ b/src/lib/checkpoint/coordinator.py
@@ -21,8 +21,10 @@ Worker (inside its own ``run()``):
 SubTaskTrackedAgent lifecycle:
 
     coord = CheckpointCoordinator.current()
-    cached = coord.check_worker_skip(agent_name, input_hash) if coord else None
-    call_index = coord.record_worker_start(...) if coord else 0
+    preparation = coord.prepare_worker_call(...) if coord else None
+    if preparation is not None and not preparation.should_execute:
+        return preparation.cached_result
+    call_index = preparation.call_index if preparation is not None else 0
     try:
         result = callable_fn(...)
         if coord: coord.record_worker_success(...)
@@ -33,9 +35,9 @@ SubTaskTrackedAgent lifecycle:
 
 from __future__ import annotations
 
+import threading
 from contextvars import ContextVar
 from dataclasses import replace
-import threading
 from typing import Any, Optional
 
 from src.lib.context_engine import (
@@ -44,9 +46,8 @@ from src.lib.context_engine import (
     clear_current_context_engine,
     set_current_context_engine,
 )
-from src.lib.logging import get_logger
 from src.lib.heartbeat.worker_heartbeat import WorkerHeartbeat
-
+from src.lib.logging import get_logger
 
 _logger = get_logger(__name__)
 
@@ -59,8 +60,29 @@ _current_coordinator: ContextVar[Optional["CheckpointCoordinator"]] = ContextVar
 _pending_supervisor_heartbeat: ContextVar[Any] = ContextVar("_pending_supervisor_heartbeat", default=None)
 # Stores a file history manager set by runner.py before supervisor.run(); consumed by activate().
 _pending_file_history: ContextVar[Any] = ContextVar("_pending_file_history", default=None)
-_active_coordinator_lock = threading.Lock()
-_active_coordinator: Optional["CheckpointCoordinator"] = None
+
+
+def _steps_including_completed(
+    existing_steps: Any,
+    completed_step: Any,
+) -> list[Any]:
+    """Return checkpoint memory including the step that triggered a callback.
+
+    smolagents invokes step callbacks before appending the completed ActionStep
+    to ``memory.steps``.  Some callers may already have appended that exact
+    object, so avoid adding it twice by identity.
+    """
+    steps = list(existing_steps)
+    if not steps:
+        steps.append(completed_step)
+        return steps
+
+    tail = steps[-1]
+    if tail is completed_step:
+        return steps
+
+    steps.append(completed_step)
+    return steps
 
 
 class CheckpointCoordinator:
@@ -90,11 +112,9 @@ class CheckpointCoordinator:
         self._step_cb: Any = None
         # Worker heartbeat writers — one per worker_name.
         self._worker_heartbeats: dict[str, WorkerHeartbeat] = {}
+        self._worker_heartbeats_lock = threading.Lock()
         # Supervisor heartbeat writer (set via set_supervisor_heartbeat).
         self._supervisor_heartbeat: Any = None
-        # Pending worker runtime agents waiting for call_index after record_worker_start().
-        # Maps agent_name -> runtime_agent (inner CodeAgentV2 / ToolCallingAgentV2).
-        self._pending_worker_runtime: dict[str, Any] = {}
         # File history manager (set by runner.py after creation).
         self._file_history: Any = None
         self._context_engine: ContextEngine | None = None
@@ -123,13 +143,11 @@ class CheckpointCoordinator:
         task_text: str,
         *,
         resume: bool = False,
+        effective_config: dict[str, Any] | None = None,
     ) -> "CheckpointCoordinator":
         """Create and store a new coordinator for this task.  Called by supervisor."""
-        global _active_coordinator
         coord = cls(checkpoint_manager, task_id, task_text, resume=resume)
         _current_coordinator.set(coord)
-        with _active_coordinator_lock:
-            _active_coordinator = coord
         # Auto-inject any heartbeat writer set by runner.py before supervisor.run().
         pending_hb = _pending_supervisor_heartbeat.get()
         if pending_hb is not None:
@@ -140,45 +158,58 @@ class CheckpointCoordinator:
         if pending_fh is not None:
             coord._file_history = pending_fh
             _pending_file_history.set(None)
-        coord._activate_context_engine()
+        coord._activate_context_engine(effective_config)
         return coord
 
     @staticmethod
     def current() -> Optional["CheckpointCoordinator"]:
         """Return the coordinator inherited from the current context (may be None)."""
-        coord = _current_coordinator.get()
-        if coord is not None:
-            return coord
-        with _active_coordinator_lock:
-            return _active_coordinator
+        return _current_coordinator.get()
 
     @staticmethod
     def deactivate(coord: Optional["CheckpointCoordinator"] = None) -> None:
         """Clear the active coordinator after a supervisor run finishes."""
-        global _active_coordinator
-        if coord is not None:
-            clear_current_context_engine(coord._context_engine)
-        elif _active_coordinator is not None:
-            clear_current_context_engine(_active_coordinator._context_engine)
-        else:
-            clear_current_context_engine(None)
-        if _current_coordinator.get() is coord or coord is None:
+        current = _current_coordinator.get()
+        target = coord or current
+        if target is not None:
+            target.stop_all_worker_heartbeats()
+            if target._context_engine is not None:
+                target._context_engine.close()
+        clear_current_context_engine(
+            target._context_engine if target is not None else None
+        )
+        if current is coord or coord is None:
             _current_coordinator.set(None)
-        with _active_coordinator_lock:
-            if coord is None or _active_coordinator is coord:
-                _active_coordinator = None
 
-    def _activate_context_engine(self) -> None:
-        config = ContextEngineConfig.from_runtime()
-        if config.store.ttl_seconds is None:
+    def _activate_context_engine(
+        self,
+        effective_config: dict[str, Any] | None,
+    ) -> None:
+        if effective_config is None:
+            config = ContextEngineConfig.from_runtime()
             from src.lib.config import C
 
-            ttl = C.get_nested("checkpoint", "max_resume_age", default=None)
+            checkpoint_config = C.get("checkpoint", {})
+        else:
+            config = ContextEngineConfig.from_mapping(
+                effective_config.get("context_engine", {})
+            )
+            checkpoint_config = effective_config.get("checkpoint", {})
+        if config.store.ttl_seconds is None:
+            ttl = (
+                checkpoint_config.get("max_resume_age")
+                if isinstance(checkpoint_config, dict)
+                else None
+            )
             if ttl is not None:
                 config = replace(config, store=replace(config.store, ttl_seconds=int(ttl)))
         self._context_engine = ContextEngine(
             self._cm.context_store_dir(self._task_id),
             config=config,
+            storage=self._cm.directory_storage(
+                self._task_id,
+                self._cm.context_store_dir(self._task_id),
+            ),
         )
         set_current_context_engine(self._context_engine)
 
@@ -193,8 +224,8 @@ class CheckpointCoordinator:
         into the agent's memory.
         """
         try:
-            from src.lib.checkpoint.serializer import CheckpointSerializer
             from src.lib.checkpoint.conversation_recovery import prepare_steps_for_resume
+            from src.lib.checkpoint.serializer import CheckpointSerializer
 
             sup_ckpt = self._cm.load_supervisor_checkpoint(self._task_id)
             if sup_ckpt is None:
@@ -231,14 +262,26 @@ class CheckpointCoordinator:
 
         def _on_step_complete(memory_step, **kwargs):
             try:
-                self.save_supervisor(runtime_agent, "running")
+                memory_steps = list(runtime_agent.memory.steps)
+                # This callback is inherited by workers.  Only add the
+                # callback step to supervisor memory when the supervisor itself
+                # completed it; a worker step belongs in its own checkpoint.
+                if kwargs.get("agent") is inner_agent:
+                    memory_steps = _steps_including_completed(
+                        memory_steps,
+                        memory_step,
+                    )
+                self.save_supervisor(
+                    runtime_agent,
+                    "running",
+                    memory_steps=memory_steps,
+                )
                 if self._supervisor_heartbeat is not None:
-                    self._supervisor_heartbeat.update_step(len(runtime_agent.memory.steps))
+                    self._supervisor_heartbeat.update_step(len(memory_steps))
                 # Create post-step file history snapshot.
                 if self._file_history is not None:
                     try:
-                        step_num = len(runtime_agent.memory.steps)
-                        self._file_history.make_post_step_snapshot(step_num)
+                        self._file_history.make_post_step_snapshot(len(memory_steps))
                     except Exception as fh_exc:
                         _logger.debug("file_history snapshot failed: %s", fh_exc)
             except Exception as exc:
@@ -276,12 +319,18 @@ class CheckpointCoordinator:
         *,
         result: Optional[str] = None,
         error: Optional[str] = None,
+        memory_steps: list[Any] | None = None,
     ) -> None:
         """Save supervisor checkpoint + update task_tree status."""
         try:
+            checkpoint_steps = (
+                list(runtime_agent.memory.steps)
+                if memory_steps is None
+                else list(memory_steps)
+            )
             self._cm.save_supervisor_checkpoint(
                 self._task_id,
-                memory_steps=list(runtime_agent.memory.steps),
+                memory_steps=checkpoint_steps,
                 task_text=self._task_text,
                 status=status,
                 config_snapshot=getattr(runtime_agent, "_config", None),
@@ -300,7 +349,7 @@ class CheckpointCoordinator:
                 "Checkpoint saved [%s] task_id=%s steps=%d",
                 status,
                 self._task_id,
-                len(runtime_agent.memory.steps),
+                len(checkpoint_steps),
             )
         except Exception as exc:
             _logger.error("Failed to save checkpoint: %s", exc, exc_info=True)
@@ -320,10 +369,6 @@ class CheckpointCoordinator:
 
         This is the clean replacement for the previous ``elif checkpoint_manager is None``
         block in ``_execute_agent()``.
-
-        Also stores *runtime_agent* keyed by *agent_name* so that
-        ``record_worker_start()`` can later register the dedicated worker step
-        tracker (which needs the real call_index, only available after start).
         """
         if self._step_cb is None:
             return
@@ -334,10 +379,6 @@ class CheckpointCoordinator:
             cb_reg = getattr(inner, 'step_callbacks', None)
             if cb_reg is not None:
                 cb_reg.register(ActionStep, self._step_cb)
-
-            # Store for later use in record_worker_start().
-            if agent_name:
-                self._pending_worker_runtime[agent_name] = inner
         except Exception as exc:
             _logger.warning("Failed to register worker step callback: %s", exc)
 
@@ -352,9 +393,9 @@ class CheckpointCoordinator:
     ) -> None:
         """Register a dedicated step-counter callback for a specific worker call.
 
-        Called from ``SubTaskTrackedAgent._execute_with_lifecycle`` **after**
-        ``record_worker_start()`` so that ``agent_name`` and ``call_index`` are
-        already known.  This updates the worker heartbeat ``step`` field on
+        Called from ``SubTaskTrackedAgent._execute_with_lifecycle`` after the
+        atomic worker preparation returns ``call_index``.  This updates the
+        worker heartbeat ``step`` field on
         every ActionStep so the dashboard reflects real-time progress.
         """
         try:
@@ -367,20 +408,24 @@ class CheckpointCoordinator:
 
             def _on_worker_step(memory_step, **kwargs):
                 try:
+                    memory_steps = _steps_including_completed(
+                        inner.memory.steps,
+                        memory_step,
+                    )
                     self._cm.save_worker_checkpoint(
                         self._task_id,
                         agent_name,
                         call_index=call_index,
                         input_hash=input_hash,
-                        memory_steps=list(inner.memory.steps),
+                        memory_steps=memory_steps,
                         task_input=str(task_input),
                         status="running",
                     )
-                    whb = self._worker_heartbeats.get(agent_name)
+                    whb = self.get_worker_heartbeat(agent_name)
                     if whb is not None:
                         whb.update_call_step(
                             call_index,
-                            len(inner.memory.steps),
+                            len(memory_steps),
                         )
                 except Exception as exc:
                     _logger.debug("Worker step tracker failed: %s", exc)
@@ -389,65 +434,62 @@ class CheckpointCoordinator:
         except Exception as exc:
             _logger.warning("Failed to register worker step tracker: %s", exc)
 
-    def check_worker_skip(
-        self, agent_name: str, input_hash: str
-    ) -> Optional[str]:
-        """Return cached result if this worker call already completed, else None."""
-        try:
-            tree = self._cm.load_task_tree(self._task_id)
-            if tree:
-                calls = tree.get("workers", {}).get(agent_name)
-                if isinstance(calls, list):
-                    for entry in calls:
-                        if (
-                            entry.get("input_hash") == input_hash
-                            and entry.get("status") == "completed"
-                            and entry.get("result") is not None
-                        ):
-                            return entry["result"]
-        except Exception:
-            pass
-        return None
-
-    def record_worker_start(
-        self, agent_name: str, input_hash: str, task_input: str
-    ) -> int:
-        """Record a worker call start in the task_tree.  Returns call_index."""
-        call_index = 0
-        try:
-            call_index = self._cm.record_worker_started(
-                self._task_id,
-                agent_name,
-                input_hash=input_hash,
-                task_input=str(task_input),
-                reuse_incomplete=self._resume,
-            )
-        except Exception:
-            pass
+    def prepare_worker_call(
+        self,
+        agent_name: str,
+        input_hash: str,
+        task_input: str,
+        *,
+        runtime_agent: Any = None,
+    ) -> Any:
+        """Atomically claim prior work/cache or allocate one new worker call."""
+        worker_dir = self._cm.worker_dir(self._task_id, agent_name)
+        preparation = self._cm.prepare_worker_call(
+            self._task_id,
+            agent_name,
+            input_hash=input_hash,
+            task_input=str(task_input),
+            resume=self._resume,
+        )
+        if not preparation.should_execute:
+            return preparation
+        call_index = preparation.call_index
 
         # ── Worker heartbeat: register call ──
         try:
-            whb = self._worker_heartbeats.get(agent_name)
-            if whb is None:
-                hb_path = (
-                    self._cm._task_dir(self._task_id)
-                    / "workers" / agent_name / "heartbeat.json"
-                )
-                whb = WorkerHeartbeat(
-                    path=hb_path, agent_name=agent_name,
-                )
+            with self._worker_heartbeats_lock:
+                whb = self._worker_heartbeats.get(agent_name)
+                if whb is None:
+                    if not self._cm.run_id:
+                        raise RuntimeError("checkpoint manager has no current run_id")
+                    hb_path = worker_dir / "heartbeat.json"
+                    whb = WorkerHeartbeat(
+                        path=hb_path,
+                        agent_name=agent_name,
+                        run_id=self._cm.run_id,
+                        storage=self._cm.directory_storage(
+                            self._task_id,
+                            hb_path.parent,
+                        ),
+                    )
+                    self._worker_heartbeats[agent_name] = whb
+                # Keep registration and terminal-state checks under the same
+                # coordinator lock.  Otherwise one fast call can stop the
+                # shared writer before a concurrent call has registered.
+                whb.register_call(call_index)
+                # ``start`` is idempotent and restarts a writer that a prior
+                # sequential group of calls stopped after becoming terminal.
                 whb.start()
-                self._worker_heartbeats[agent_name] = whb
-            whb.register_call(call_index)
         except Exception as exc:
             _logger.debug("Worker heartbeat register failed: %s", exc)
 
-        # ── Worker step tracker: register dedicated callback now that call_index is known ──
+        # Register the tracker directly on this invocation's runtime.  Passing
+        # the runtime explicitly avoids a shared agent-name staging map, which
+        # cannot distinguish concurrent calls of the same worker type.
         try:
-            inner = self._pending_worker_runtime.pop(agent_name, None)
-            if inner is not None:
+            if runtime_agent is not None:
                 self.register_worker_step_tracker(
-                    inner,
+                    runtime_agent,
                     agent_name,
                     call_index,
                     input_hash=input_hash,
@@ -456,15 +498,15 @@ class CheckpointCoordinator:
         except Exception as exc:
             _logger.debug("Worker step tracker register failed: %s", exc)
 
-        return call_index
+        return preparation
 
     def restore_worker(self, runtime_agent: Any, agent_name: str, call_index: int) -> bool:
         """Inject saved worker memory for an incomplete resumed worker call."""
         try:
             if not self._resume:
                 return False
-            from src.lib.checkpoint.serializer import CheckpointSerializer
             from src.lib.checkpoint.conversation_recovery import prepare_steps_for_resume
+            from src.lib.checkpoint.serializer import CheckpointSerializer
 
             worker_ckpt = self._cm.load_worker_checkpoint(
                 self._task_id,
@@ -503,7 +545,7 @@ class CheckpointCoordinator:
     ) -> None:
         """Record successful worker completion."""
         try:
-            full_result = str(result) if result else None
+            full_result = None if result is None else str(result)
             stored_result = full_result
             if full_result and self._context_engine is not None:
                 stored_result = (
@@ -612,12 +654,13 @@ class CheckpointCoordinator:
     ) -> None:
         """Update a worker call's heartbeat status; stop writer if all done."""
         try:
-            whb = self._worker_heartbeats.get(agent_name)
-            if whb is None:
-                return
-            whb.update_call_status(call_index, status)
-            if whb.all_calls_terminal():
-                whb.stop()
+            with self._worker_heartbeats_lock:
+                whb = self._worker_heartbeats.get(agent_name)
+                if whb is None:
+                    return
+                whb.update_call_status(call_index, status)
+                if whb.all_calls_terminal():
+                    whb.stop()
         except Exception as exc:
             _logger.debug("Worker heartbeat update failed: %s", exc)
 
@@ -637,13 +680,20 @@ class CheckpointCoordinator:
 
     def get_worker_heartbeat(self, agent_name: str) -> "WorkerHeartbeat | None":
         """Return the heartbeat writer for *agent_name* (if any)."""
-        return self._worker_heartbeats.get(agent_name)
+        with self._worker_heartbeats_lock:
+            return self._worker_heartbeats.get(agent_name)
 
     def stop_all_worker_heartbeats(self) -> None:
         """Stop all worker heartbeat writers.  Called by runner on shutdown."""
-        for whb in self._worker_heartbeats.values():
+        with self._worker_heartbeats_lock:
+            heartbeats = list(self._worker_heartbeats.values())
+            self._worker_heartbeats.clear()
+        for whb in heartbeats:
             try:
                 whb.stop()
             except Exception:
                 pass
-        self._worker_heartbeats.clear()
+            try:
+                whb.close()
+            except Exception:
+                pass

--- a/src/lib/checkpoint/file_history.py
+++ b/src/lib/checkpoint/file_history.py
@@ -9,7 +9,7 @@ reversed when resuming from a checkpoint.
 
 Storage layout::
 
-    .runtime/{agent_name}/file-history/{task_id}/
+    {runtime.root_dir}/checkpoints/{application_id}/{task_id}/file-history/
         {hash}@v1          # Pre-edit backup of original file
         {hash}@v2          # Post-step snapshot
         snapshots.json     # Persistent index for resume
@@ -25,10 +25,7 @@ Usage::
 from __future__ import annotations
 
 import hashlib
-import json
 import os
-import shutil
-import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
@@ -36,6 +33,7 @@ from pathlib import Path
 from typing import Optional
 
 from src.lib.logging import get_logger
+from src.lib.runtime import SecureDirectory
 
 _logger = get_logger(__name__)
 
@@ -83,9 +81,14 @@ class FileHistoryManager:
     the expensive I/O (file copy) happens outside the critical section.
     """
 
-    def __init__(self, backup_dir: Path | str) -> None:
+    def __init__(
+        self,
+        backup_dir: Path | str,
+        *,
+        storage: SecureDirectory | None = None,
+    ) -> None:
         self._backup_dir = Path(backup_dir)
-        self._backup_dir.mkdir(parents=True, exist_ok=True)
+        self._storage = storage or SecureDirectory(self._backup_dir, create=True)
         self._lock = threading.Lock()
         self._snapshots: list[FileHistorySnapshot] = []
         self._tracked_files: set[str] = set()
@@ -169,8 +172,7 @@ class FileHistoryManager:
 
                 # Check if file changed since last backup.
                 if prev_backup and prev_backup.backup_filename is not None:
-                    backup_path = self._backup_dir / prev_backup.backup_filename
-                    if backup_path.exists() and not self._file_changed(abs_path, str(backup_path)):
+                    if not self._file_changed(abs_path, prev_backup.backup_filename):
                         # Unchanged — reuse previous backup.
                         new_backups[abs_path] = prev_backup
                         continue
@@ -236,13 +238,17 @@ class FileHistoryManager:
                         restored.append(abs_path)
                         _logger.info("FileHistory: deleted %s (didn't exist at step %d)", abs_path, step_number)
                 else:
-                    backup_path = self._backup_dir / backup.backup_filename
-                    if not backup_path.exists():
-                        _logger.warning("FileHistory: backup file missing: %s", backup_path)
+                    try:
+                        self._storage.stat_file(backup.backup_filename)
+                    except (FileNotFoundError, OSError, RuntimeError):
+                        _logger.warning(
+                            "FileHistory: backup file missing: %s",
+                            self._backup_dir / backup.backup_filename,
+                        )
                         continue
                     # Ensure parent directory exists (file may have been deleted).
                     os.makedirs(os.path.dirname(abs_path), exist_ok=True)
-                    shutil.copy2(str(backup_path), abs_path)
+                    self._storage.copy_to(backup.backup_filename, abs_path)
                     restored.append(abs_path)
                     _logger.info("FileHistory: restored %s to step %d (v%d)", abs_path, step_number, backup.version)
             except Exception as exc:
@@ -281,6 +287,18 @@ class FileHistoryManager:
                     tracked_file_backups=backups,
                     timestamp=snap_data.get("timestamp", 0.0),
                 ))
+
+    def restore_persisted_index(self) -> bool:
+        """Restore ``snapshots.json`` through the anchored storage handle."""
+
+        try:
+            data = self._storage.read_json("snapshots.json")
+        except FileNotFoundError:
+            return False
+        if not isinstance(data, dict):
+            raise ValueError("file-history snapshots.json must contain an object")
+        self.restore_from_index(data)
+        return True
 
     @property
     def snapshot_count(self) -> int:
@@ -356,21 +374,7 @@ class FileHistoryManager:
 
         phash = _path_hash(file_path)
         filename = f"{phash}@v{version}"
-        dest = self._backup_dir / filename
-
-        # Atomic copy via temp file.
-        fd, tmp_path = tempfile.mkstemp(dir=str(self._backup_dir), prefix=f".bk_{phash}_")
-        try:
-            os.close(fd)
-            shutil.copy2(file_path, tmp_path)
-            os.replace(tmp_path, str(dest))
-        except Exception:
-            # Clean up temp file on failure.
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+        self._storage.copy_from(file_path, filename)
 
         return FileHistoryBackup(
             backup_filename=filename,
@@ -378,23 +382,15 @@ class FileHistoryManager:
             backup_time=time.time(),
         )
 
-    def _file_changed(self, original: str, backup: str) -> bool:
+    def _file_changed(self, original: str, backup_filename: str) -> bool:
         """Check if *original* differs from *backup* by comparing content."""
         try:
-            orig_stat = os.stat(original)
-            bk_stat = os.stat(backup)
-            # Quick size check.
-            if orig_stat.st_size != bk_stat.st_size:
-                return True
-            # Content comparison.
-            with open(original, "rb") as f1, open(backup, "rb") as f2:
-                return f1.read() != f2.read()
-        except OSError:
+            return not self._storage.same_content_as(backup_filename, original)
+        except (OSError, RuntimeError):
             return True
 
     def _persist_index(self) -> None:
         """Atomically write ``snapshots.json`` to the backup directory."""
-        index_path = self._backup_dir / "snapshots.json"
         with self._lock:
             data = {
                 "first_tracked_backups": {
@@ -422,14 +418,13 @@ class FileHistoryManager:
                 ],
             }
 
-        fd, tmp_path = tempfile.mkstemp(dir=str(self._backup_dir), prefix=".idx_")
+        self._storage.atomic_write_json("snapshots.json", data)
+
+    def close(self) -> None:
+        self._storage.close()
+
+    def __del__(self) -> None:
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-            os.replace(tmp_path, str(index_path))
+            self.close()
         except Exception:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+            pass

--- a/src/lib/config/__init__.py
+++ b/src/lib/config/__init__.py
@@ -8,6 +8,8 @@ _LAZY_EXPORTS = {
     "get_default_toolsets": (".config", "get_default_toolsets"),
     "get_model_config": (".config", "get_model_config"),
     "RootSettings": (".config_validation", "RootSettings"),
+    "LoggingSettings": (".config_validation", "LoggingSettings"),
+    "RuntimeSettings": (".config_validation", "RuntimeSettings"),
     "normalize_tool_access_control_section": (
         ".config_validation",
         "normalize_tool_access_control_section",
@@ -37,8 +39,10 @@ def __dir__() -> list[str]:
 __all__ = [
     "C",
     "LayeredConfigBuilder",
+    "LoggingSettings",
     "OverlaySpec",
     "RootSettings",
+    "RuntimeSettings",
     "build_effective_agent_config",
     "get_code_agent_config",
     "get_config",

--- a/src/lib/config/config.py
+++ b/src/lib/config/config.py
@@ -53,6 +53,7 @@ _WORKFLOW_OVERLAY_KEYS = {
     "self_learning",
 }
 _LLM_ONLY_TOP_LEVEL_KEYS = {"model", "llm", "langfuse"}
+_GLOBAL_ONLY_TOP_LEVEL_KEYS = {"runtime", "logging"}
 
 logger = get_logger(__name__)
 
@@ -117,6 +118,31 @@ def _filter_llm_only_top_level_keys(
             )
             continue
         filtered[key] = value
+    return filtered
+
+
+def _reject_application_global_only_keys(
+    config_map: dict[str, Any] | None,
+    *,
+    source_name: str,
+) -> dict[str, Any]:
+    """Reject configuration that would pretend to override global storage.
+
+    Application config may tune checkpoint behavior, but allowing it to move
+    ``runtime.root_dir`` would fragment task discovery and retention across
+    unrelated roots in the same process.  Silently dropping these keys is also
+    unsafe because the caller would reasonably believe the override applied.
+    """
+
+    filtered = dict(config_map or {})
+    disallowed = sorted(_GLOBAL_ONLY_TOP_LEVEL_KEYS.intersection(filtered))
+    if disallowed:
+        keys = ", ".join(disallowed)
+        raise ValueError(
+            f"Unsupported global-only key(s) in {source_name}: {keys}. "
+            "Configure runtime and logging only in the project root "
+            "config/system.yaml."
+        )
     return filtered
 
 
@@ -424,7 +450,14 @@ def extract_workflow_overlay(
         source = str(config_map.get("_yaml_file_path") or config_map.get("name") or "workflow config")
         raise raise_project_key_error(source)
 
-    filtered_map = _filter_llm_only_top_level_keys(config_map, source_name=source_name)
+    filtered_map = _reject_application_global_only_keys(
+        config_map,
+        source_name=source_name,
+    )
+    filtered_map = _filter_llm_only_top_level_keys(
+        filtered_map,
+        source_name=source_name,
+    )
     overlay: dict[str, Any] = {}
     for key in _WORKFLOW_OVERLAY_KEYS:
         if key not in filtered_map:
@@ -489,21 +522,26 @@ def build_effective_agent_config(
                 app_root = _resolve_app_root_from_yaml(
                     base.agent_root, Path(yaml_file_path)
                 )
-                app_config_path = app_root / APP_CONFIG_RELATIVE_PATH
-                if app_root != base.agent_root and app_config_path.exists():
-                    app_system_yaml = _filter_llm_only_top_level_keys(
-                        _load_yaml(app_config_path),
-                        source_name=str(app_config_path),
-                    )
-                    layered_builder.apply_mapping(
-                        str(app_config_path), app_system_yaml
-                    )
             except ValueError:
                 logger.warning(
                     "Skipped application config discovery for '%s': "
                     "no workflows/ directory found.",
                     yaml_file_path,
                 )
+            else:
+                app_config_path = app_root / APP_CONFIG_RELATIVE_PATH
+                if app_root != base.agent_root and app_config_path.exists():
+                    app_system_yaml = _filter_llm_only_top_level_keys(
+                        _load_yaml(app_config_path),
+                        source_name=str(app_config_path),
+                    )
+                    app_system_yaml = _reject_application_global_only_keys(
+                        app_system_yaml,
+                        source_name=str(app_config_path),
+                    )
+                    layered_builder.apply_mapping(
+                        str(app_config_path), app_system_yaml
+                    )
 
     # --- Agent YAML overlay ---
     if isinstance(agent_config, dict):

--- a/src/lib/config/config_validation.py
+++ b/src/lib/config/config_validation.py
@@ -280,11 +280,43 @@ class ToolAccessControlSettings(BaseModel):
     path_validation: list[PathValidationRule] = Field(default_factory=list)
 
 
+class RuntimeSettings(BaseModel):
+    """Canonical runtime-home and retention settings."""
+
+    model_config = ConfigDict(extra="forbid")
+    root_dir: str = ".agentloom"
+    successful_run_retention_days: int = Field(default=7, ge=0)
+    failed_run_retention_days: int = Field(default=30, ge=0)
+    artifact_retention_days: int = Field(default=3, ge=0)
+    cleanup_interval_hours: int = Field(default=24, ge=24)
+
+    @field_validator("root_dir")
+    @classmethod
+    def _validate_root_dir(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("runtime.root_dir must not be empty")
+        return cleaned
+
+
+class LoggingSettings(BaseModel):
+    """Run-scoped logging settings with bounded file retention."""
+
+    model_config = ConfigDict(extra="forbid")
+    level: str | int = "INFO"
+    console_enabled: bool = True
+    file_enabled: bool = True
+    max_file_bytes: int = Field(default=25 * 1024 * 1024, ge=1)
+    backup_count: int = Field(default=3, ge=0)
+
+
 class RootSettings(BaseModel):
     model_config = ConfigDict(extra="allow")
     system: SystemSettings = Field(default_factory=SystemSettings)
     model_request_headers: ModelRequestHeadersSettings = Field(default_factory=ModelRequestHeadersSettings)
     tool_access_control: ToolAccessControlSettings = Field(default_factory=ToolAccessControlSettings)
+    runtime: RuntimeSettings = Field(default_factory=RuntimeSettings)
+    logging: LoggingSettings = Field(default_factory=LoggingSettings)
     smart_summary: bool = True
     context_engine: dict[str, Any] = Field(default_factory=dict)
     model: dict[str, Any] = Field(default_factory=dict)
@@ -314,6 +346,12 @@ def validate_system_snapshot(snapshot: dict[str, Any], source: str) -> None:
         raise ValueError(
             f"Unsupported top-level key 'default_loaded_tools' in {source}. "
             "Use 'default_toolsets' in system config or 'toolsets' in Agent YAML."
+        )
+    self_learning = snapshot.get("self_learning")
+    if isinstance(self_learning, dict) and "root_dir" in self_learning:
+        raise ValueError(
+            f"Unsupported key 'self_learning.root_dir' in {source}. "
+            "Use the single canonical 'runtime.root_dir'."
         )
     tools_mapping = snapshot.get("tools_mapping")
     if isinstance(tools_mapping, dict) and "mapping" in tools_mapping:

--- a/src/lib/context_engine/engine.py
+++ b/src/lib/context_engine/engine.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
+from src.lib.runtime import SecureDirectory
+
 from .compressors import compress_content
 from .config import ContextEngineConfig
 from .models import CompressionResult, ContextEntry
 from .router import route_content
 from .store import ContextStore, make_context_ref
-
 
 CONTEXT_REF_PREFIX = "[ContextRef "
 
@@ -21,12 +22,14 @@ class ContextEngine:
         store_dir: Path,
         *,
         config: ContextEngineConfig | None = None,
+        storage: SecureDirectory | None = None,
     ) -> None:
         self.config = config or ContextEngineConfig.from_runtime()
         self.store = ContextStore(
             store_dir,
             max_entries=self.config.store.max_entries,
             ttl_seconds=self.config.store.ttl_seconds,
+            storage=storage,
         )
 
     def should_compress_tool_result(self, text: str, tool_name: str = "default") -> bool:
@@ -87,6 +90,9 @@ class ContextEngine:
 
     def stats_snapshot(self) -> dict:
         return self.store.stats_snapshot()
+
+    def close(self) -> None:
+        self.store.close()
 
     def format_preview(self, entry: ContextEntry, compressed: CompressionResult | None = None) -> str:
         preview = compressed.preview if compressed else entry.preview

--- a/src/lib/context_engine/runtime.py
+++ b/src/lib/context_engine/runtime.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
-import threading
 from typing import Optional
 
 from .engine import ContextEngine
@@ -12,23 +11,14 @@ from .engine import ContextEngine
 _current_context_engine: ContextVar[Optional[ContextEngine]] = ContextVar(
     "_current_context_engine", default=None
 )
-_active_lock = threading.Lock()
-_active_context_engine: Optional[ContextEngine] = None
 
 
 def set_current_context_engine(engine: ContextEngine | None) -> None:
-    global _active_context_engine
     _current_context_engine.set(engine)
-    with _active_lock:
-        _active_context_engine = engine
 
 
 def get_current_context_engine() -> ContextEngine | None:
-    engine = _current_context_engine.get()
-    if engine is not None:
-        return engine
-    with _active_lock:
-        return _active_context_engine
+    return _current_context_engine.get()
 
 
 def get_active_context_engine() -> ContextEngine | None:
@@ -42,10 +32,6 @@ def get_active_context_engine() -> ContextEngine | None:
 
 
 def clear_current_context_engine(engine: ContextEngine | None = None) -> None:
-    global _active_context_engine
     current = _current_context_engine.get()
     if engine is None or current is engine:
         _current_context_engine.set(None)
-    with _active_lock:
-        if engine is None or _active_context_engine is engine:
-            _active_context_engine = None

--- a/src/lib/context_engine/store.py
+++ b/src/lib/context_engine/store.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Iterable
 
 from src.lib.logging import get_logger
+from src.lib.runtime import SecureDirectory
 
 from .models import ContextEntry
-
 
 _logger = get_logger(__name__)
 _REF_RE = re.compile(r"^ctx_[0-9a-f]{16}$")
@@ -27,6 +27,7 @@ class ContextStore:
         *,
         max_entries: int = 1000,
         ttl_seconds: int | None = None,
+        storage: SecureDirectory | None = None,
     ) -> None:
         self.root_dir = Path(root_dir)
         self.entries_dir = self.root_dir / "entries"
@@ -34,18 +35,18 @@ class ContextStore:
         self.max_entries = max_entries
         self.ttl_seconds = ttl_seconds
         self._lock = threading.RLock()
-        self.entries_dir.mkdir(parents=True, exist_ok=True)
+        self._storage = storage or SecureDirectory(self.root_dir, create=True)
+        self._storage.ensure_dir("entries")
 
     def put(self, entry: ContextEntry) -> ContextEntry:
         if not _REF_RE.match(entry.ref):
             raise ValueError(f"Invalid context ref: {entry.ref}")
         with self._lock:
-            self.entries_dir.mkdir(parents=True, exist_ok=True)
             self._evict_if_needed()
-            path = self._entry_path(entry.ref)
-            tmp = path.with_suffix(".json.tmp")
-            tmp.write_text(json.dumps(entry.to_json(), ensure_ascii=False, indent=2), encoding="utf-8")
-            tmp.replace(path)
+            self._storage.atomic_write_json(
+                f"entries/{entry.ref}.json",
+                entry.to_json(),
+            )
             self._append_event(
                 {
                     "type": "compressed",
@@ -63,11 +64,8 @@ class ContextStore:
     def get(self, ref: str) -> ContextEntry | None:
         if not _REF_RE.match(ref):
             return None
-        path = self._entry_path(ref)
-        if not path.exists():
-            return None
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            data = self._storage.read_json(f"entries/{ref}.json")
             entry = ContextEntry.from_json(data)
         except Exception as exc:
             _logger.warning("Failed to read context entry %s: %s", ref, exc)
@@ -132,9 +130,15 @@ class ContextStore:
         }
 
     def refs(self) -> list[str]:
-        if not self.entries_dir.exists():
+        try:
+            names = self._storage.regular_file_names("entries")
+        except (FileNotFoundError, OSError, RuntimeError):
             return []
-        return sorted(path.stem for path in self.entries_dir.glob("ctx_*.json"))
+        return sorted(
+            Path(name).stem
+            for name in names
+            if name.startswith("ctx_") and name.endswith(".json")
+        )
 
     def _entry_path(self, ref: str) -> Path:
         return self.entries_dir / f"{ref}.json"
@@ -167,21 +171,38 @@ class ContextStore:
     def _evict_if_needed(self) -> None:
         if self.max_entries <= 0:
             return
-        entries = sorted(self.entries_dir.glob("ctx_*.json"), key=lambda p: p.stat().st_mtime)
+        entries = [
+            name
+            for name in self._storage.regular_file_names("entries")
+            if name.startswith("ctx_") and name.endswith(".json")
+        ]
+        entries.sort(
+            key=lambda name: self._storage.stat_file(f"entries/{name}").st_mtime
+        )
         overflow = len(entries) - max(0, self.max_entries - 1)
-        for path in entries[:max(0, overflow)]:
+        for name in entries[:max(0, overflow)]:
             try:
-                path.unlink()
+                self._storage.unlink(f"entries/{name}")
             except OSError:
                 pass
 
     def _append_event(self, event: dict) -> None:
         try:
-            self.root_dir.mkdir(parents=True, exist_ok=True)
-            with self.events_path.open("a", encoding="utf-8") as fp:
-                fp.write(json.dumps(event, ensure_ascii=False, default=str) + "\n")
+            self._storage.append_text(
+                "events.jsonl",
+                json.dumps(event, ensure_ascii=False, default=str) + "\n",
+            )
         except Exception as exc:
             _logger.debug("Failed to write context store event: %s", exc)
+
+    def close(self) -> None:
+        self._storage.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
 
 def make_context_ref(original: str, *, tool_name: str, source: str = "") -> str:

--- a/src/lib/heartbeat/__init__.py
+++ b/src/lib/heartbeat/__init__.py
@@ -15,13 +15,13 @@ Backward-compatible alias:
 """
 
 from src.lib.heartbeat._base import BaseHeartbeatWriter
-from src.lib.heartbeat.supervisor_heartbeat import SupervisorHeartbeat
-from src.lib.heartbeat.worker_heartbeat import WorkerHeartbeat
 from src.lib.heartbeat.status import (
     HEARTBEAT_STALE_THRESHOLD,
     detect_crashed_status,
     detect_worker_call_crashed,
 )
+from src.lib.heartbeat.supervisor_heartbeat import SupervisorHeartbeat
+from src.lib.heartbeat.worker_heartbeat import WorkerHeartbeat
 
 # Backward-compatible alias — existing code that imports HeartbeatWriter
 # continues to work without changes.

--- a/src/lib/heartbeat/_base.py
+++ b/src/lib/heartbeat/_base.py
@@ -8,11 +8,11 @@ write) and optionally :meth:`_on_stopping` (cleanup before the final write).
 from __future__ import annotations
 
 import atexit
-import json
-import os
 import threading
 import time
 from pathlib import Path
+
+from src.lib.runtime import SecureDirectory
 
 
 class BaseHeartbeatWriter:
@@ -30,9 +30,20 @@ class BaseHeartbeatWriter:
       final write (e.g. set ``status = "stopped"``).
     """
 
-    def __init__(self, path: Path, agent_name: str, interval: float = 5.0):
+    def __init__(
+        self,
+        path: Path,
+        agent_name: str,
+        run_id: str,
+        interval: float = 5.0,
+        storage: SecureDirectory | None = None,
+    ):
+        if not str(run_id).strip():
+            raise ValueError("run_id is required for heartbeat writers")
         self._path = Path(path)
+        self._storage = storage or SecureDirectory(self._path.parent, create=True)
         self._agent_name = agent_name
+        self._run_id = str(run_id)
         self._interval = interval
 
         self._stop_event = threading.Event()
@@ -94,9 +105,15 @@ class BaseHeartbeatWriter:
         try:
             with self._write_lock:
                 data = self._build_payload()
-                self._path.parent.mkdir(parents=True, exist_ok=True)
-                tmp = self._path.with_suffix(".tmp")
-                tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-                tmp.replace(self._path)
+                self._storage.atomic_write_json(self._path.name, data)
         except Exception:
             pass  # heartbeat must never crash the host process
+
+    def close(self) -> None:
+        self._storage.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/src/lib/heartbeat/supervisor_heartbeat.py
+++ b/src/lib/heartbeat/supervisor_heartbeat.py
@@ -8,8 +8,9 @@ is blocked on a long-running LLM call with no log output.
 Usage::
 
     hb = SupervisorHeartbeat(
-        path=Path(".runtime/agent/checkpoints/task_xxx/heartbeat.json"),
+        path=runtime_context.heartbeat_path,
         agent_name="code_review_agent",
+        run_id=runtime_context.run_id,
     )
     hb.start()
     ...
@@ -25,6 +26,7 @@ import time
 from pathlib import Path
 
 from src.lib.heartbeat._base import BaseHeartbeatWriter
+from src.lib.runtime import SecureDirectory
 
 
 class SupervisorHeartbeat(BaseHeartbeatWriter):
@@ -42,9 +44,17 @@ class SupervisorHeartbeat(BaseHeartbeatWriter):
         self,
         path: Path,
         agent_name: str,
+        run_id: str,
         interval: float = 5.0,
+        storage: SecureDirectory | None = None,
     ):
-        super().__init__(path=path, agent_name=agent_name, interval=interval)
+        super().__init__(
+            path=path,
+            agent_name=agent_name,
+            run_id=run_id,
+            interval=interval,
+            storage=storage,
+        )
         self._step: int = 0
         self._status: str = "running"
 
@@ -66,6 +76,7 @@ class SupervisorHeartbeat(BaseHeartbeatWriter):
             "status": self._status,
             "step": self._step,
             "agent_name": self._agent_name,
+            "run_id": self._run_id,
         }
 
     def _on_stopping(self) -> None:

--- a/src/lib/heartbeat/worker_heartbeat.py
+++ b/src/lib/heartbeat/worker_heartbeat.py
@@ -7,7 +7,7 @@ tracks all concurrent calls.  This avoids file-per-call proliferation when
 
 File layout::
 
-    .runtime/{supervisor}/checkpoints/{task_id}/workers/{worker_name}/heartbeat.json
+    {runtime.root_dir}/checkpoints/{application_id}/{task_id}/workers/{worker_name}/heartbeat.json
 
 JSON payload::
 
@@ -34,6 +34,7 @@ import time
 from pathlib import Path
 
 from src.lib.heartbeat._base import BaseHeartbeatWriter
+from src.lib.runtime import SecureDirectory
 
 
 class WorkerHeartbeat(BaseHeartbeatWriter):
@@ -48,9 +49,17 @@ class WorkerHeartbeat(BaseHeartbeatWriter):
         self,
         path: Path,
         agent_name: str,
+        run_id: str,
         interval: float = 5.0,
+        storage: SecureDirectory | None = None,
     ):
-        super().__init__(path=path, agent_name=agent_name, interval=interval)
+        super().__init__(
+            path=path,
+            agent_name=agent_name,
+            run_id=run_id,
+            interval=interval,
+            storage=storage,
+        )
         self._lock = threading.Lock()
         self._calls: dict[str, dict] = {}
 
@@ -102,6 +111,7 @@ class WorkerHeartbeat(BaseHeartbeatWriter):
             calls_snapshot = {k: dict(v) for k, v in self._calls.items()}
         return {
             "agent_name": self._agent_name,
+            "run_id": self._run_id,
             "pid": os.getpid(),
             "timestamp": time.time(),
             "timestamp_iso": time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime()),

--- a/src/lib/logging/__init__.py
+++ b/src/lib/logging/__init__.py
@@ -1,6 +1,6 @@
 """Unified logging helpers for AgentLoom."""
 
-from .agent_logger import EnhancedAgentLogger, AgentLoomLogLevel
+from .agent_logger import AgentLoomLogLevel, EnhancedAgentLogger
 from .logger_manager import (
     LazyLoggerAdapter,
     LoggerAdapter,
@@ -8,18 +8,15 @@ from .logger_manager import (
     LoggingConfigOverlay,
     NullLoggerBackend,
     UnifiedLogger,
-    build_default_log_filename,
-    build_run_timestamp_dirname,
+    bind_logger_backend,
     build_logger_backend_from_config,
-    get_current_run_log_dir,
-    get_global_logger,
-    get_or_create_process_log_path,
+    close_run_logger,
     get_active_log_file_path,
+    get_global_logger,
     get_logger,
-    initialize_logging,
     initialize_global_logger_once,
+    initialize_run_logger,
     merge_logging_config,
-    resolve_log_file_path,
     resolve_logger,
     set_global_logger,
     validate_logging_config,
@@ -34,19 +31,16 @@ __all__ = [
     "LoggingConfigBuilder",
     "LoggingConfigOverlay",
     "NullLoggerBackend",
-    "initialize_logging",
+    "bind_logger_backend",
+    "close_run_logger",
     "initialize_global_logger_once",
+    "initialize_run_logger",
     "get_logger",
     "resolve_logger",  # backward-compatible alias for get_logger
     "set_global_logger",
     "get_global_logger",
-    "get_or_create_process_log_path",
-    "build_default_log_filename",
-    "build_run_timestamp_dirname",
     "build_logger_backend_from_config",
-    "get_current_run_log_dir",
     "merge_logging_config",
     "validate_logging_config",
-    "resolve_log_file_path",
     "get_active_log_file_path",
 ]

--- a/src/lib/logging/agent_logger.py
+++ b/src/lib/logging/agent_logger.py
@@ -3,16 +3,13 @@
 
 from datetime import datetime
 from enum import IntEnum
+
 from rich.console import Console
 from rich.text import Text
 from smolagents import AgentLogger
 from smolagents import LogLevel as SmolaLogLevel
 
-from src.trace import (
-    get_current_task_id,
-    get_current_sub_task_id,
-    get_current_agent_name,
-)
+from src.trace import capture_explicit_execution_context
 
 
 class AgentLoomLogLevel(IntEnum):
@@ -150,9 +147,10 @@ class EnhancedAgentLogger(AgentLogger):
             ts = datetime.now().strftime(self.timestamp_format)
             prefix.append(f"[{ts}]", style=TIMESTAMP_STYLE)
         if self.show_trace_info:
-            task_id    = get_current_task_id()
-            sub_id     = get_current_sub_task_id()
-            agent_name = get_current_agent_name()
+            execution_context = capture_explicit_execution_context()
+            task_id = execution_context.task_id
+            sub_id = execution_context.sub_task_id
+            agent_name = execution_context.agent_name
             if task_id:
                 prefix.append(f"[task:{self._truncate_id(task_id)}]", style=TASK_ID_STYLE)
             if sub_id:

--- a/src/lib/logging/logger_manager.py
+++ b/src/lib/logging/logger_manager.py
@@ -1,30 +1,41 @@
 from __future__ import annotations
 
+import contextvars
 import logging
 import os
-import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
-from threading import Lock, RLock
 from typing import Any, Protocol, runtime_checkable
 
-from src.lib.config.config_validation import BoolParser, LogLevelParser
+from src.lib.config.config_validation import BoolParser
+from src.lib.runtime import RuntimeContext, get_current_run_context
 
 DEFAULT_LEVEL = "INFO"
-DEFAULT_LOG_DIR = ".logs"
-_ALLOWED_LOGGING_KEYS = {"enabled", "level", "file_path", "dir"}
-
-
-_INIT_LOCK = Lock()
-_INITIALIZED = False
-_ACTIVE_LOG_FILE_PATH: Path | None = None
-_PROCESS_LOG_FILE_PATH: Path | None = None
-_PROCESS_LOG_PATH_LOCK = RLock()
-_GLOBAL_LOGGER_LOCK = RLock()
-_GLOBAL_LOGGER: Any | None = None
-_SAFE_COMPONENT_PATTERN = re.compile(r"[^A-Za-z0-9._-]+")
+DEFAULT_CONSOLE_ENABLED = True
+DEFAULT_FILE_ENABLED = True
+DEFAULT_MAX_FILE_BYTES = 25 * 1024 * 1024
+DEFAULT_BACKUP_COUNT = 3
+_ALLOWED_LOGGING_KEYS = {
+    "level",
+    "console_enabled",
+    "file_enabled",
+    "max_file_bytes",
+    "backup_count",
+}
 _MEMORY_CAMPAIGN_SAFE_ARTIFACTS_ENV = "AGENTLOOM_MEMORY_CAMPAIGN_SAFE_ARTIFACTS"
+
+
+@dataclass(frozen=True)
+class _LoggerBinding:
+    backend: Any
+    runtime_key: tuple[str, str, str, str] | None
+
+
+_CURRENT_LOGGER_BINDING: contextvars.ContextVar[_LoggerBinding | None] = (
+    contextvars.ContextVar("agentloom_logger_backend", default=None)
+)
 
 
 def _memory_campaign_safe_artifacts_enabled() -> bool:
@@ -46,50 +57,6 @@ def _get_config_value(*keys: str, default: Any = None) -> Any:
         return default
 
 
-def _get_agent_root() -> Path:
-    try:
-        from src.lib.config import C
-
-        return Path(C.agent_root).resolve()
-    except Exception:
-        return Path.cwd().resolve()
-
-
-def _sanitize_path_component(value: str | None, *, fallback: str = "unknown") -> str:
-    if value is None:
-        return fallback
-    normalized = _SAFE_COMPONENT_PATTERN.sub("_", value.strip())
-    normalized = normalized.strip("._")
-    return normalized or fallback
-
-
-def build_default_log_filename(app_name: str, now: datetime | None = None) -> str:
-    """Build ``<app_name>.log`` — the per-run log filename.
-
-    The timestamp is now encoded in the **parent directory** name
-    (``{base}/{agent}/{timestamp}/``) so the filename itself is stable.
-
-    Args:
-        app_name: Application name from the YAML ``name`` field.
-        now: Accepted for backward compatibility but no longer used.
-    """
-    stem = _sanitize_path_component(app_name, fallback="session")
-    return f"{stem}.log"
-
-
-def build_run_timestamp_dirname(now: datetime | None = None) -> str:
-    """Build the per-run timestamp directory name ``YYYYMMDD_HHMMSS``.
-
-    Args:
-        now: Optional fixed datetime for deterministic names in tests.
-    """
-    return (now or datetime.now()).strftime("%Y%m%d_%H%M%S")
-
-
-def _candidate_with_suffix(path: Path, suffix_index: int) -> Path:
-    return path.with_name(f"{path.stem}_{suffix_index}{path.suffix}")
-
-
 def _resolve_config_logging_section() -> dict[str, Any]:
     cfg = _get_config_value("logging", default={})
     if isinstance(cfg, dict):
@@ -108,31 +75,33 @@ def validate_logging_config(
         raise ValueError(f"{source} must be a mapping")
     unknown = sorted(set(logging_config.keys()) - _ALLOWED_LOGGING_KEYS)
     if unknown:
-        logging.getLogger(__name__).warning(
-            "%s contains unsupported keys and they will be ignored: %s",
-            source,
-            ", ".join(unknown),
+        raise ValueError(
+            f"{source} contains unsupported logging key(s): "
+            f"{', '.join(unknown)}"
         )
-    return {key: value for key, value in logging_config.items() if key in _ALLOWED_LOGGING_KEYS}
+    return dict(logging_config)
 
 
 @dataclass(frozen=True)
 class LoggingConfigOverlay:
-    enabled: Any = None
     level: Any = None
-    file_path: Any = None
-    dir: Any = None
+    console_enabled: Any = None
+    file_enabled: Any = None
+    max_file_bytes: Any = None
+    backup_count: Any = None
 
     def to_mapping(self) -> dict[str, Any]:
         mapping: dict[str, Any] = {}
-        if self.enabled is not None:
-            mapping["enabled"] = self.enabled
         if self.level is not None:
             mapping["level"] = self.level
-        if self.file_path is not None:
-            mapping["file_path"] = self.file_path
-        if self.dir is not None:
-            mapping["dir"] = self.dir
+        if self.console_enabled is not None:
+            mapping["console_enabled"] = self.console_enabled
+        if self.file_enabled is not None:
+            mapping["file_enabled"] = self.file_enabled
+        if self.max_file_bytes is not None:
+            mapping["max_file_bytes"] = self.max_file_bytes
+        if self.backup_count is not None:
+            mapping["backup_count"] = self.backup_count
         return mapping
 
 
@@ -147,7 +116,7 @@ class LoggingConfigBuilder:
         overlay: LoggingConfigOverlay,
         *,
         source: str = "overlay",
-    ) -> "LoggingConfigBuilder":
+    ) -> LoggingConfigBuilder:
         self._layers.append((source, overlay.to_mapping()))
         return self
 
@@ -156,13 +125,13 @@ class LoggingConfigBuilder:
         mapping: dict[str, Any] | None,
         *,
         source: str = "overlay",
-    ) -> "LoggingConfigBuilder":
+    ) -> LoggingConfigBuilder:
         normalized = validate_logging_config(mapping, source=source)
         if normalized:
             self._layers.append((source, normalized))
         return self
 
-    def extend(self, other: "LoggingConfigBuilder") -> "LoggingConfigBuilder":
+    def extend(self, other: LoggingConfigBuilder) -> LoggingConfigBuilder:
         self._layers.extend(other._layers)
         return self
 
@@ -181,185 +150,6 @@ def merge_logging_config(logging_builder: LoggingConfigBuilder | None = None) ->
     if logging_builder is None:
         logging_builder = LoggingConfigBuilder()
     return logging_builder.build(include_system_defaults=True)
-
-
-def _resolve_explicit_path(path_value: str | Path, ensure_parent: bool = True) -> Path:
-    path_obj = Path(path_value).expanduser()
-    if not path_obj.is_absolute():
-        path_obj = _get_agent_root() / path_obj
-    resolved = path_obj.resolve()
-    if ensure_parent:
-        resolved.parent.mkdir(parents=True, exist_ok=True)
-    return resolved
-
-
-def resolve_log_file_path(
-    app_name: str,
-    *,
-    log_file_path: str | Path | None = None,
-    now: datetime | None = None,
-    logging_builder: LoggingConfigBuilder | None = None,
-    ensure_parent: bool = True,
-) -> Path:
-    """Resolve final log file path.
-
-    Priority:
-      1) explicit *log_file_path* argument
-      2) merged ``logging.file_path`` from config + override
-      3) default layered path: ``{logging.dir}/{app_name}/{app_name}_{ts}.log``
-
-    Args:
-        app_name: Application name from the YAML ``name`` field.  Used both as
-            the sub-directory under the log root **and** the filename stem.
-    """
-    if log_file_path:
-        return _resolve_explicit_path(log_file_path, ensure_parent=ensure_parent)
-
-    effective_logging = merge_logging_config(logging_builder)
-    configured_path = effective_logging.get("file_path")
-    if isinstance(configured_path, str) and configured_path.strip():
-        return _resolve_explicit_path(configured_path.strip(), ensure_parent=ensure_parent)
-
-    configured_dir = effective_logging.get("dir", DEFAULT_LOG_DIR)
-    if isinstance(configured_dir, str) and configured_dir.strip():
-        base_dir = Path(configured_dir.strip()).expanduser()
-    else:
-        base_dir = Path(DEFAULT_LOG_DIR)
-    if not base_dir.is_absolute():
-        base_dir = _get_agent_root() / base_dir
-    base_dir = base_dir.resolve()
-
-    sanitized_name = _sanitize_path_component(app_name, fallback="session")
-    ts_dir_name = build_run_timestamp_dirname(now=now)
-    # Layout: {base_dir}/{agent_name}/{timestamp}/{agent_name}.log
-    target_dir = (base_dir / sanitized_name / ts_dir_name).resolve()
-    filename = build_default_log_filename(app_name, now=now)
-
-    # Handle collision: if the timestamp dir already exists (same-second run),
-    # append a numeric suffix to the directory name.
-    suffix_index = 1
-    while target_dir.exists():
-        target_dir = (base_dir / sanitized_name / f"{ts_dir_name}_{suffix_index}").resolve()
-        suffix_index += 1
-
-    if ensure_parent:
-        target_dir.mkdir(parents=True, exist_ok=True)
-
-    return (target_dir / filename).resolve()
-
-
-def get_or_create_process_log_path(
-    app_name: str,
-    *,
-    log_file_path: str | Path | None = None,
-    now: datetime | None = None,
-    logging_builder: LoggingConfigBuilder | None = None,
-    ensure_parent: bool = True,
-) -> Path:
-    """Return process-scoped log file path, creating and caching it on first access.
-
-    Args:
-        app_name: Application name from the YAML ``name`` field.
-    """
-    global _PROCESS_LOG_FILE_PATH
-
-    with _PROCESS_LOG_PATH_LOCK:
-        if log_file_path:
-            resolved = resolve_log_file_path(
-                app_name,
-                log_file_path=log_file_path,
-                now=now,
-                logging_builder=logging_builder,
-                ensure_parent=ensure_parent,
-            )
-            _PROCESS_LOG_FILE_PATH = resolved
-            return resolved
-
-        if _PROCESS_LOG_FILE_PATH is not None:
-            if ensure_parent:
-                _PROCESS_LOG_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
-            return _PROCESS_LOG_FILE_PATH
-
-        resolved = resolve_log_file_path(
-            app_name,
-            log_file_path=None,
-            now=now,
-            logging_builder=logging_builder,
-            ensure_parent=ensure_parent,
-        )
-        _PROCESS_LOG_FILE_PATH = resolved
-        return resolved
-
-
-def _configure_noisy_loggers() -> None:
-    for lib in ("httpx", "litellm", "openai"):
-        logging.getLogger(lib).setLevel(logging.WARNING)
-
-
-def initialize_logging(
-    app_name: str,
-    *,
-    force_reconfigure: bool = False,
-    log_file_path: str | Path | None = None,
-) -> Path | None:
-    """Initialize root logging exactly once (unless forced).
-
-    Args:
-        app_name: Application name from the YAML ``name`` field.
-    """
-    global _INITIALIZED, _ACTIVE_LOG_FILE_PATH
-
-    with _INIT_LOCK:
-        if _INITIALIZED and not force_reconfigure and log_file_path is None:
-            return _ACTIVE_LOG_FILE_PATH
-
-        root_logger = logging.getLogger()
-        if force_reconfigure or not _INITIALIZED:
-            for handler in list(root_logger.handlers):
-                root_logger.removeHandler(handler)
-                try:
-                    handler.close()
-                except Exception:
-                    pass
-
-        enabled = BoolParser.parse(_get_config_value("logging", "enabled", default=True), default=True)
-        level = LogLevelParser.parse(_get_config_value("logging", "level", default=DEFAULT_LEVEL))
-
-        if not enabled or level >= LogLevelParser.OFF_LEVEL:
-            logging.disable(LogLevelParser.OFF_LEVEL)
-            root_logger.setLevel(LogLevelParser.OFF_LEVEL)
-            _ACTIVE_LOG_FILE_PATH = None
-            _INITIALIZED = True
-            return None
-
-        logging.disable(logging.NOTSET)
-        resolved_log_file = get_or_create_process_log_path(app_name, log_file_path=log_file_path)
-        formatter = logging.Formatter(
-            "[%(asctime)s] [%(levelname)s] %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-
-        stream_handler = logging.StreamHandler()
-        stream_handler.setLevel(level)
-        stream_handler.setFormatter(formatter)
-
-        file_handler = logging.FileHandler(resolved_log_file, mode="a", encoding="utf-8", delay=True)
-        file_handler.setLevel(level)
-        file_handler.setFormatter(formatter)
-
-        root_logger.addHandler(stream_handler)
-        root_logger.addHandler(file_handler)
-        root_logger.setLevel(level)
-
-        _configure_noisy_loggers()
-
-        _ACTIVE_LOG_FILE_PATH = resolved_log_file
-        _INITIALIZED = True
-        return resolved_log_file
-
-
-def get_active_log_file_path() -> Path | None:
-    return _ACTIVE_LOG_FILE_PATH
 
 
 def _extract_backend_log_file_path(logger_backend: Any | None) -> Path | None:
@@ -413,17 +203,60 @@ def _resolve_agent_log_level(level_value: Any):
     return AgentLoomLogLevel.INFO
 
 
+def _positive_int(value: Any, *, default: int, minimum: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= minimum else default
+
+
+def _runtime_key(context: RuntimeContext | None) -> tuple[str, str, str, str] | None:
+    if context is None:
+        return None
+    return (
+        str(context.root_dir),
+        context.application_id,
+        context.task_id,
+        context.run_id,
+    )
+
+
+def _backend_runtime_tag(backend: Any) -> tuple[str, str, str, str] | None:
+    try:
+        attributes = vars(backend)
+    except TypeError:
+        attributes = {}
+    value = attributes.get("_agentloom_runtime_key")
+    return value if isinstance(value, tuple) and len(value) == 4 else None
+
+
+def _tag_backend_runtime(backend: Any, context: RuntimeContext | None) -> Any:
+    """Attach immutable run ownership to a backend when the object permits it."""
+    runtime_key = _runtime_key(context)
+    if runtime_key is None:
+        return backend
+    existing = _backend_runtime_tag(backend)
+    if existing is not None and existing != runtime_key:
+        raise ValueError("logger backend is already owned by a different RuntimeContext")
+    try:
+        setattr(backend, "_agentloom_runtime_key", runtime_key)
+    except Exception:
+        pass
+    return backend
+
+
 def build_logger_backend_from_config(
-    app_name: str,
+    app_name: str = "AgentLoom",
     *,
     logging_builder: LoggingConfigBuilder | None = None,
-    log_file_path: str | Path | None = None,
-    now: datetime | None = None,
+    runtime_context: RuntimeContext | None = None,
+    file_logging: bool | None = None,
 ) -> Any:
-    """Build an :class:`EnhancedAgentLogger` from merged logging config.
+    """Build a logger without deriving any filesystem path.
 
-    Args:
-        app_name: Application name from the YAML ``name`` field.
+    File output is only possible when a canonical ``RuntimeContext`` is
+    supplied.  Standalone callers receive a console-only backend.
     """
     # Lazy import to keep logging core lightweight and avoid import cycles.
     from rich.console import Console
@@ -432,28 +265,49 @@ def build_logger_backend_from_config(
     from src.lib.logging.rich_console import DualConsole
 
     effective_logging = merge_logging_config(logging_builder)
-    enabled = BoolParser.parse(effective_logging.get("enabled", True), default=True)
     level = _resolve_agent_log_level(effective_logging.get("level", DEFAULT_LEVEL))
-    if not enabled or level == AgentLoomLogLevel.OFF:
-        return NullLoggerBackend()
-
+    console_enabled = BoolParser.parse(
+        effective_logging.get("console_enabled", DEFAULT_CONSOLE_ENABLED),
+        default=DEFAULT_CONSOLE_ENABLED,
+    )
+    file_enabled = BoolParser.parse(
+        effective_logging.get("file_enabled", DEFAULT_FILE_ENABLED),
+        default=DEFAULT_FILE_ENABLED,
+    )
+    if file_logging is not None:
+        file_enabled = bool(file_logging)
     if _memory_campaign_safe_artifacts_enabled():
-        # The campaign captures terminal output through a pipe and sanitizes it
-        # before its own atomic write. Creating a second process file sink would
-        # persist the unsanitized task/tool stream outside that boundary.
+        file_enabled = False
+    if runtime_context is None:
+        file_enabled = False
+
+    if level == AgentLoomLogLevel.OFF or not (console_enabled or file_enabled):
+        return _tag_backend_runtime(NullLoggerBackend(), runtime_context)
+
+    if file_enabled and runtime_context is not None:
+        max_file_bytes = _positive_int(
+            effective_logging.get("max_file_bytes"),
+            default=DEFAULT_MAX_FILE_BYTES,
+            minimum=1,
+        )
+        backup_count = _positive_int(
+            effective_logging.get("backup_count"),
+            default=DEFAULT_BACKUP_COUNT,
+            minimum=0,
+        )
+        console = DualConsole(
+            log_file_path=str(runtime_context.log_path),
+            max_file_bytes=max_file_bytes,
+            backup_count=backup_count,
+            console_enabled=console_enabled,
+            runtime_context=runtime_context,
+            highlight=False,
+        )
+    elif console_enabled:
         console = Console(highlight=False)
     else:
-        resolved_path = get_or_create_process_log_path(
-            app_name,
-            log_file_path=log_file_path,
-            now=now,
-            logging_builder=LoggingConfigBuilder().apply_mapping(
-                effective_logging,
-                source="effective_logging",
-            ),
-        )
-        console = DualConsole(log_file_path=str(resolved_path))
-    return EnhancedAgentLogger(
+        return _tag_backend_runtime(NullLoggerBackend(), runtime_context)
+    backend = EnhancedAgentLogger(
         level=level,
         console=console,
         show_timestamp=True,
@@ -461,55 +315,30 @@ def build_logger_backend_from_config(
         show_trace_info=True,
         truncate_id_length=8,
     )
+    return _tag_backend_runtime(backend, runtime_context)
 
 
-def get_current_run_log_dir() -> Path | None:
-    """Return the per-run timestamp log directory for the current process.
+def initialize_run_logger(
+    context: RuntimeContext,
+    *,
+    logging_builder: LoggingConfigBuilder | None = None,
+    file_logging: bool | None = None,
+) -> Any:
+    """Create the backend for one execution attempt.
 
-    Shell audit loggers and other subsystems call this to share the same
-    run directory as the main agent log, producing a layout like::
-
-        .logs/{agent_name}/{timestamp}/
-            {agent_name}.log
-            shell_audit.log
-
-    Returns ``None`` if no process log path has been established yet.
+    Binding is deliberately separate so callers can establish the complete
+    run context before constructing agents and can deterministically close it.
     """
-    if _PROCESS_LOG_FILE_PATH is not None:
-        return _PROCESS_LOG_FILE_PATH.parent
-    return None
+    return build_logger_backend_from_config(
+        context.application_id,
+        logging_builder=logging_builder,
+        runtime_context=context,
+        file_logging=file_logging,
+    )
 
 
-def initialize_global_logger_once(app_name: str) -> Any | None:
-    """Initialize process-global logger backend exactly once.
-
-    Must be called with the YAML ``name`` field **before** any agent
-    construction.  Subsequent calls return the cached backend.
-
-    Args:
-        app_name: Application name from the YAML ``name`` field.  Determines
-            the log directory: ``{logging.dir}/{app_name}/{timestamp}/{app_name}.log``.
-    """
-    if _GLOBAL_LOGGER is not None:
-        return _GLOBAL_LOGGER
-
-    backend = build_logger_backend_from_config(app_name)
-    set_global_logger(backend)
-    return backend
-
-
-def set_global_logger(logger_backend: Any | None) -> None:
-    """Set or clear process-wide default logger backend."""
-    global _GLOBAL_LOGGER
-    previous_backend: Any | None = None
-    with _GLOBAL_LOGGER_LOCK:
-        previous_backend = _GLOBAL_LOGGER
-        _GLOBAL_LOGGER = logger_backend
-    if previous_backend is not None and previous_backend is not logger_backend:
-        _close_logger_backend_sink(previous_backend)
-
-
-def _close_logger_backend_sink(logger_backend: Any | None) -> None:
+def close_run_logger(logger_backend: Any | None) -> None:
+    """Close a run logger's file sink without changing any context binding."""
     if logger_backend is None:
         return
     try:
@@ -518,27 +347,95 @@ def _close_logger_backend_sink(logger_backend: Any | None) -> None:
         if callable(close_log_file):
             close_log_file()
     except Exception:
-        # Logger cleanup should never break caller flow.
+        # Logging cleanup must never replace the application's real outcome.
         return
 
 
-def get_global_logger(*, create_if_missing: bool = False) -> Any | None:
-    """Get process-wide default logger backend.
+@contextmanager
+def bind_logger_backend(
+    logger_backend: Any,
+    *,
+    context: RuntimeContext | None = None,
+) -> Iterator[Any]:
+    """Bind a backend to exactly one RuntimeContext and close it on exit."""
+    effective_context = context or get_current_run_context()
+    _tag_backend_runtime(logger_backend, effective_context)
+    token = _CURRENT_LOGGER_BINDING.set(
+        _LoggerBinding(logger_backend, _runtime_key(effective_context))
+    )
+    try:
+        if effective_context is not None:
+            from src.tools.shell.shell_audit_log import (
+                initialize_shell_audit_scope,
+            )
 
-    Returns the backend previously created by :func:`initialize_global_logger_once`.
-    If ``create_if_missing`` is *False* (default) and no backend has been
-    registered yet, returns *None* instead of attempting lazy creation.
+            initialize_shell_audit_scope(effective_context)
+        yield logger_backend
+    finally:
+        try:
+            from src.tools.shell.shell_audit_log import (
+                close_current_shell_audit_loggers,
+            )
+
+            close_current_shell_audit_loggers()
+        except Exception:
+            # Audit cleanup is best-effort and must not mask run failures.
+            pass
+        _CURRENT_LOGGER_BINDING.reset(token)
+        close_run_logger(logger_backend)
+
+
+def initialize_global_logger_once(app_name: str) -> Any | None:
+    """Legacy helper for tests and standalone construction.
+
+    It never invents a file path.  When called under a RuntimeContext the
+    canonical run path is used; otherwise the backend is console-only.
     """
-    if _GLOBAL_LOGGER is not None:
-        return _GLOBAL_LOGGER
+    existing = get_global_logger(create_if_missing=False)
+    if existing is not None:
+        return existing
+    runtime_context = get_current_run_context()
+    backend = build_logger_backend_from_config(
+        app_name,
+        runtime_context=runtime_context,
+    )
+    set_global_logger(backend)
+    return backend
 
-    if not create_if_missing:
+
+def set_global_logger(logger_backend: Any | None) -> None:
+    """Set or clear the backend in the current execution context only."""
+    previous = _CURRENT_LOGGER_BINDING.get()
+    if logger_backend is None:
+        _CURRENT_LOGGER_BINDING.set(None)
+    else:
+        context = get_current_run_context()
+        _tag_backend_runtime(logger_backend, context)
+        _CURRENT_LOGGER_BINDING.set(
+            _LoggerBinding(logger_backend, _runtime_key(context))
+        )
+    if previous is not None and previous.backend is not logger_backend:
+        close_run_logger(previous.backend)
+
+
+def get_global_logger(*, create_if_missing: bool = False) -> Any | None:
+    """Get the backend bound to the current execution context.
+
+    A backend tied to another (or already-ended) run is deliberately ignored.
+    ``create_if_missing`` remains accepted for call-site stability but never
+    creates a backend implicitly.
+    """
+    binding = _CURRENT_LOGGER_BINDING.get()
+    if binding is None:
         return None
+    if binding.runtime_key != _runtime_key(get_current_run_context()):
+        return None
+    return binding.backend
 
-    return _GLOBAL_LOGGER
 
-
-_FALLBACK_APP_NAME = "AgentLoom"
+def get_active_log_file_path() -> Path | None:
+    """Return the current run backend's canonical file path, if enabled."""
+    return _extract_backend_log_file_path(get_global_logger())
 
 
 @runtime_checkable
@@ -602,7 +499,7 @@ class LoggerAdapter:
     *Lazy mode* (``backend=None``): created by ``get_logger(__name__)``.
     Safe at **import time** — never triggers ``initialize_global_logger_once``
     or any other side-effecting initialisation.  On each log call it
-    dynamically looks up the process-global backend via
+    dynamically looks up the run-scoped backend via
     :func:`get_global_logger`; if none exists yet, it falls back to the
     stdlib ``logging`` hierarchy.
 
@@ -611,9 +508,8 @@ class LoggerAdapter:
     and dispatches directly to it.  If the backend method is missing or fails,
     applies the same global → stdlib fallback chain as lazy mode.
 
-    After ``initialize_global_logger_once(app_name)`` is called (typically by
-    :func:`src.runner.run_app`), **all** lazy-mode instances automatically
-    pick up the correct backend on subsequent calls.
+    After a backend is bound with :func:`bind_logger_backend`, **all** lazy-mode
+    instances in that context automatically pick it up on subsequent calls.
 
     Usage::
 
@@ -626,11 +522,16 @@ class LoggerAdapter:
             log.info("building...")
     """
 
-    __slots__ = ("_backend", "_name")
+    __slots__ = ("_backend", "_name", "_runtime_key")
 
     def __init__(self, backend: Any = None, name: str | None = None):
         self._backend = backend
         self._name = name or __name__
+        self._runtime_key = _backend_runtime_tag(backend)
+        if backend is not None and self._runtime_key is None:
+            binding = _CURRENT_LOGGER_BINDING.get()
+            if binding is not None and binding.backend is backend:
+                self._runtime_key = binding.runtime_key
 
     # -- internal helpers ---------------------------------------------------
 
@@ -655,6 +556,12 @@ class LoggerAdapter:
 
         # Bound mode: try the explicit backend first.
         if self._backend is not None:
+            if (
+                self._runtime_key is not None
+                and self._runtime_key != _runtime_key(get_current_run_context())
+            ):
+                _stdlib_emit(self._name, method_name, rendered)
+                return
             if isinstance(self._backend, logging.Logger):
                 used_stdlib = True
             if _call_log_method(self._backend, method_name, rendered, **kwargs):
@@ -699,7 +606,7 @@ LazyLoggerAdapter = LoggerAdapter
 # ---------------------------------------------------------------------------
 
 def get_logger(
-    name_or_backend: "str | Any | None" = None,
+    name_or_backend: str | Any | None = None,
     name: str | None = None,
 ) -> LoggerAdapter:
     """Obtain a logger — the **single unified API** for all logging needs.

--- a/src/lib/logging/rich_console.py
+++ b/src/lib/logging/rich_console.py
@@ -1,75 +1,108 @@
-from rich.console import Console
+from __future__ import annotations
+
+import threading
+from io import StringIO
 from pathlib import Path
+from typing import Any, TextIO
+
+from rich.console import Console
+
+from src.lib.runtime import RuntimeContext, RuntimeRotatingTextSink
+
 
 class DualConsole(Console):
-    """Dual-output console: output to terminal and file at the same time."""
-    
-    def __init__(self, log_file_path, *args, **kwargs):
-        # Initialize parent Console (for terminal output).
+    """Rich console with an optional bounded, rotating plain-text file sink."""
+
+    def __init__(
+        self,
+        log_file_path: str | None,
+        *args: Any,
+        max_file_bytes: int = 25 * 1024 * 1024,
+        backup_count: int = 3,
+        console_enabled: bool = True,
+        runtime_context: RuntimeContext | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
-        # Do not reuse Console internals like `_closed`; keep our own file sink state.
+        self.console_enabled = bool(console_enabled)
+        self.max_file_bytes = max(1, int(max_file_bytes))
+        self.backup_count = max(0, int(backup_count))
+        self.log_file_path = (
+            str(Path(log_file_path).expanduser().absolute()) if log_file_path else None
+        )
+        self.log_file: TextIO | None = None
+        self.file_console: Console | None = None
         self._file_sink_closed = False
         self._file_sink_disabled = False
+        self._file_lock = threading.RLock()
+        self._runtime_sink = None
+        if self.log_file_path:
+            if runtime_context is None:
+                raise ValueError("file logging requires a RuntimeContext")
+            self._runtime_sink = RuntimeRotatingTextSink(
+                runtime_context,
+                Path(self.log_file_path),
+                max_file_bytes=self.max_file_bytes,
+                backup_count=self.backup_count,
+            )
 
-        # File sink is lazily opened on first write to avoid eager empty-file creation.
-        self.log_file = None
-        self.file_console = None
-        if log_file_path:
-            resolved_path = Path(log_file_path).expanduser()
-            self.log_file_path = str(resolved_path.resolve())
-        else:
-            self.log_file_path = None
-
-    def _ensure_file_sink_open(self) -> bool:
-        if self._file_sink_closed or self._file_sink_disabled:
+    def _open_file_sink(self) -> bool:
+        if self._file_sink_closed or self._file_sink_disabled or not self.log_file_path:
             return False
-        if self.log_file and self.file_console:
-            return True
-        if not self.log_file_path:
-            return False
+        return self._runtime_sink is not None
 
-        try:
-            resolved_path = Path(self.log_file_path).expanduser()
-            resolved_path.parent.mkdir(parents=True, exist_ok=True)
-            self.log_file = open(resolved_path, "a", encoding="utf-8")
-            self.file_console = Console(file=self.log_file, width=self.width, no_color=True, highlight=False)
-            return True
-        except Exception:
-            # Keep terminal logging healthy even when file sink is not writable.
-            self._file_sink_disabled = True
-            self.log_file = None
-            self.file_console = None
-            return False
+    def _render_plain(self, *args: Any, **kwargs: Any) -> str:
+        buffer = StringIO()
+        file_console = Console(
+            file=buffer,
+            width=self.width,
+            no_color=True,
+            highlight=False,
+            force_terminal=False,
+        )
+        file_console.print(*args, **kwargs)
+        return buffer.getvalue()
 
-    def print(self, *args, **kwargs):
-        # Output to terminal (call parent method).
-        super().print(*args, **kwargs)
-        # Output to file.
-        if not self._ensure_file_sink_open():
+    def _rollover(self) -> None:
+        # Rotation is owned by RuntimeRotatingTextSink so every rename remains
+        # anchored to the validated run directory descriptor.
+        return None
+
+    def _write_file(self, rendered: str) -> None:
+        if not rendered or not self.log_file_path:
             return
-        try:
-            self.file_console.print(*args, **kwargs)
-            # Force flush buffer.
-            self.log_file.flush()
-        except Exception:
-            self._file_sink_disabled = True
-            if self.log_file:
-                try:
-                    self.log_file.close()
-                except Exception:
-                    pass
-            self.log_file = None
-            self.file_console = None
-
-    def close_log_file(self):
-        """Close file sink explicitly when caller needs deterministic cleanup."""
-        if self._file_sink_closed:
-            return
-        if self.log_file:
+        with self._file_lock:
             try:
-                self.log_file.close()
-            except Exception:
-                pass
-        self.log_file = None
-        self.file_console = None
-        self._file_sink_closed = True
+                if not self._open_file_sink() or self._runtime_sink is None:
+                    return
+                self._runtime_sink.write(rendered)
+                self.log_file = self._runtime_sink.stream
+            except (OSError, RuntimeError):
+                self._file_sink_disabled = True
+                if self._runtime_sink is not None:
+                    self._runtime_sink.close()
+                    self._runtime_sink = None
+                self.log_file = None
+                return
+
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        if self.console_enabled:
+            super().print(*args, **kwargs)
+        if self.log_file_path:
+            self._write_file(self._render_plain(*args, **kwargs))
+
+    def close_log_file(self) -> None:
+        with self._file_lock:
+            if self._file_sink_closed:
+                return
+            if self.log_file is not None:
+                self.log_file = None
+            if self._runtime_sink is not None:
+                try:
+                    self._runtime_sink.close()
+                except OSError:
+                    pass
+                self._runtime_sink = None
+            self.log_file = None
+            self.file_console = None
+            self._file_sink_closed = True

--- a/src/lib/runtime/__init__.py
+++ b/src/lib/runtime/__init__.py
@@ -1,0 +1,41 @@
+"""Run-scoped runtime storage API."""
+
+from .context import (
+    RUNTIME_ROOT_ENV,
+    RuntimeContext,
+    RuntimeHome,
+    RuntimeRotatingTextSink,
+    RuntimeRunLease,
+    bind_run_context,
+    copy_runtime_context,
+    fallback_application_id,
+    generate_runtime_id,
+    get_current_run_context,
+    portable_runtime_component,
+    resolve_application_id,
+    resolve_runtime_home,
+    safe_application_id,
+    validate_runtime_id,
+    validate_runtime_owned_path,
+)
+from .storage import SecureDirectory
+
+__all__ = [
+    "RuntimeContext",
+    "RUNTIME_ROOT_ENV",
+    "RuntimeHome",
+    "RuntimeRotatingTextSink",
+    "RuntimeRunLease",
+    "SecureDirectory",
+    "bind_run_context",
+    "copy_runtime_context",
+    "fallback_application_id",
+    "generate_runtime_id",
+    "get_current_run_context",
+    "portable_runtime_component",
+    "resolve_application_id",
+    "resolve_runtime_home",
+    "safe_application_id",
+    "validate_runtime_id",
+    "validate_runtime_owned_path",
+]

--- a/src/lib/runtime/context.py
+++ b/src/lib/runtime/context.py
@@ -1,0 +1,867 @@
+"""Canonical runtime storage paths and run-scoped context.
+
+This module is the only place that knows the on-disk layout under the
+AgentLoom runtime home.  Callers receive concrete paths from a
+``RuntimeContext`` instead of deriving paths from the current directory,
+timestamps, logger state, or agent names.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+import threading
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import Any, TextIO
+
+_SAFE_PART = re.compile(r"[^A-Za-z0-9._-]+")
+_CURRENT_RUN_CONTEXT: contextvars.ContextVar[RuntimeContext | None] = contextvars.ContextVar(
+    "agentloom_run_context", default=None
+)
+_DIRECTORY_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_FILE_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+RUNTIME_ROOT_ENV = "AGENTLOOM_RUNTIME_ROOT"
+
+
+def _absolute_path_without_resolving_symlinks(path: str | Path) -> Path:
+    return Path(os.path.abspath(os.fspath(Path(path).expanduser())))
+
+
+def _safe_part(value: str, *, field: str) -> str:
+    raw = str(value).strip()
+    if not raw or raw in {".", ".."}:
+        raise ValueError(f"{field} must be a non-empty safe path component")
+    if "/" in raw or "\\" in raw:
+        raise ValueError(f"{field} must not contain path separators")
+    cleaned = _SAFE_PART.sub("_", raw).strip("._")
+    if not cleaned or cleaned != raw or len(raw) > 160:
+        raise ValueError(f"{field} must already be a safe path component")
+    return cleaned
+
+
+def validate_runtime_id(value: str, *, field: str = "runtime_id") -> str:
+    """Validate an opaque task/run id without changing its identity."""
+
+    return _safe_part(value, field=field)
+
+
+def validate_runtime_owned_path(path: Path, *, root: Path) -> Path:
+    """Reject symlinks inside a runtime-owned path before creating files."""
+
+    root = Path(root).expanduser().absolute()
+    path = Path(path).expanduser().absolute()
+    if root.is_symlink():
+        raise RuntimeError(f"runtime root is a symlink: {root}")
+    try:
+        relative = path.relative_to(root)
+    except ValueError as exc:
+        raise RuntimeError(f"runtime path escapes root: {path}") from exc
+    current = root
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            raise RuntimeError(f"runtime path contains a symlink: {current}")
+    return path
+
+
+def _open_runtime_directory(
+    directory: Path,
+    *,
+    root: Path,
+    create: bool = False,
+) -> int:
+    """Open a runtime-owned directory without following any child symlink.
+
+    Path-level validation alone has a check/use race.  This helper anchors the
+    traversal at an opened runtime-root descriptor and opens every component
+    with ``O_NOFOLLOW``.  The returned descriptor therefore keeps referring to
+    the validated directory even if a pathname is renamed afterwards.
+    """
+
+    root = _absolute_path_without_resolving_symlinks(root)
+    directory = _absolute_path_without_resolving_symlinks(directory)
+    try:
+        relative = directory.relative_to(root)
+    except ValueError as exc:
+        raise RuntimeError(f"runtime path escapes root: {directory}") from exc
+
+    if create:
+        root.mkdir(parents=True, exist_ok=True)
+    if root.is_symlink():
+        raise RuntimeError(f"runtime root is a symlink: {root}")
+    try:
+        current_fd = os.open(root, _DIRECTORY_OPEN_FLAGS)
+    except OSError as exc:
+        raise RuntimeError(f"cannot open runtime root safely: {root}") from exc
+
+    try:
+        for part in relative.parts:
+            try:
+                next_fd = os.open(part, _DIRECTORY_OPEN_FLAGS, dir_fd=current_fd)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    os.mkdir(part, mode=0o700, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                next_fd = os.open(part, _DIRECTORY_OPEN_FLAGS, dir_fd=current_fd)
+            except OSError as exc:
+                raise RuntimeError(
+                    f"runtime path component is not a safe directory: {directory}"
+                ) from exc
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _ensure_runtime_directory(directory: Path, *, root: Path) -> Path:
+    fd = _open_runtime_directory(directory, root=root, create=True)
+    os.close(fd)
+    return _absolute_path_without_resolving_symlinks(directory)
+
+
+def _safe_named_part(value: str, *, fallback: str, include_hash_on_change: bool) -> str:
+    """Sanitize a human-readable name without losing stable identity."""
+
+    raw = str(value).strip()
+    cleaned = _SAFE_PART.sub("_", raw).strip("._")[:160]
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:10]
+    if not cleaned:
+        return f"{fallback}-{digest}"
+    if include_hash_on_change and (cleaned != raw or len(raw) > 160):
+        return f"{cleaned[:149]}-{digest}"
+    return cleaned
+
+
+def portable_runtime_component(value: str, *, fallback: str = "item") -> str:
+    """Map a display name to one deterministic portable storage component."""
+
+    raw = str(value).strip()
+    if not raw:
+        raise ValueError("runtime storage name must not be empty")
+    return _safe_named_part(raw, fallback=fallback, include_hash_on_change=True)
+
+
+def safe_application_id(value: str) -> str:
+    """Return a safe, possibly nested application identifier.
+
+    Application ids may contain ``/`` so nested applications retain their
+    stable identity.  Traversal and absolute paths are rejected rather than
+    normalized away.
+    """
+
+    raw = str(value).strip().replace("\\", "/")
+    path = PurePosixPath(raw)
+    if not raw or path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("application_id must be a safe relative path")
+    return "/".join(
+        _safe_named_part(part, fallback="app", include_hash_on_change=True)
+        for part in path.parts
+    )
+
+
+def fallback_application_id(
+    workflow_path: str | Path | None,
+    *,
+    name_hint: str | None = None,
+) -> str:
+    """Build a stable id for YAML files outside ``applications/``.
+
+    The readable stem is not unique by itself, so a short hash of the resolved
+    path is always included.
+    """
+
+    if workflow_path:
+        path = Path(workflow_path).expanduser()
+        try:
+            canonical = str(path.resolve())
+        except OSError:
+            canonical = str(path.absolute())
+        readable = name_hint or path.stem or "external"
+    else:
+        canonical = str(name_hint or "external")
+        readable = name_hint or "external"
+    safe_name = _safe_named_part(
+        readable,
+        fallback="external",
+        include_hash_on_change=False,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:10]
+    return f"{safe_name}-{digest}"
+
+
+def generate_runtime_id(kind: str) -> str:
+    prefix = _safe_part(kind, field="id kind")
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    return f"{prefix}_{timestamp}_{uuid.uuid4().hex[:12]}"
+
+
+class RuntimeRunLease:
+    """Cross-process lease proving that a run attempt is still active."""
+
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = Path(run_dir)
+        self._fd: int | None = None
+
+    def acquire(self) -> None:
+        if self._fd is not None:
+            return
+        if self.run_dir.is_symlink() or not self.run_dir.is_dir():
+            raise RuntimeError(f"run directory is unavailable: {self.run_dir}")
+        fd = os.open(self.run_dir, os.O_RDONLY)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BaseException:
+            os.close(fd)
+            raise
+        self._fd = fd
+
+    def release(self) -> None:
+        if self._fd is None:
+            return
+        fd, self._fd = self._fd, None
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+    def __enter__(self) -> RuntimeRunLease:
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.release()
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContext:
+    """All canonical paths and identities for one execution attempt."""
+
+    root_dir: Path
+    application_id: str
+    task_id: str
+    run_id: str
+
+    def __post_init__(self) -> None:
+        canonical_root = _absolute_path_without_resolving_symlinks(self.root_dir)
+        object.__setattr__(self, "root_dir", canonical_root)
+        object.__setattr__(self, "application_id", safe_application_id(self.application_id))
+        object.__setattr__(self, "task_id", validate_runtime_id(self.task_id, field="task_id"))
+        object.__setattr__(self, "run_id", validate_runtime_id(self.run_id, field="run_id"))
+
+    @property
+    def runtime_key(self) -> tuple[str, str, str, str]:
+        """Stable process-local identity used to partition run-scoped state."""
+
+        return (str(self.root_dir), self.application_id, self.task_id, self.run_id)
+
+    def run_lease(self) -> RuntimeRunLease:
+        return RuntimeRunLease(self.run_dir)
+
+    @property
+    def run_dir(self) -> Path:
+        return self.root_dir / "runs" / Path(*self.application_id.split("/")) / self.run_id
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.run_dir / "manifest.json"
+
+    @property
+    def logs_dir(self) -> Path:
+        return self.run_dir / "logs"
+
+    @property
+    def log_path(self) -> Path:
+        return self.logs_dir / "runtime.log"
+
+    @property
+    def audit_dir(self) -> Path:
+        return self.run_dir / "audit"
+
+    @property
+    def shell_audit_path(self) -> Path:
+        return self.audit_dir / "shell.jsonl"
+
+    @property
+    def artifacts_dir(self) -> Path:
+        return self.run_dir / "artifacts"
+
+    @property
+    def shell_artifacts_dir(self) -> Path:
+        return self.artifacts_dir / "shell"
+
+    @property
+    def background_artifacts_dir(self) -> Path:
+        return self.artifacts_dir / "background"
+
+    @property
+    def skill_artifacts_dir(self) -> Path:
+        return self.artifacts_dir / "skills"
+
+    def skill_workspace_dir(self, skill_name: str) -> Path:
+        """Return the canonical workspace for one skill in this run."""
+
+        component = _safe_named_part(
+            skill_name,
+            fallback="skill",
+            include_hash_on_change=True,
+        )
+        return self.skill_artifacts_dir / component
+
+    def new_skill_execution_dir(self, skill_name: str) -> Path:
+        """Atomically allocate a unique audit directory for a skill execution."""
+
+        executions_dir = self.skill_workspace_dir(skill_name) / "runs"
+        executions_fd = _open_runtime_directory(
+            executions_dir,
+            root=self.root_dir,
+            create=True,
+        )
+        try:
+            while True:
+                name = generate_runtime_id("execution")
+                try:
+                    os.mkdir(name, mode=0o700, dir_fd=executions_fd)
+                except FileExistsError:
+                    continue
+                return executions_dir / name
+        finally:
+            os.close(executions_fd)
+
+    def prepare_skill_workspace(self, skill_name: str) -> Path:
+        """Create and return a skill workspace through the trusted path layer."""
+
+        return _ensure_runtime_directory(
+            self.skill_workspace_dir(skill_name),
+            root=self.root_dir,
+        )
+
+    def allocate_artifact(
+        self,
+        kind: str,
+        *,
+        prefix: str,
+        suffix: str,
+    ) -> tuple[int, Path]:
+        """Atomically allocate a run artifact and return its open descriptor."""
+
+        directories = {
+            "shell": self.shell_artifacts_dir,
+            "background": self.background_artifacts_dir,
+            "skills": self.skill_artifacts_dir,
+        }
+        try:
+            directory = directories[kind]
+        except KeyError as exc:
+            raise ValueError(f"unknown run artifact kind: {kind}") from exc
+        if any(separator in prefix or separator in suffix for separator in ("/", "\\", "\x00")):
+            raise ValueError("artifact prefix and suffix must be filename fragments")
+
+        directory_fd = _open_runtime_directory(
+            directory,
+            root=self.root_dir,
+            create=True,
+        )
+        try:
+            while True:
+                name = f"{prefix}{uuid.uuid4().hex}{suffix}"
+                try:
+                    fd = os.open(
+                        name,
+                        os.O_RDWR | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW,
+                        0o600,
+                        dir_fd=directory_fd,
+                    )
+                except FileExistsError:
+                    continue
+                return fd, directory / name
+        finally:
+            os.close(directory_fd)
+
+    def create_run_file(self, path: Path) -> int:
+        """Create one exclusive regular file below this run and return its fd.
+
+        This is intended for subprocess stdout/stderr redirection: the child
+        writes directly to the runtime-owned file, so arbitrarily large output
+        never has to be buffered in the AgentLoom process.
+        """
+
+        target = _absolute_path_without_resolving_symlinks(path)
+        try:
+            target.relative_to(self.run_dir)
+        except ValueError as exc:
+            raise RuntimeError(f"run file escapes run directory: {target}") from exc
+        parent_fd = _open_runtime_directory(
+            target.parent,
+            root=self.root_dir,
+            create=False,
+        )
+        try:
+            fd = os.open(
+                target.name,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                os.close(fd)
+                raise RuntimeError(f"run file is not regular: {target}")
+            return fd
+        finally:
+            os.close(parent_fd)
+
+    def atomic_write_run_file(
+        self,
+        path: Path,
+        content: str | bytes,
+        *,
+        encoding: str = "utf-8",
+    ) -> None:
+        """Atomically replace one file below this run without following links."""
+
+        target = _absolute_path_without_resolving_symlinks(path)
+        try:
+            target.relative_to(self.run_dir)
+        except ValueError as exc:
+            raise RuntimeError(f"run artifact escapes run directory: {target}") from exc
+        parent_fd = _open_runtime_directory(
+            target.parent,
+            root=self.root_dir,
+            create=False,
+        )
+        temporary = f".{target.name}.{uuid.uuid4().hex}.tmp"
+        fd = -1
+        try:
+            try:
+                existing = os.stat(target.name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                existing = None
+            if existing is not None and not stat.S_ISREG(existing.st_mode):
+                raise RuntimeError(f"run file is not a regular file: {target}")
+            fd = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            payload = content.encode(encoding) if isinstance(content, str) else content
+            with os.fdopen(fd, "wb", closefd=True) as stream:
+                fd = -1
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(
+                temporary,
+                target.name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(temporary, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
+
+    def read_run_file(self, path: Path, *, encoding: str = "utf-8") -> str:
+        """Read one regular file below this run through a trusted directory fd."""
+
+        target = _absolute_path_without_resolving_symlinks(path)
+        try:
+            target.relative_to(self.run_dir)
+        except ValueError as exc:
+            raise RuntimeError(f"run file escapes run directory: {target}") from exc
+        parent_fd = _open_runtime_directory(target.parent, root=self.root_dir)
+        try:
+            fd = os.open(target.name, os.O_RDONLY | _FILE_NOFOLLOW, dir_fd=parent_fd)
+            try:
+                if not stat.S_ISREG(os.fstat(fd).st_mode):
+                    raise RuntimeError(f"run file is not regular: {target}")
+                with os.fdopen(fd, "r", encoding=encoding, closefd=True) as stream:
+                    fd = -1
+                    return stream.read()
+            finally:
+                if fd >= 0:
+                    os.close(fd)
+        finally:
+            os.close(parent_fd)
+
+    def remove_run_file(self, path: Path) -> None:
+        """Unlink one run file without following a replaced parent directory."""
+
+        target = _absolute_path_without_resolving_symlinks(path)
+        try:
+            target.relative_to(self.run_dir)
+        except ValueError as exc:
+            raise RuntimeError(f"run file escapes run directory: {target}") from exc
+        parent_fd = _open_runtime_directory(target.parent, root=self.root_dir)
+        try:
+            os.unlink(target.name, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+
+    @property
+    def checkpoint_dir(self) -> Path:
+        return self.root_dir / "checkpoints" / Path(*self.application_id.split("/")) / self.task_id
+
+    @property
+    def task_events_path(self) -> Path:
+        return self.checkpoint_dir / "task_events.jsonl"
+
+    @property
+    def task_tree_path(self) -> Path:
+        return self.checkpoint_dir / "task_tree.json"
+
+    @property
+    def checkpoint_path(self) -> Path:
+        return self.checkpoint_dir / "checkpoint.json"
+
+    @property
+    def heartbeat_path(self) -> Path:
+        return self.checkpoint_dir / "heartbeat.json"
+
+    @property
+    def workers_dir(self) -> Path:
+        return self.checkpoint_dir / "workers"
+
+    @property
+    def context_store_dir(self) -> Path:
+        return self.checkpoint_dir / "context_store"
+
+    @property
+    def file_history_dir(self) -> Path:
+        return self.checkpoint_dir / "file-history"
+
+    def prepare_run(self) -> None:
+        _ensure_runtime_directory(self.run_dir, root=self.root_dir)
+        self.atomic_write_run_file(
+            self.run_dir / ".run-starting.json",
+            json.dumps(
+                {
+                    "application_id": self.application_id,
+                    "task_id": self.task_id,
+                    "run_id": self.run_id,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            + "\n",
+        )
+        _ensure_runtime_directory(self.logs_dir, root=self.root_dir)
+        _ensure_runtime_directory(self.audit_dir, root=self.root_dir)
+        for path in (
+            self.shell_artifacts_dir,
+            self.background_artifacts_dir,
+            self.skill_artifacts_dir,
+        ):
+            _ensure_runtime_directory(path, root=self.root_dir)
+
+    def prepare_checkpoint(self) -> None:
+        self.validate_checkpoint_path()
+        _ensure_runtime_directory(self.checkpoint_dir, root=self.root_dir)
+
+    def validate_checkpoint_path(self, *, require_exists: bool = False) -> Path:
+        """Validate the full canonical checkpoint path without following links."""
+
+        path = validate_runtime_owned_path(self.checkpoint_dir, root=self.root_dir)
+        if require_exists and not path.is_dir():
+            raise FileNotFoundError(
+                f"checkpoint directory does not exist: {self.checkpoint_dir}"
+            )
+        return path
+
+    def write_manifest(self, **extra: Any) -> None:
+        payload: dict[str, Any] = {
+            "schema_version": 1,
+            "application_id": self.application_id,
+            "task_id": self.task_id,
+            "run_id": self.run_id,
+            "started_at": datetime.now(UTC).isoformat(),
+            "status": "running",
+        }
+        payload.update(extra)
+        self.atomic_write_run_file(
+            self.manifest_path,
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        )
+        try:
+            self.remove_run_file(self.run_dir / ".run-starting.json")
+        except FileNotFoundError:
+            pass
+
+    def update_manifest(self, **updates: Any) -> None:
+        payload: dict[str, Any] = {}
+        if self.manifest_path.exists():
+            try:
+                loaded = json.loads(self.read_run_file(self.manifest_path))
+                if isinstance(loaded, dict):
+                    payload = loaded
+            except (OSError, json.JSONDecodeError):
+                payload = {}
+        payload.update(updates)
+        self.atomic_write_run_file(
+            self.manifest_path,
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        data = asdict(self)
+        data["root_dir"] = str(self.root_dir)
+        return data
+
+
+class RuntimeHome:
+    """Factory for canonical run and task contexts under one root."""
+
+    def __init__(self, root_dir: str | Path) -> None:
+        self.root_dir = _absolute_path_without_resolving_symlinks(root_dir)
+
+    def validate_root(self) -> Path:
+        """Reject a runtime root that redirects storage through a symlink."""
+
+        return validate_runtime_owned_path(self.root_dir, root=self.root_dir)
+
+    @property
+    def checkpoints_root(self) -> Path:
+        self.validate_root()
+        return self.root_dir / "checkpoints"
+
+    @property
+    def runs_root(self) -> Path:
+        self.validate_root()
+        return self.root_dir / "runs"
+
+    def context(
+        self,
+        *,
+        application_id: str,
+        task_id: str,
+        run_id: str,
+    ) -> RuntimeContext:
+        return RuntimeContext(
+            root_dir=self.root_dir,
+            application_id=safe_application_id(application_id),
+            task_id=validate_runtime_id(task_id, field="task_id"),
+            run_id=validate_runtime_id(run_id, field="run_id"),
+        )
+
+    def new_context(
+        self,
+        *,
+        application_id: str,
+        task_id: str | None = None,
+        run_id: str | None = None,
+    ) -> RuntimeContext:
+        return self.context(
+            application_id=application_id,
+            task_id=task_id or generate_runtime_id("task"),
+            run_id=run_id or generate_runtime_id("run"),
+        )
+
+
+def resolve_runtime_home(
+    effective_config: dict[str, Any] | None,
+    *,
+    agent_root: str | Path,
+) -> RuntimeHome:
+    section = effective_config.get("runtime", {}) if isinstance(effective_config, dict) else {}
+    if not isinstance(section, dict):
+        section = {}
+    # Subprocess harnesses may override the one canonical home, but the
+    # override applies to every runtime consumer.  There is deliberately no
+    # self-learning-only environment variable.
+    root_override = os.environ.get(RUNTIME_ROOT_ENV, "").strip()
+    configured = Path(
+        root_override or str(section.get("root_dir", ".agentloom"))
+    ).expanduser()
+    if not configured.is_absolute():
+        configured = Path(agent_root).expanduser() / configured
+    return RuntimeHome(configured)
+
+
+def resolve_application_id(
+    agent_config: dict[str, Any] | None,
+    workflow_path: str | Path,
+    *,
+    agent_root: str | Path | None = None,
+) -> str:
+    """Resolve a canonical Application id, with a hashed external fallback."""
+
+    from src.extensions.self_learning.application_scope import resolve_application_scope
+
+    scope = resolve_application_scope(agent_config, workflow_path=workflow_path)
+    if scope.application_id:
+        return safe_application_id(scope.application_id)
+
+    path = Path(workflow_path).expanduser()
+    if agent_root is not None:
+        applications_root = Path(agent_root).expanduser().resolve() / "applications"
+        try:
+            relative = path.resolve().relative_to(applications_root)
+            parts = relative.parts
+            if "workflows" in parts:
+                workflow_index = parts.index("workflows")
+                if workflow_index > 0:
+                    return safe_application_id("/".join(parts[:workflow_index]))
+        except (OSError, ValueError):
+            pass
+    hint = str((agent_config or {}).get("name") or path.stem or "external")
+    return fallback_application_id(path, name_hint=hint)
+
+
+def get_current_run_context(*, required: bool = False) -> RuntimeContext | None:
+    context = _CURRENT_RUN_CONTEXT.get()
+    if context is None and required:
+        raise RuntimeError("no AgentLoom RuntimeContext is bound to this execution context")
+    return context
+
+
+@contextmanager
+def bind_run_context(context: RuntimeContext) -> Iterator[RuntimeContext]:
+    token = _CURRENT_RUN_CONTEXT.set(context)
+    try:
+        yield context
+    finally:
+        _CURRENT_RUN_CONTEXT.reset(token)
+
+
+def copy_runtime_context() -> contextvars.Context:
+    """Capture the current context for explicit propagation to a worker thread."""
+
+    return contextvars.copy_context()
+
+
+class RuntimeRotatingTextSink:
+    """Bounded append-only text sink anchored to a validated run directory."""
+
+    def __init__(
+        self,
+        context: RuntimeContext,
+        path: Path,
+        *,
+        max_file_bytes: int,
+        backup_count: int,
+        encoding: str = "utf-8",
+    ) -> None:
+        target = _absolute_path_without_resolving_symlinks(path)
+        try:
+            target.relative_to(context.run_dir)
+        except ValueError as exc:
+            raise RuntimeError(f"log path escapes run directory: {target}") from exc
+        self.path = target
+        self.max_file_bytes = max(1, int(max_file_bytes))
+        self.backup_count = max(0, int(backup_count))
+        self.encoding = encoding
+        self._directory_fd = _open_runtime_directory(
+            target.parent,
+            root=context.root_dir,
+            create=True,
+        )
+        self._stream: TextIO | None = None
+        self._lock = threading.RLock()
+        self._closed = False
+
+    @property
+    def stream(self) -> TextIO | None:
+        return self._stream
+
+    def _open_unlocked(self) -> TextIO:
+        if self._closed:
+            raise RuntimeError("runtime text sink is closed")
+        if self._stream is None:
+            fd = os.open(
+                self.path.name,
+                os.O_WRONLY | os.O_APPEND | os.O_CREAT | _FILE_NOFOLLOW,
+                0o600,
+                dir_fd=self._directory_fd,
+            )
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                os.close(fd)
+                raise RuntimeError(f"runtime log is not regular: {self.path}")
+            self._stream = os.fdopen(fd, "a", encoding=self.encoding)
+        return self._stream
+
+    def _regular_exists_unlocked(self, name: str) -> bool:
+        try:
+            metadata = os.stat(name, dir_fd=self._directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return False
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError(f"runtime log generation is not regular: {self.path.parent / name}")
+        return True
+
+    def _rollover_unlocked(self) -> None:
+        if self._stream is not None:
+            self._stream.close()
+            self._stream = None
+        active = self.path.name
+        if self.backup_count == 0:
+            try:
+                os.unlink(active, dir_fd=self._directory_fd)
+            except FileNotFoundError:
+                pass
+            return
+        oldest = f"{active}.{self.backup_count}"
+        try:
+            os.unlink(oldest, dir_fd=self._directory_fd)
+        except FileNotFoundError:
+            pass
+        for index in range(self.backup_count - 1, 0, -1):
+            source = f"{active}.{index}"
+            if self._regular_exists_unlocked(source):
+                os.replace(
+                    source,
+                    f"{active}.{index + 1}",
+                    src_dir_fd=self._directory_fd,
+                    dst_dir_fd=self._directory_fd,
+                )
+        if self._regular_exists_unlocked(active):
+            os.replace(
+                active,
+                f"{active}.1",
+                src_dir_fd=self._directory_fd,
+                dst_dir_fd=self._directory_fd,
+            )
+
+    def write(self, text: str) -> None:
+        if not text:
+            return
+        encoded_size = len(text.encode(self.encoding))
+        with self._lock:
+            stream = self._open_unlocked()
+            current_size = os.fstat(stream.fileno()).st_size
+            if current_size > 0 and current_size + encoded_size > self.max_file_bytes:
+                self._rollover_unlocked()
+                stream = self._open_unlocked()
+            stream.write(text)
+            stream.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self._stream is not None:
+                self._stream.close()
+                self._stream = None
+            os.close(self._directory_fd)

--- a/src/lib/runtime/migration.py
+++ b/src/lib/runtime/migration.py
@@ -1,0 +1,1127 @@
+"""One-time migration from the legacy log-coupled checkpoint layout.
+
+The legacy ``.task_index.json`` files are intentionally never read.  Real
+checkpoint directories and their own events/tree/checkpoint metadata are the
+only source of truth.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import uuid
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from .context import (
+    portable_runtime_component,
+    resolve_application_id,
+    validate_runtime_id,
+    validate_runtime_owned_path,
+)
+
+MigrationValidator = Callable[["MigrationCandidate", Path], None]
+
+
+class MigrationError(RuntimeError):
+    """Raised when migration cannot complete without risking partial state."""
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationCandidate:
+    source_dir: Path
+    destination_dir: Path
+    application_id: str
+    task_id: str
+    yaml_path: str
+    created_at: datetime | None
+    last_progress_at: datetime
+    progress_kinds: tuple[str, ...]
+    checksum: str
+    malformed_event_lines: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedMigration:
+    source_dir: Path
+    task_id: str
+    reason: str
+
+
+@dataclass(slots=True)
+class MigrationPlan:
+    candidates: list[MigrationCandidate] = field(default_factory=list)
+    skipped: list[SkippedMigration] = field(default_factory=list)
+
+    @property
+    def candidate_count(self) -> int:
+        return len(self.candidates)
+
+    @property
+    def skipped_count(self) -> int:
+        return len(self.skipped)
+
+
+@dataclass(slots=True)
+class MigrationResult:
+    plan: MigrationPlan
+    dry_run: bool
+    migrated: list[MigrationCandidate] = field(default_factory=list)
+    already_migrated: list[MigrationCandidate] = field(default_factory=list)
+    archive_dir: Path | None = None
+
+    @property
+    def migrated_count(self) -> int:
+        return len(self.migrated)
+
+    @property
+    def already_migrated_count(self) -> int:
+        return len(self.already_migrated)
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedMigration:
+    candidate: MigrationCandidate
+    staged_dir: Path
+    checksum: str
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkflowIdentity:
+    path: Path
+    config: dict[str, Any]
+    application_id: str
+
+
+class RuntimeMigration:
+    """Plan and apply a legacy checkpoint migration."""
+
+    def __init__(
+        self,
+        *,
+        legacy_logs_dir: str | Path,
+        runtime_root: str | Path,
+        agent_root: str | Path | None = None,
+        max_age: timedelta = timedelta(days=7),
+        now: datetime | None = None,
+    ) -> None:
+        self.legacy_logs_dir = Path(legacy_logs_dir).expanduser().absolute()
+        self.runtime_root = Path(runtime_root).expanduser().absolute()
+        self.agent_root = Path(agent_root).expanduser().absolute() if agent_root is not None else None
+        self.max_age = max_age
+        self.now = _as_utc(now or datetime.now(UTC))
+        if _is_relative_to(self.runtime_root, self.legacy_logs_dir):
+            raise ValueError("runtime_root must not be inside legacy_logs_dir")
+
+    def scan(self) -> MigrationPlan:
+        plan = MigrationPlan()
+        candidates_by_destination: dict[Path, MigrationCandidate] = {}
+        for task_dir in _iter_legacy_task_dirs(self.legacy_logs_dir):
+            inspected = self._inspect_task(task_dir)
+            if isinstance(inspected, SkippedMigration):
+                plan.skipped.append(inspected)
+                continue
+            previous = candidates_by_destination.get(inspected.destination_dir)
+            if previous is None or inspected.last_progress_at > previous.last_progress_at:
+                if previous is not None:
+                    plan.skipped.append(
+                        SkippedMigration(
+                            previous.source_dir,
+                            previous.task_id,
+                            "older duplicate checkpoint",
+                        )
+                    )
+                candidates_by_destination[inspected.destination_dir] = inspected
+            else:
+                plan.skipped.append(
+                    SkippedMigration(
+                        inspected.source_dir,
+                        inspected.task_id,
+                        "older duplicate checkpoint",
+                    )
+                )
+
+        plan.candidates = sorted(
+            candidates_by_destination.values(),
+            key=lambda candidate: candidate.destination_dir.as_posix(),
+        )
+        plan.skipped.sort(key=lambda item: (item.task_id, item.source_dir.as_posix()))
+        return plan
+
+    def migrate(
+        self,
+        *,
+        dry_run: bool = True,
+        archive_legacy: bool = False,
+        validator: MigrationValidator | None = None,
+    ) -> MigrationResult:
+        plan = self.scan()
+        result = MigrationResult(plan=plan, dry_run=dry_run)
+        if dry_run:
+            return result
+
+        from src.lib.checkpoint.checkpoint_manager import CheckpointTaskLease
+
+        _validate_migration_path(self.runtime_root, root=self.runtime_root)
+        self.runtime_root.mkdir(parents=True, exist_ok=True)
+        lock_path = self.runtime_root / ".migration.lock"
+        lock_stream = lock_path.open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(lock_stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            lock_stream.close()
+            raise MigrationError("another runtime migration is already in progress") from exc
+
+        staging_parent = self.runtime_root / ".migration-staging"
+        staging_root = staging_parent / uuid.uuid4().hex
+        _validate_migration_path(staging_root, root=self.runtime_root)
+        prepared: list[_PreparedMigration] = []
+        created_destinations: list[Path] = []
+        task_leases: list[CheckpointTaskLease] = []
+        try:
+            if staging_parent.exists():
+                shutil.rmtree(staging_parent)
+
+            # Phase 1 is intentionally invisible to runtime consumers.  Copy,
+            # normalize, checksum, and all caller-provided validation happen in
+            # staging before any canonical task path is published.
+            for candidate in plan.candidates:
+                staged = staging_root / Path(*candidate.application_id.split("/")) / candidate.task_id
+                _validate_migration_path(candidate.destination_dir, root=self.runtime_root)
+                _validate_migration_path(staged, root=self.runtime_root)
+                if _has_symlink_component(candidate.source_dir, self.legacy_logs_dir):
+                    raise MigrationError(
+                        f"legacy checkpoint source has a symlink component: {candidate.source_dir}"
+                    )
+                staged.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(candidate.source_dir, staged, symlinks=True)
+                copied_checksum = _tree_checksum(staged)
+                if copied_checksum != candidate.checksum:
+                    raise MigrationError(f"checksum mismatch while staging {candidate.task_id}")
+                _normalize_legacy_worker_checkpoints(staged)
+                validate_migrated_checkpoint(candidate, staged)
+                if validator is not None:
+                    validator(candidate, staged)
+                # A validator may read through framework code that repairs an
+                # old schema.  Revalidate and checksum that final staged tree.
+                validate_migrated_checkpoint(candidate, staged)
+                prepared.append(
+                    _PreparedMigration(
+                        candidate=candidate,
+                        staged_dir=staged,
+                        checksum=_tree_checksum(staged),
+                    )
+                )
+
+            self._assert_sources_quiescent_and_unchanged(prepared)
+
+            # Phase 2 publishes each canonical task.  A new task's directory
+            # inode is leased while it is still staged, so the same exclusive
+            # lease remains effective across the atomic rename.  Existing
+            # destinations are leased before they are inspected.  Every lease
+            # remains held through legacy archival or rollback; a concurrent
+            # resume can therefore never become active and then be deleted by
+            # rollback.
+            for item in prepared:
+                candidate = item.candidate
+                destination = candidate.destination_dir
+                staged = item.staged_dir
+                if destination.exists():
+                    lease = CheckpointTaskLease(
+                        destination,
+                        require_exists=True,
+                    ).acquire()
+                    task_leases.append(lease)
+                    if _tree_checksum(destination) != item.checksum:
+                        raise MigrationError(
+                            f"destination already exists with different contents: {destination}"
+                        )
+                    validate_migrated_checkpoint(candidate, destination)
+                    result.already_migrated.append(candidate)
+                    shutil.rmtree(staged)
+                    continue
+
+                lease = CheckpointTaskLease(staged, require_exists=True).acquire()
+                task_leases.append(lease)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(staged, destination)
+                created_destinations.append(destination)
+                if _tree_checksum(destination) != item.checksum:
+                    raise MigrationError(f"post-rename checksum mismatch for {candidate.task_id}")
+                validate_migrated_checkpoint(candidate, destination)
+                result.migrated.append(candidate)
+
+            if archive_legacy:
+                # Publishing and canonical validation can take time.  Refuse
+                # to archive if a legacy writer appeared or any source gained
+                # progress after the first pre-publish check.
+                self._assert_sources_quiescent_and_unchanged(prepared)
+                _validate_migration_path(
+                    self.runtime_root / "legacy",
+                    root=self.runtime_root,
+                )
+                result.archive_dir = archive_legacy_logs(
+                    self.legacy_logs_dir,
+                    self.runtime_root,
+                    now=self.now,
+                )
+            return result
+        except BaseException as exc:
+            for destination in reversed(created_destinations):
+                shutil.rmtree(destination, ignore_errors=True)
+                _remove_empty_parents(
+                    destination.parent,
+                    stop=self.runtime_root / "checkpoints",
+                )
+            if isinstance(exc, MigrationError):
+                raise
+            raise MigrationError(f"migration validation failed: {exc}") from exc
+        finally:
+            for lease in reversed(task_leases):
+                lease.release()
+            shutil.rmtree(staging_root, ignore_errors=True)
+            try:
+                staging_parent.rmdir()
+            except OSError:
+                pass
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
+            fcntl.flock(lock_stream.fileno(), fcntl.LOCK_UN)
+            lock_stream.close()
+
+    def _inspect_task(self, task_dir: Path) -> MigrationCandidate | SkippedMigration:
+        task_id = task_dir.name
+        try:
+            validate_runtime_id(task_id, field="task_id")
+        except ValueError:
+            return SkippedMigration(task_dir, task_id, "unsafe task id")
+        if _has_symlink_component(task_dir, self.legacy_logs_dir):
+            return SkippedMigration(task_dir, task_id, "unsafe symlink")
+
+        events, malformed_lines, unsafe_event_corruption = _read_jsonl_objects(
+            task_dir / "task_events.jsonl"
+        )
+        if unsafe_event_corruption:
+            return SkippedMigration(task_dir, task_id, "corrupt task events")
+        writer_state = _legacy_task_writer_state(task_dir)
+        if writer_state == "live":
+            return SkippedMigration(task_dir, task_id, "live legacy heartbeat")
+        if writer_state == "unknown":
+            return SkippedMigration(task_dir, task_id, "unverifiable legacy heartbeat")
+
+        task_tree_path = task_dir / "task_tree.json"
+        task_tree = _read_json_object(task_tree_path)
+        if task_tree is None:
+            reason = "invalid task tree" if task_tree_path.exists() else "missing task tree"
+            return SkippedMigration(task_dir, task_id, reason)
+        checkpoint_path = task_dir / "checkpoint.json"
+        checkpoint = _read_json_object(checkpoint_path)
+        if checkpoint is None:
+            reason = "invalid checkpoint" if checkpoint_path.exists() else "missing checkpoint"
+            return SkippedMigration(task_dir, task_id, reason)
+        task_created = next(
+            (event for event in events if event.get("type") == "task_created"),
+            {},
+        )
+        yaml_path = str(
+            task_created.get("yaml_path") or task_tree.get("yaml_path") or checkpoint.get("yaml_path") or ""
+        )
+        if not yaml_path.strip():
+            return SkippedMigration(task_dir, task_id, "missing workflow path")
+        supervisor = str(
+            task_created.get("agent_name")
+            or task_tree.get("agent_name")
+            or checkpoint.get("agent_name")
+            or _legacy_supervisor_name(task_dir, self.legacy_logs_dir)
+        )
+        workflow = self._workflow_identity(yaml_path)
+        if isinstance(workflow, str):
+            return SkippedMigration(task_dir, task_id, workflow)
+        yaml_path = str(workflow.path)
+        application_id = workflow.application_id
+        recorded_application_id = str(
+            task_created.get("application_id")
+            or task_tree.get("application_id")
+            or checkpoint.get("application_id")
+            or ""
+        ).strip()
+        if recorded_application_id and recorded_application_id != application_id:
+            return SkippedMigration(task_dir, task_id, "workflow application mismatch")
+        managed_workflow = bool(
+            self.agent_root is not None
+            and _application_id_from_workflow(workflow.path, self.agent_root)
+        )
+
+        if _is_test_task(
+            yaml_path=yaml_path,
+            application_id=application_id,
+            supervisor=supervisor,
+            managed_workflow=managed_workflow,
+        ):
+            return SkippedMigration(task_dir, task_id, "test task")
+
+        metadata: list[Any] = [events, task_tree, checkpoint]
+        for path in sorted((task_dir / "workers").glob("**/checkpoint.json")):
+            worker_checkpoint = _read_json_object(path)
+            if worker_checkpoint is None:
+                return SkippedMigration(
+                    task_dir,
+                    task_id,
+                    "invalid worker checkpoint",
+                )
+            metadata.append(worker_checkpoint)
+        for heartbeat_path in (
+            task_dir / "heartbeat.json",
+            *((task_dir / "workers").glob("**/heartbeat.json")),
+        ):
+            heartbeat = _read_json_object(heartbeat_path)
+            if heartbeat is not None:
+                metadata.append(heartbeat)
+
+        timestamps = list(_metadata_timestamps(metadata))
+        if not timestamps:
+            return SkippedMigration(task_dir, task_id, "missing execution timestamp")
+        last_progress_at = max(timestamps)
+        created_at = _parse_datetime(
+            task_created.get("created_at") or task_tree.get("created_at") or checkpoint.get("created_at")
+        )
+        if created_at is None:
+            return SkippedMigration(task_dir, task_id, "missing original created_at")
+        # Resume expiry is anchored to the original logical task creation time.
+        # A freshly touched directory/heartbeat must not revive an expired task.
+        if self.now - created_at > self.max_age:
+            return SkippedMigration(task_dir, task_id, "outside migration window")
+
+        file_history_state = _file_history_progress_state(task_dir)
+        if file_history_state == "invalid":
+            return SkippedMigration(task_dir, task_id, "invalid file history")
+        context_store_state = _context_store_progress_state(task_dir)
+        if context_store_state == "invalid":
+            return SkippedMigration(task_dir, task_id, "invalid context store")
+        progress_kinds = _progress_kinds(task_dir, checkpoint)
+        if not progress_kinds:
+            return SkippedMigration(task_dir, task_id, "no resumable progress")
+
+        try:
+            checksum = _tree_checksum(task_dir)
+        except MigrationError:
+            return SkippedMigration(task_dir, task_id, "unsafe symlink")
+        destination = self.runtime_root / "checkpoints" / Path(*application_id.split("/")) / task_id
+        return MigrationCandidate(
+            source_dir=task_dir,
+            destination_dir=destination,
+            application_id=application_id,
+            task_id=task_id,
+            yaml_path=yaml_path,
+            created_at=created_at,
+            last_progress_at=last_progress_at,
+            progress_kinds=progress_kinds,
+            checksum=checksum,
+            malformed_event_lines=malformed_lines,
+        )
+
+    def _application_id(
+        self,
+        yaml_path: str,
+        supervisor: str,
+        task_dir: Path,
+    ) -> str:
+        del supervisor, task_dir
+        workflow = self._workflow_identity(yaml_path)
+        if isinstance(workflow, str):
+            raise MigrationError(workflow)
+        return workflow.application_id
+
+    def _workflow_identity(self, yaml_path: str) -> _WorkflowIdentity | str:
+        path = Path(yaml_path).expanduser()
+        if not path.is_absolute():
+            if self.agent_root is None:
+                return "relative workflow path requires agent_root"
+            path = self.agent_root / path
+        try:
+            path = path.resolve(strict=True)
+        except (FileNotFoundError, OSError):
+            return "workflow file not found"
+        if not path.is_file():
+            return "workflow file not found"
+
+        # Use the exact loader and launch-time validation used by run_app.  In
+        # particular, the full config (including explicit application_id/app/
+        # application) must participate in application scope resolution.
+        from src.lib.smolagents.agent.yaml_agent_factory import YamlAgentFactory
+        from src.runner import validate_required_yaml_fields
+
+        try:
+            agent_config = YamlAgentFactory._load_config_from_file(path)
+            validate_required_yaml_fields(agent_config, path)
+            application_id = resolve_application_id(
+                agent_config,
+                path,
+                agent_root=self.agent_root,
+            )
+        except Exception:
+            return "invalid workflow"
+        if not application_id:
+            return "invalid workflow"
+        return _WorkflowIdentity(
+            path=path,
+            config=agent_config,
+            application_id=application_id,
+        )
+
+    def _assert_sources_quiescent_and_unchanged(
+        self,
+        prepared: Iterable[_PreparedMigration],
+    ) -> None:
+        # Archival moves the whole legacy tree, not just candidates.  A live or
+        # ambiguous writer in any skipped task therefore blocks the operation.
+        for task_dir in _iter_legacy_task_dirs(self.legacy_logs_dir):
+            state = _legacy_task_writer_state(task_dir)
+            if state != "inactive":
+                raise MigrationError(
+                    f"legacy checkpoint writer is {state}: {task_dir}"
+                )
+        for item in prepared:
+            if _has_symlink_component(
+                item.candidate.source_dir,
+                self.legacy_logs_dir,
+            ):
+                raise MigrationError(
+                    f"legacy checkpoint source has a symlink component: "
+                    f"{item.candidate.source_dir}"
+                )
+            try:
+                current_checksum = _tree_checksum(item.candidate.source_dir)
+            except (OSError, MigrationError) as exc:
+                raise MigrationError(
+                    f"legacy checkpoint source became unreadable: {item.candidate.source_dir}"
+                ) from exc
+            if current_checksum != item.candidate.checksum:
+                raise MigrationError(
+                    f"legacy checkpoint changed during migration: {item.candidate.task_id}"
+                )
+
+
+def _validate_migration_path(path: Path, *, root: Path) -> None:
+    try:
+        validate_runtime_owned_path(path, root=root)
+    except RuntimeError as exc:
+        raise MigrationError(str(exc)) from exc
+
+
+def plan_migration(
+    legacy_logs_dir: str | Path,
+    runtime_root: str | Path,
+    *,
+    agent_root: str | Path | None = None,
+    max_age: timedelta = timedelta(days=7),
+    now: datetime | None = None,
+) -> MigrationPlan:
+    return RuntimeMigration(
+        legacy_logs_dir=legacy_logs_dir,
+        runtime_root=runtime_root,
+        agent_root=agent_root,
+        max_age=max_age,
+        now=now,
+    ).scan()
+
+
+def migrate_runtime(
+    legacy_logs_dir: str | Path,
+    runtime_root: str | Path,
+    *,
+    dry_run: bool = True,
+    archive_legacy: bool = False,
+    validator: MigrationValidator | None = None,
+    agent_root: str | Path | None = None,
+    max_age: timedelta = timedelta(days=7),
+    now: datetime | None = None,
+) -> MigrationResult:
+    return RuntimeMigration(
+        legacy_logs_dir=legacy_logs_dir,
+        runtime_root=runtime_root,
+        agent_root=agent_root,
+        max_age=max_age,
+        now=now,
+    ).migrate(
+        dry_run=dry_run,
+        archive_legacy=archive_legacy,
+        validator=validator,
+    )
+
+
+def archive_legacy_logs(
+    legacy_logs_dir: str | Path,
+    runtime_root: str | Path,
+    *,
+    now: datetime | None = None,
+) -> Path | None:
+    """Atomically move the whole legacy log tree beneath ``legacy/``."""
+
+    source = Path(legacy_logs_dir).expanduser().absolute()
+    if not source.exists():
+        return None
+    if source.is_symlink():
+        raise MigrationError(f"legacy_logs_dir must not be a symlink: {source}")
+    root = Path(runtime_root).expanduser().absolute()
+    if _is_relative_to(root, source):
+        raise MigrationError("runtime_root must not be inside legacy_logs_dir")
+    legacy_dir = root / "legacy"
+    legacy_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = _as_utc(now or datetime.now(UTC)).strftime("%Y%m%dT%H%M%S%fZ")
+    destination = legacy_dir / f"logs-v1-{timestamp}"
+    suffix = 1
+    while destination.exists():
+        destination = legacy_dir / f"logs-v1-{timestamp}-{suffix}"
+        suffix += 1
+    try:
+        os.replace(source, destination)
+    except OSError as exc:
+        raise MigrationError(f"failed to atomically archive {source}: {exc}") from exc
+    return destination
+
+
+def _iter_legacy_task_dirs(legacy_root: Path) -> list[Path]:
+    if legacy_root.is_symlink() or not legacy_root.is_dir():
+        return []
+    found: set[Path] = set()
+    patterns = ("*/*/checkpoints/*", "*/checkpoints/*")
+    for pattern in patterns:
+        for path in legacy_root.glob(pattern):
+            if (
+                path.is_dir()
+                and not path.name.startswith(".")
+                and not _has_symlink_component(path, legacy_root)
+            ):
+                found.add(path.absolute())
+    return sorted(found, key=lambda path: path.as_posix())
+
+
+def _has_symlink_component(path: Path, root: Path) -> bool:
+    root = root.absolute()
+    path = path.absolute()
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return True
+    current = root
+    if current.is_symlink():
+        return True
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+    return False
+
+
+def _read_jsonl_objects(path: Path) -> tuple[list[dict[str, Any]], int, bool]:
+    events: list[dict[str, Any]] = []
+    malformed: list[tuple[int, bool]] = []
+    try:
+        lines = [
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except UnicodeError:
+        return events, 1, True
+    except OSError:
+        return events, 0, False
+    for index, line in enumerate(lines):
+        raw = line.strip()
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError:
+            malformed.append((index, True))
+            continue
+        if isinstance(value, dict) and value.get("type"):
+            events.append(value)
+        else:
+            malformed.append((index, False))
+
+    # A process can die halfway through its final append.  That one specific
+    # case is recoverable.  Corruption in the middle (or multiple bad records)
+    # can hide completed worker events and would make resume repeat work.
+    safe_crash_tail = (
+        len(malformed) == 1
+        and malformed[0][0] == len(lines) - 1
+        and malformed[0][1]
+    )
+    return events, len(malformed), bool(malformed) and not safe_crash_tail
+
+
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _legacy_task_writer_state(task_dir: Path) -> str:
+    """Return inactive/live/unknown for every legacy writer heartbeat."""
+
+    heartbeat_paths = [task_dir / "heartbeat.json"]
+    workers_root = task_dir / "workers"
+    if workers_root.is_symlink():
+        return "unknown"
+    if workers_root.exists():
+        try:
+            heartbeat_paths.extend(workers_root.rglob("heartbeat.json"))
+        except OSError:
+            return "unknown"
+
+    for heartbeat_path in heartbeat_paths:
+        if not heartbeat_path.exists():
+            continue
+        if heartbeat_path.is_symlink():
+            return "unknown"
+        payload = _read_json_object(heartbeat_path)
+        if payload is None:
+            return "unknown"
+
+        calls = payload.get("calls")
+        if isinstance(calls, dict):
+            running = any(
+                isinstance(call, dict) and call.get("status") == "running"
+                for call in calls.values()
+            )
+            if not running:
+                continue
+        else:
+            status = str(payload.get("status") or "").strip().lower()
+            if status in {"stopped", "exited", "completed", "failed"}:
+                continue
+            if status not in {"", "running"}:
+                return "unknown"
+
+        pid = payload.get("pid")
+        if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+            return "unknown"
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            continue
+        except PermissionError:
+            return "live"
+        except OSError:
+            return "unknown"
+        return "live"
+    return "inactive"
+
+
+def _metadata_timestamps(values: Iterable[Any]) -> Iterable[datetime]:
+    timestamp_keys = {
+        "created_at",
+        "finished_at",
+        "interrupted_at",
+        "last_run_at",
+        "saved_at",
+        "started_at",
+        "timestamp",
+        "updated_at",
+    }
+
+    def walk(value: Any) -> Iterable[datetime]:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key in timestamp_keys:
+                    parsed = _parse_datetime(child)
+                    if parsed is not None:
+                        yield parsed
+                elif isinstance(child, (dict, list, tuple)):
+                    yield from walk(child)
+        elif isinstance(value, (list, tuple)):
+            for child in value:
+                yield from walk(child)
+
+    for value in values:
+        yield from walk(value)
+
+
+def _progress_kinds(task_dir: Path, checkpoint: dict[str, Any]) -> tuple[str, ...]:
+    kinds: list[str] = []
+    checkpoints = [checkpoint]
+    for path in sorted((task_dir / "workers").glob("**/checkpoint.json")):
+        worker = _read_json_object(path)
+        if worker is not None:
+            checkpoints.append(worker)
+    if any(_checkpoint_has_memory(item) for item in checkpoints):
+        kinds.append("memory")
+
+    if _context_store_progress_state(task_dir) == "valid":
+        kinds.append("context_store")
+
+    if _file_history_progress_state(task_dir) == "valid":
+        kinds.append("file_history")
+    return tuple(kinds)
+
+
+def _context_store_progress_state(task_dir: Path) -> str:
+    """Return absent, valid, or invalid for durable ContextStore entries."""
+
+    store_dir = task_dir / "context_store"
+    if not store_dir.exists():
+        return "absent"
+    if not store_dir.is_dir() or store_dir.is_symlink():
+        return "invalid"
+    entries_dir = store_dir / "entries"
+    if not entries_dir.exists():
+        return "absent"
+    if not entries_dir.is_dir() or entries_dir.is_symlink():
+        return "invalid"
+    found = False
+    try:
+        entry_paths = sorted(entries_dir.glob("ctx_*.json"))
+    except OSError:
+        return "invalid"
+    for entry_path in entry_paths:
+        if entry_path.is_symlink():
+            return "invalid"
+        entry = _read_json_object(entry_path)
+        if entry is None:
+            return "invalid"
+        if entry.get("ref") and entry.get("original") is not None:
+            found = True
+    return "valid" if found else "absent"
+
+
+def _file_history_progress_state(task_dir: Path) -> str:
+    """Return absent, valid, or invalid for durable file-history progress."""
+
+    history_dir = task_dir / "file-history"
+    if not history_dir.is_dir() or history_dir.is_symlink():
+        return "absent"
+    index_path = history_dir / "snapshots.json"
+    if not index_path.exists():
+        # Crash leftovers such as .bk_* / .idx_* and metadata files are not
+        # resumable state and must not turn a task into a migration candidate.
+        return "absent"
+    history_index = _read_json_object(index_path)
+    if history_index is None:
+        return "invalid"
+    snapshots = history_index.get("snapshots", [])
+    first_backups = history_index.get("first_tracked_backups", {})
+    if not isinstance(snapshots, list) or not isinstance(first_backups, dict):
+        return "invalid"
+    has_progress = bool(snapshots or first_backups)
+    if not has_progress:
+        return "absent"
+    try:
+        _validate_file_history_backups(history_dir, history_index)
+    except MigrationError:
+        return "invalid"
+    return "valid"
+
+
+def _checkpoint_has_memory(checkpoint: dict[str, Any]) -> bool:
+    steps = checkpoint.get("memory_steps")
+    return isinstance(steps, list) and len(steps) > 0
+
+
+def _application_id_from_workflow(workflow: Path, agent_root: Path) -> str:
+    path = workflow.expanduser()
+    if not path.is_absolute():
+        path = agent_root / path
+    try:
+        relative = path.absolute().relative_to((agent_root / "applications").absolute())
+    except ValueError:
+        return ""
+    parts = relative.parts
+    try:
+        workflows_index = parts.index("workflows")
+    except ValueError:
+        return ""
+    if workflows_index < 1:
+        return ""
+    return "/".join(parts[:workflows_index])
+
+
+def _is_test_task(
+    *,
+    yaml_path: str,
+    application_id: str,
+    supervisor: str,
+    managed_workflow: bool,
+) -> bool:
+    normalized = yaml_path.replace("\\", "/").lower()
+    path_parts = {part for part in normalized.split("/") if part}
+    app_parts = {part.lower() for part in application_id.split("/")}
+    if not managed_workflow and ("pytest-of-" in normalized or any(part.startswith("pytest-") for part in path_parts)):
+        return True
+    if "tests" in path_parts:
+        return True
+    if any(part == "test" or part.startswith("test_") for part in app_parts):
+        return True
+    return supervisor.lower().startswith("test_")
+
+
+def _legacy_supervisor_name(task_dir: Path, legacy_root: Path) -> str:
+    try:
+        relative = task_dir.relative_to(legacy_root)
+    except ValueError:
+        return "legacy"
+    return relative.parts[0] if relative.parts else "legacy"
+
+
+def _normalize_legacy_worker_checkpoints(task_dir: Path) -> None:
+    """Convert v1 worker checkpoints to the canonical per-call layout."""
+
+    workers_dir = task_dir / "workers"
+    if not workers_dir.is_dir():
+        return
+    tree = _read_json_object(task_dir / "task_tree.json") or {}
+    for worker_dir in sorted(path for path in workers_dir.iterdir() if path.is_dir()):
+        raw_worker_name = worker_dir.name
+        portable_name = portable_runtime_component(raw_worker_name, fallback="worker")
+        if portable_name != raw_worker_name:
+            portable_dir = workers_dir / portable_name
+            if portable_dir.exists():
+                raise MigrationError(
+                    f"conflicting portable worker directory: {portable_dir}"
+                )
+            worker_dir.rename(portable_dir)
+            worker_dir = portable_dir
+        legacy_checkpoint = worker_dir / "checkpoint.json"
+        if not legacy_checkpoint.is_file():
+            continue
+        checkpoint = _read_json_object(legacy_checkpoint)
+        if checkpoint is None:
+            raise MigrationError(f"invalid legacy worker checkpoint: {legacy_checkpoint}")
+        call_index = _worker_call_index(checkpoint, tree, raw_worker_name)
+        target = worker_dir / "calls" / str(call_index) / "checkpoint.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            if target.read_bytes() != legacy_checkpoint.read_bytes():
+                raise MigrationError(f"conflicting worker checkpoints for {worker_dir.name} call {call_index}")
+            legacy_checkpoint.unlink()
+        else:
+            os.replace(legacy_checkpoint, target)
+
+
+def _worker_call_index(checkpoint: dict[str, Any], tree: dict[str, Any], worker_name: str) -> int:
+    raw_index = checkpoint.get("call_index")
+    if isinstance(raw_index, int) and not isinstance(raw_index, bool) and raw_index >= 0:
+        return raw_index
+    if isinstance(raw_index, str) and raw_index.isdigit():
+        return int(raw_index)
+
+    worker = (tree.get("workers") or {}).get(worker_name, [])
+    calls = worker if isinstance(worker, list) else [worker]
+    indexes: list[int] = []
+    for call in calls:
+        if not isinstance(call, dict):
+            continue
+        try:
+            index = int(call.get("call_index"))
+        except (TypeError, ValueError):
+            continue
+        if index >= 0:
+            indexes.append(index)
+    return max(indexes) if indexes else 0
+
+
+def _tree_checksum(root: Path) -> str:
+    digest = hashlib.sha256()
+    if root.is_symlink():
+        raise MigrationError(f"symlink is not allowed in checkpoint tree: {root}")
+    for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        if path.is_symlink():
+            raise MigrationError(f"symlink is not allowed in checkpoint tree: {path}")
+        if path.is_dir():
+            digest.update(b"D\0" + relative + b"\0")
+            continue
+        if not path.is_file():
+            raise MigrationError(f"unsupported checkpoint entry: {path}")
+        digest.update(b"F\0" + relative + b"\0")
+        try:
+            with path.open("rb") as stream:
+                while chunk := stream.read(1024 * 1024):
+                    digest.update(chunk)
+        except OSError as exc:
+            raise MigrationError(f"failed to checksum {path}: {exc}") from exc
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def validate_migrated_checkpoint(candidate: MigrationCandidate, destination: Path) -> None:
+    """Deeply validate canonical resume, ContextRefs, and file history.
+
+    Imports stay local so planning and ``--dry-run`` do not initialize the
+    checkpoint/runtime stack.
+    """
+
+    if not (destination / "task_events.jsonl").is_file() and not (destination / "task_tree.json").is_file():
+        raise MigrationError(f"task metadata missing for {candidate.task_id}")
+    progress = _progress_kinds(
+        destination,
+        _read_json_object(destination / "checkpoint.json") or {},
+    )
+    if not progress:
+        raise MigrationError(f"resumable progress missing for {candidate.task_id}")
+
+    from types import SimpleNamespace
+
+    from src.lib.checkpoint import CheckpointManager
+    from src.lib.checkpoint.coordinator import CheckpointCoordinator
+
+    manager = CheckpointManager(
+        "migration-validator",
+        checkpoint_dir=destination,
+    )
+    tree = manager.load_task_tree(candidate.task_id)
+    if not isinstance(tree, dict):
+        raise MigrationError(f"canonical task tree unreadable for {candidate.task_id}")
+    supervisor_checkpoint = manager.load_supervisor_checkpoint(candidate.task_id)
+    if not isinstance(supervisor_checkpoint, dict):
+        raise MigrationError(f"supervisor checkpoint unreadable for {candidate.task_id}")
+
+    sentinel = object()
+    holder = SimpleNamespace(memory=SimpleNamespace(steps=sentinel))
+    coordinator = CheckpointCoordinator(
+        manager,
+        candidate.task_id,
+        str(supervisor_checkpoint.get("task_text", "")),
+        resume=True,
+    )
+    coordinator.restore(holder)
+    if holder.memory.steps is sentinel:
+        raise MigrationError(f"supervisor restore failed for {candidate.task_id}")
+    if supervisor_checkpoint.get("memory_steps") and not holder.memory.steps:
+        raise MigrationError(f"supervisor memory was not restored for {candidate.task_id}")
+
+    workers_dir = destination / "workers"
+    if workers_dir.is_dir():
+        legacy_workers = sorted(workers_dir.glob("*/checkpoint.json"))
+        if legacy_workers:
+            raise MigrationError(f"legacy worker layout remains at {legacy_workers[0]}")
+        for worker_path in sorted(workers_dir.glob("*/calls/*/checkpoint.json")):
+            relative = worker_path.relative_to(workers_dir)
+            worker_name = relative.parts[0]
+            try:
+                call_index = int(relative.parts[2])
+            except (IndexError, ValueError) as exc:
+                raise MigrationError(f"invalid worker call path: {worker_path}") from exc
+            worker_checkpoint = manager.load_worker_checkpoint(
+                candidate.task_id,
+                worker_name,
+                call_index,
+            )
+            if not isinstance(worker_checkpoint, dict):
+                raise MigrationError(f"canonical worker checkpoint unreadable: {worker_path}")
+            raw_steps = worker_checkpoint.get("memory_steps") or []
+            if raw_steps and worker_checkpoint.get("status") != "completed":
+                worker_holder = SimpleNamespace(memory=SimpleNamespace(steps=[]))
+                if not coordinator.restore_worker(worker_holder, worker_name, call_index):
+                    raise MigrationError(f"worker restore failed for {worker_name} call {call_index}")
+
+    context_store_dir = destination / "context_store"
+    if context_store_dir.is_dir():
+        from src.lib.context_engine.store import ContextStore
+
+        store = ContextStore(context_store_dir)
+        # Retrieval normally appends an audit event. Disable only that side
+        # effect so validation stays checksum/idempotency neutral while still
+        # exercising the real lookup and slicing path.
+        store._append_event = lambda _event: None  # type: ignore[method-assign]
+        refs = store.refs()
+        if "context_store" in candidate.progress_kinds and not refs:
+            raise MigrationError(f"ContextStore has no refs for {candidate.task_id}")
+        for ref in refs:
+            if store.get(ref) is None or store.retrieve(ref, limit=0) is None:
+                raise MigrationError(f"ContextRef retrieval failed: {ref}")
+
+    history_dir = destination / "file-history"
+    history_index_path = history_dir / "snapshots.json"
+    if history_index_path.exists():
+        history_index = _read_json_object(history_index_path)
+        if history_index is None:
+            raise MigrationError(f"file-history index unreadable for {candidate.task_id}")
+        _validate_file_history_backups(history_dir, history_index)
+
+        from src.lib.checkpoint.file_history import FileHistoryManager
+
+        history = FileHistoryManager(history_dir)
+        try:
+            history.restore_from_index(history_index)
+        except Exception as exc:
+            raise MigrationError(f"file-history restore failed: {exc}") from exc
+        expected_snapshots = history_index.get("snapshots", [])
+        if history.snapshot_count != len(expected_snapshots):
+            raise MigrationError(f"file-history snapshots were not fully restored for {candidate.task_id}")
+    elif "file_history" in candidate.progress_kinds:
+        raise MigrationError(f"file-history index missing for {candidate.task_id}")
+
+
+def _validate_file_history_backups(history_dir: Path, history_index: dict[str, Any]) -> None:
+    groups: list[Any] = [history_index.get("first_tracked_backups", {})]
+    for snapshot in history_index.get("snapshots", []):
+        if isinstance(snapshot, dict):
+            groups.append(snapshot.get("tracked_file_backups", {}))
+    for group in groups:
+        if not isinstance(group, dict):
+            raise MigrationError("file-history backup mapping is invalid")
+        for backup in group.values():
+            if not isinstance(backup, dict):
+                raise MigrationError("file-history backup record is invalid")
+            filename = backup.get("backup_filename")
+            if filename is None:
+                continue
+            backup_path = history_dir / str(filename)
+            if not _is_relative_to(backup_path, history_dir) or not backup_path.is_file():
+                raise MigrationError(f"file-history backup missing: {filename}")
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value), tz=UTC)
+        except (OSError, OverflowError, ValueError):
+            return None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = f"{raw[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return _as_utc(parsed)
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _remove_empty_parents(path: Path, *, stop: Path) -> None:
+    current = path
+    while _is_relative_to(current, stop):
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        if current == stop:
+            return
+        current = current.parent

--- a/src/lib/runtime/retention.py
+++ b/src/lib/runtime/retention.py
@@ -1,0 +1,505 @@
+"""Bounded retention for run-scoped runtime data.
+
+Only ``<runtime-root>/runs`` is eligible for deletion.  Checkpoints have their
+own resume lifecycle, while ``legacy`` and application-owned output trees are
+deliberately outside this cleaner's traversal boundary.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from .context import RuntimeRunLease, safe_application_id, validate_runtime_id
+
+_SUCCESS_STATUSES = frozenset({"completed", "success", "succeeded"})
+_FAILURE_STATUSES = frozenset({"cancelled", "crashed", "error", "failed", "interrupted"})
+_ORPHAN_RUN_GRACE = timedelta(minutes=5)
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionPolicy:
+    successful_runs: timedelta = timedelta(days=7)
+    failed_runs: timedelta = timedelta(days=30)
+    raw_artifacts: timedelta = timedelta(days=3)
+    automatic_interval: timedelta = timedelta(hours=24)
+
+
+@dataclass(slots=True)
+class CleanupResult:
+    removed_runs: list[Path] = field(default_factory=list)
+    removed_artifacts: list[Path] = field(default_factory=list)
+    reclaimed_bytes: int = 0
+    skipped: bool = False
+    skip_reason: str | None = None
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def removed_run_count(self) -> int:
+        return len(self.removed_runs)
+
+    @property
+    def removed_artifact_count(self) -> int:
+        return len(self.removed_artifacts)
+
+
+def clean_runtime(
+    runtime_root: str | Path,
+    *,
+    policy: RetentionPolicy | None = None,
+    config: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> CleanupResult:
+    """Explicitly enforce run and raw-artifact retention.
+
+    A directory is considered a run only when it owns a readable
+    ``manifest.json``.  Unknown and currently-running statuses are preserved:
+    deleting a live attempt is worse than retaining an orphan for manual
+    inspection.
+    """
+
+    configured_root = Path(runtime_root).expanduser()
+    if policy is not None and config is not None:
+        raise ValueError("pass either policy or config, not both")
+    policy = policy or retention_policy_from_config(config)
+    current = _as_utc(now or datetime.now(UTC))
+    if configured_root.is_symlink() or not configured_root.exists():
+        return CleanupResult()
+    root = configured_root.resolve()
+    lock_fd = _acquire_cleanup_lock(root)
+    if lock_fd is None:
+        return CleanupResult(skipped=True, skip_reason="cleanup already in progress")
+    try:
+        return _clean_runtime_unlocked(root, policy=policy, current=current)
+    finally:
+        _release_cleanup_lock(lock_fd)
+
+
+def _clean_runtime_unlocked(
+    root: Path,
+    *,
+    policy: RetentionPolicy,
+    current: datetime,
+) -> CleanupResult:
+    """Apply retention while the caller owns the runtime-root lock."""
+    result = CleanupResult()
+    runs_root = root / "runs"
+    if runs_root.is_symlink() or not runs_root.is_dir():
+        return result
+
+    for manifest_path in sorted(runs_root.rglob("manifest.json")):
+        if manifest_path.is_symlink() or not manifest_path.is_file():
+            continue
+        manifest = _read_json_object(manifest_path)
+        run_dir = _canonical_run_dir(runs_root, manifest_path, manifest)
+        if run_dir is None or run_dir.is_symlink():
+            continue
+        run_lease = RuntimeRunLease(run_dir)
+        try:
+            run_lease.acquire()
+        except (BlockingIOError, OSError, RuntimeError):
+            continue
+        try:
+            # Re-read only through the already validated canonical pathname.
+            # The run lease prevents a cooperating AgentLoom process from
+            # finalizing or cleaning the same run while retention evaluates it.
+            manifest = _read_json_object(manifest_path)
+            if _canonical_run_dir(runs_root, manifest_path, manifest) != run_dir:
+                continue
+            status = str(manifest.get("status", "")).strip().lower()
+            if status in _SUCCESS_STATUSES:
+                run_ttl = policy.successful_runs
+            elif status in _FAILURE_STATUSES or status == "running":
+                # A running manifest whose directory lease is acquirable has
+                # no live owner: the attempt crashed before finalization.
+                run_ttl = policy.failed_runs
+            else:
+                continue
+
+            reference_time = _manifest_time(manifest)
+            if reference_time is None:
+                continue
+            age = current - reference_time
+            if age < timedelta(0):
+                continue
+
+            if age >= run_ttl:
+                size = _tree_size(run_dir)
+                try:
+                    shutil.rmtree(run_dir)
+                except OSError as exc:
+                    result.errors.append(f"failed to remove run {run_dir}: {exc}")
+                else:
+                    result.removed_runs.append(run_dir)
+                    result.reclaimed_bytes += size
+                continue
+
+            artifacts_dir = run_dir / "artifacts"
+            if age >= policy.raw_artifacts and artifacts_dir.is_dir():
+                size = _tree_size(artifacts_dir)
+                try:
+                    shutil.rmtree(artifacts_dir)
+                except OSError as exc:
+                    result.errors.append(f"failed to remove raw artifacts {artifacts_dir}: {exc}")
+                else:
+                    result.removed_artifacts.append(artifacts_dir)
+                    result.reclaimed_bytes += size
+        finally:
+            run_lease.release()
+
+    # A SIGKILL during the atomic first-manifest write can leave only the
+    # canonical empty run skeleton and a framework manifest temp file.  Such a
+    # run has no timestamp payload, so its newest filesystem mtime is used only
+    # for this narrowly identified orphan case, with a non-zero safety grace.
+    orphan_ttl = max(policy.failed_runs, _ORPHAN_RUN_GRACE)
+    for run_dir in _safe_orphan_run_dirs(runs_root):
+        run_lease = RuntimeRunLease(run_dir)
+        try:
+            run_lease.acquire()
+        except (BlockingIOError, OSError, RuntimeError):
+            continue
+        try:
+            reference_time = _orphan_reference_time(run_dir)
+            if reference_time is None or current - reference_time < orphan_ttl:
+                continue
+            size = _tree_size(run_dir)
+            try:
+                shutil.rmtree(run_dir)
+            except OSError as exc:
+                result.errors.append(f"failed to remove orphan run {run_dir}: {exc}")
+            else:
+                result.removed_runs.append(run_dir)
+                result.reclaimed_bytes += size
+        finally:
+            run_lease.release()
+
+    return result
+
+
+def _safe_orphan_run_dirs(runs_root: Path) -> list[Path]:
+    candidates: set[Path] = set()
+    try:
+        markers = list(runs_root.rglob(".run-starting.json"))
+    except OSError:
+        return []
+    for marker in markers:
+        if marker.is_symlink() or not marker.is_file():
+            continue
+        identity = _read_json_object(marker)
+        run_dir = _canonical_run_dir(runs_root, marker, identity, filename=marker.name)
+        if run_dir is None:
+            continue
+        logs_dir = run_dir / "logs"
+        if not logs_dir.is_dir() or logs_dir.is_symlink():
+            continue
+        if (run_dir / "manifest.json").exists() or run_dir.is_symlink():
+            continue
+        try:
+            children = list(run_dir.iterdir())
+        except OSError:
+            continue
+        safe = True
+        for child in children:
+            if child.name in {"logs", "audit", "artifacts"}:
+                if not child.is_dir() or child.is_symlink():
+                    safe = False
+                    break
+                try:
+                    nested = list(child.iterdir())
+                except OSError:
+                    safe = False
+                    break
+                if child.name == "artifacts":
+                    if any(
+                        item.name not in {"shell", "background", "skills"}
+                        or not item.is_dir()
+                        or item.is_symlink()
+                        or any(item.iterdir())
+                        for item in nested
+                    ):
+                        safe = False
+                        break
+                elif nested:
+                    safe = False
+                    break
+            elif child.name == ".run-starting.json":
+                if child != marker or child.is_symlink() or not child.is_file():
+                    safe = False
+                    break
+            elif not (
+                child.is_file()
+                and not child.is_symlink()
+                and child.name.startswith(".manifest.json.")
+                and child.name.endswith(".tmp")
+            ):
+                safe = False
+                break
+        if safe and {"logs", "audit", "artifacts"}.issubset(
+            {child.name for child in children}
+        ):
+            candidates.add(run_dir)
+    return sorted(candidates)
+
+
+def _canonical_run_dir(
+    runs_root: Path,
+    identity_path: Path,
+    payload: dict[str, Any] | None,
+    *,
+    filename: str = "manifest.json",
+) -> Path | None:
+    """Return the canonical run directory named by one trusted identity file.
+
+    A raw artifact may legitimately be called ``manifest.json``.  Its content
+    never grants deletion authority: the identity must map back to the exact
+    ``runs/<application_id>/<run_id>`` pathname where it was found.
+    """
+
+    if payload is None or identity_path.name != filename:
+        return None
+    application_id = payload.get("application_id")
+    run_id = payload.get("run_id")
+    task_id = payload.get("task_id")
+    if not all(isinstance(value, str) for value in (application_id, run_id, task_id)):
+        return None
+    try:
+        canonical_application = safe_application_id(application_id)
+        canonical_run = validate_runtime_id(run_id, field="run_id")
+        validate_runtime_id(task_id, field="task_id")
+    except ValueError:
+        return None
+    if canonical_application != application_id or canonical_run != run_id:
+        return None
+    expected = runs_root / Path(*canonical_application.split("/")) / canonical_run
+    if identity_path != expected / filename or not _is_within(expected, runs_root):
+        return None
+    return expected
+
+
+def _orphan_reference_time(run_dir: Path) -> datetime | None:
+    newest: float | None = None
+    try:
+        paths = [run_dir, *run_dir.iterdir()]
+    except OSError:
+        return None
+    for path in paths:
+        try:
+            modified = path.stat(follow_symlinks=False).st_mtime
+        except OSError:
+            return None
+        newest = modified if newest is None else max(newest, modified)
+    return datetime.fromtimestamp(newest, tz=UTC) if newest is not None else None
+
+
+def maybe_clean_runtime(
+    runtime_root: str | Path,
+    *,
+    policy: RetentionPolicy | None = None,
+    now: datetime | None = None,
+) -> CleanupResult:
+    """Run automatic cleanup no more than once per policy interval."""
+
+    root = Path(runtime_root).expanduser()
+    policy = policy or RetentionPolicy()
+    current = _as_utc(now or datetime.now(UTC))
+    if root.is_symlink():
+        return CleanupResult(skipped=True, skip_reason="runtime root is a symlink")
+    root.mkdir(parents=True, exist_ok=True)
+    root = root.resolve()
+    state_path = root / ".cleanup-state.json"
+    lock_fd = _acquire_cleanup_lock(root)
+    if lock_fd is None:
+        return CleanupResult(skipped=True, skip_reason="cleanup already in progress")
+    try:
+        state = _read_json_object(state_path) or {}
+        last_run = _parse_datetime(state.get("last_completed_at"))
+        if last_run is not None:
+            elapsed = current - last_run
+            if timedelta(0) <= elapsed < policy.automatic_interval:
+                return CleanupResult(
+                    skipped=True,
+                    skip_reason="automatic cleanup throttled",
+                )
+
+        result = _clean_runtime_unlocked(root, policy=policy, current=current)
+        _atomic_write_json(state_path, {"last_completed_at": current.isoformat()})
+        return result
+    finally:
+        _release_cleanup_lock(lock_fd)
+
+
+def prune_runtime_if_due(
+    runtime_root: str | Path,
+    config: Mapping[str, Any] | RetentionPolicy | None = None,
+    *,
+    now: datetime | None = None,
+) -> CleanupResult:
+    """Canonical runner entry point for throttled automatic cleanup."""
+
+    policy = config if isinstance(config, RetentionPolicy) else retention_policy_from_config(config)
+    return maybe_clean_runtime(runtime_root, policy=policy, now=now)
+
+
+def retention_policy_from_config(
+    config: Mapping[str, Any] | None,
+) -> RetentionPolicy:
+    """Build a policy from the canonical ``runtime`` config mapping."""
+
+    values = config or {}
+    successful_days = _non_negative_number(
+        values.get("successful_run_retention_days", 7),
+        "successful_run_retention_days",
+    )
+    failed_days = _non_negative_number(
+        values.get("failed_run_retention_days", 30),
+        "failed_run_retention_days",
+    )
+    artifact_days = _non_negative_number(
+        values.get("artifact_retention_days", 3),
+        "artifact_retention_days",
+    )
+    cleanup_hours = _non_negative_number(
+        values.get("cleanup_interval_hours", 24),
+        "cleanup_interval_hours",
+    )
+    if cleanup_hours < 24:
+        raise ValueError("cleanup_interval_hours must be at least 24")
+    return RetentionPolicy(
+        successful_runs=timedelta(days=successful_days),
+        failed_runs=timedelta(days=failed_days),
+        raw_artifacts=timedelta(days=artifact_days),
+        automatic_interval=timedelta(hours=cleanup_hours),
+    )
+
+
+def _non_negative_number(value: Any, field: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be a non-negative number")
+    try:
+        converted = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be a non-negative number") from exc
+    if converted < 0:
+        raise ValueError(f"{field} must be a non-negative number")
+    return converted
+
+
+def _manifest_time(manifest: dict[str, Any]) -> datetime | None:
+    for key in ("finished_at", "ended_at", "updated_at", "started_at"):
+        parsed = _parse_datetime(manifest.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value), tz=UTC)
+        except (OSError, OverflowError, ValueError):
+            return None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = f"{raw[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _tree_size(path: Path) -> int:
+    total = 0
+    try:
+        entries = list(path.rglob("*"))
+    except OSError:
+        return 0
+    for entry in entries:
+        try:
+            if entry.is_file() and not entry.is_symlink():
+                total += entry.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _acquire_cleanup_lock(root: Path) -> int | None:
+    """Lock the stable runtime directory inode without leaving lock files."""
+    try:
+        lock_fd = os.open(root, os.O_RDONLY)
+    except OSError:
+        return None
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        os.close(lock_fd)
+        return None
+
+    # Remove the lock-file artifact used by the first implementation.  The
+    # directory lock remains valid even when files below the root are renamed.
+    try:
+        (root / ".cleanup.lock").unlink()
+    except (FileNotFoundError, OSError):
+        pass
+    return lock_fd
+
+
+def _release_cleanup_lock(lock_fd: int) -> None:
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    finally:
+        os.close(lock_fd)
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise

--- a/src/lib/runtime/storage.py
+++ b/src/lib/runtime/storage.py
@@ -1,0 +1,513 @@
+"""Descriptor-anchored storage primitives for runtime-owned state."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import stat
+import threading
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+_DIRECTORY_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_COPY_CHUNK_BYTES = 1024 * 1024
+
+
+def _write_all(fd: int, payload: bytes) -> None:
+    view = memoryview(payload)
+    while view:
+        try:
+            written = os.write(fd, view)
+        except InterruptedError:
+            continue
+        if written <= 0:
+            raise OSError("short write while copying runtime state")
+        view = view[written:]
+
+
+def _copy_fd(source_fd: int, destination_fd: int) -> None:
+    while True:
+        try:
+            chunk = os.read(source_fd, _COPY_CHUNK_BYTES)
+        except InterruptedError:
+            continue
+        if not chunk:
+            return
+        _write_all(destination_fd, chunk)
+
+
+def _apply_copied_metadata(fd: int, source_stat: os.stat_result) -> None:
+    """Preserve the copy2 metadata required by file-history rewind."""
+
+    os.fchmod(fd, stat.S_IMODE(source_stat.st_mode))
+    os.utime(fd, ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns))
+
+
+def _read_up_to(fd: int, limit: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = limit
+    while remaining:
+        try:
+            chunk = os.read(fd, remaining)
+        except InterruptedError:
+            continue
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+class SecureDirectory:
+    """Keep storage anchored to one directory inode across pathname changes."""
+
+    def __init__(self, path: str | Path, *, create: bool = True) -> None:
+        self.path = Path(os.path.abspath(os.fspath(Path(path).expanduser())))
+        self._lock = threading.RLock()
+        self._fd = self._open_root(create=create)
+
+    def _open_root(self, *, create: bool) -> int:
+        parent = self.path.parent
+        if create:
+            parent.mkdir(parents=True, exist_ok=True)
+        parent_fd = os.open(parent, _DIRECTORY_FLAGS)
+        try:
+            if create:
+                try:
+                    os.mkdir(self.path.name, mode=0o700, dir_fd=parent_fd)
+                except FileExistsError:
+                    pass
+            return os.open(self.path.name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+
+    @classmethod
+    def _from_fd(cls, path: Path, fd: int) -> SecureDirectory:
+        instance = cls.__new__(cls)
+        instance.path = path
+        instance._lock = threading.RLock()
+        instance._fd = fd
+        return instance
+
+    def duplicate(self) -> SecureDirectory:
+        with self._lock:
+            if self._fd < 0:
+                raise RuntimeError(f"secure directory is closed: {self.path}")
+            return self._from_fd(self.path, os.dup(self._fd))
+
+    def child(self, relative: str | Path, *, create: bool = True) -> SecureDirectory:
+        parts = self._parts(relative)
+        fd = self._open_dir(parts, create=create)
+        return self._from_fd(self.path.joinpath(*parts), fd)
+
+    @property
+    def closed(self) -> bool:
+        return self._fd < 0
+
+    def _parts(self, relative: str | Path) -> tuple[str, ...]:
+        path = PurePosixPath(str(relative).replace("\\", "/"))
+        if path.is_absolute() or not path.parts or any(
+            part in {"", ".", ".."} for part in path.parts
+        ):
+            raise ValueError(f"unsafe relative storage path: {relative}")
+        return path.parts
+
+    def _open_dir(self, parts: tuple[str, ...], *, create: bool) -> int:
+        with self._lock:
+            if self._fd < 0:
+                raise RuntimeError(f"secure directory is closed: {self.path}")
+            current = os.dup(self._fd)
+        try:
+            for part in parts:
+                try:
+                    next_fd = os.open(part, _DIRECTORY_FLAGS, dir_fd=current)
+                except FileNotFoundError:
+                    if not create:
+                        raise
+                    try:
+                        os.mkdir(part, mode=0o700, dir_fd=current)
+                    except FileExistsError:
+                        pass
+                    next_fd = os.open(part, _DIRECTORY_FLAGS, dir_fd=current)
+                os.close(current)
+                current = next_fd
+            return current
+        except BaseException:
+            os.close(current)
+            raise
+
+    def ensure_dir(self, relative: str | Path) -> None:
+        fd = self._open_dir(self._parts(relative), create=True)
+        os.close(fd)
+
+    def _open_parent(self, relative: str | Path, *, create: bool) -> tuple[int, str]:
+        parts = self._parts(relative)
+        parent_fd = self._open_dir(parts[:-1], create=create)
+        return parent_fd, parts[-1]
+
+    def atomic_write(
+        self,
+        relative: str | Path,
+        payload: bytes,
+        *,
+        mode: int = 0o600,
+    ) -> None:
+        parent_fd, name = self._open_parent(relative, create=True)
+        temporary = f".{name}.{uuid.uuid4().hex}.tmp"
+        file_fd = -1
+        try:
+            try:
+                existing = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                existing = None
+            if existing is not None and not stat.S_ISREG(existing.st_mode):
+                raise RuntimeError(f"storage target is not regular: {self.path / str(relative)}")
+            file_fd = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW,
+                mode,
+                dir_fd=parent_fd,
+            )
+            with os.fdopen(file_fd, "wb", closefd=True) as stream:
+                file_fd = -1
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(
+                temporary,
+                name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+        finally:
+            if file_fd >= 0:
+                os.close(file_fd)
+            try:
+                os.unlink(temporary, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
+
+    def atomic_write_text(
+        self,
+        relative: str | Path,
+        text: str,
+        *,
+        encoding: str = "utf-8",
+    ) -> None:
+        self.atomic_write(relative, text.encode(encoding))
+
+    def atomic_write_json(self, relative: str | Path, payload: Any) -> None:
+        self.atomic_write_text(
+            relative,
+            json.dumps(payload, ensure_ascii=False, indent=2, default=str) + "\n",
+        )
+
+    def append_text(
+        self,
+        relative: str | Path,
+        text: str,
+        *,
+        ensure_line_boundary: bool = False,
+        encoding: str = "utf-8",
+    ) -> None:
+        parent_fd, name = self._open_parent(relative, create=True)
+        fd = -1
+        try:
+            fd = os.open(
+                name,
+                os.O_RDWR | os.O_APPEND | os.O_CREAT | _NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise RuntimeError(f"storage target is not regular: {self.path / str(relative)}")
+            payload = text.encode(encoding)
+            if ensure_line_boundary and os.fstat(fd).st_size > 0:
+                os.lseek(fd, -1, os.SEEK_END)
+                if os.read(fd, 1) != b"\n":
+                    payload = b"\n" + payload
+            view = memoryview(payload)
+            while view:
+                try:
+                    written = os.write(fd, view)
+                except InterruptedError:
+                    continue
+                if written <= 0:
+                    raise OSError("short write while appending runtime state")
+                view = view[written:]
+            os.fsync(fd)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            os.close(parent_fd)
+
+    @contextmanager
+    def advisory_file_lock(
+        self,
+        relative: str | Path,
+        *,
+        create: bool = False,
+    ) -> Iterator[None]:
+        """Hold an exclusive advisory lock on one anchored regular file."""
+
+        parent_fd, name = self._open_parent(relative, create=create)
+        fd = -1
+        locked = False
+        try:
+            flags = os.O_RDWR | _NOFOLLOW
+            if create:
+                flags |= os.O_CREAT
+            fd = os.open(name, flags, 0o600, dir_fd=parent_fd)
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise RuntimeError(
+                    f"storage lock target is not regular: {self.path / str(relative)}"
+                )
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            locked = True
+            yield
+        finally:
+            if fd >= 0:
+                try:
+                    if locked:
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                finally:
+                    os.close(fd)
+            os.close(parent_fd)
+
+    def read_bytes(self, relative: str | Path) -> bytes:
+        parent_fd, name = self._open_parent(relative, create=False)
+        fd = -1
+        try:
+            fd = os.open(name, os.O_RDONLY | _NOFOLLOW, dir_fd=parent_fd)
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise RuntimeError(f"storage source is not regular: {self.path / str(relative)}")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(fd, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return b"".join(chunks)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            os.close(parent_fd)
+
+    def read_text(self, relative: str | Path, *, encoding: str = "utf-8") -> str:
+        return self.read_bytes(relative).decode(encoding)
+
+    def read_json(self, relative: str | Path) -> Any:
+        return json.loads(self.read_text(relative))
+
+    def regular_file_names(self, relative_dir: str | Path) -> list[str]:
+        directory_fd = self._open_dir(self._parts(relative_dir), create=False)
+        try:
+            names: list[str] = []
+            for name in os.listdir(directory_fd):
+                metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+                if stat.S_ISREG(metadata.st_mode):
+                    names.append(name)
+            return sorted(names)
+        finally:
+            os.close(directory_fd)
+
+    def directory_names(self, relative_dir: str | Path) -> list[str]:
+        directory_fd = self._open_dir(self._parts(relative_dir), create=False)
+        try:
+            names: list[str] = []
+            for name in os.listdir(directory_fd):
+                metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+                if stat.S_ISDIR(metadata.st_mode):
+                    names.append(name)
+            return sorted(names)
+        finally:
+            os.close(directory_fd)
+
+    def stat_file(self, relative: str | Path) -> os.stat_result:
+        parent_fd, name = self._open_parent(relative, create=False)
+        try:
+            metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise RuntimeError(f"storage source is not regular: {self.path / str(relative)}")
+            return metadata
+        finally:
+            os.close(parent_fd)
+
+    def unlink(self, relative: str | Path) -> None:
+        parent_fd, name = self._open_parent(relative, create=False)
+        try:
+            os.unlink(name, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+
+    def copy_from(self, source: str | Path, relative: str | Path) -> None:
+        parent_fd, name = self._open_parent(relative, create=True)
+        temporary = f".{name}.{uuid.uuid4().hex}.tmp"
+        source_fd = -1
+        destination_fd = -1
+        try:
+            try:
+                existing = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                existing = None
+            if existing is not None and not stat.S_ISREG(existing.st_mode):
+                raise RuntimeError(f"storage target is not regular: {self.path / str(relative)}")
+            source_fd = os.open(source, os.O_RDONLY)
+            source_stat = os.fstat(source_fd)
+            if not stat.S_ISREG(source_stat.st_mode):
+                raise RuntimeError(f"copy source is not regular: {source}")
+            destination_fd = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            _copy_fd(source_fd, destination_fd)
+            _apply_copied_metadata(destination_fd, source_stat)
+            os.fsync(destination_fd)
+            os.close(destination_fd)
+            destination_fd = -1
+            os.replace(
+                temporary,
+                name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+        finally:
+            if source_fd >= 0:
+                os.close(source_fd)
+            if destination_fd >= 0:
+                os.close(destination_fd)
+            try:
+                os.unlink(temporary, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
+
+    def copy_to(self, relative: str | Path, destination: str | Path) -> None:
+        target = Path(destination)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        source_parent_fd = -1
+        target_parent_fd = -1
+        temporary = f".{target.name}.{uuid.uuid4().hex}.tmp"
+        source_fd = -1
+        destination_fd = -1
+        try:
+            source_parent_fd, source_name = self._open_parent(relative, create=False)
+            target_parent_fd = os.open(target.parent, _DIRECTORY_FLAGS)
+            source_fd = os.open(
+                source_name,
+                os.O_RDONLY | _NOFOLLOW,
+                dir_fd=source_parent_fd,
+            )
+            source_stat = os.fstat(source_fd)
+            if not stat.S_ISREG(source_stat.st_mode):
+                raise RuntimeError(f"storage source is not regular: {self.path / str(relative)}")
+            try:
+                existing = os.stat(
+                    target.name,
+                    dir_fd=target_parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                existing = None
+            if existing is not None and not stat.S_ISREG(existing.st_mode):
+                raise RuntimeError(f"copy destination is not regular: {target}")
+            destination_fd = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW,
+                stat.S_IMODE(source_stat.st_mode),
+                dir_fd=target_parent_fd,
+            )
+            _copy_fd(source_fd, destination_fd)
+            _apply_copied_metadata(destination_fd, source_stat)
+            os.fsync(destination_fd)
+            os.close(destination_fd)
+            destination_fd = -1
+            os.replace(
+                temporary,
+                target.name,
+                src_dir_fd=target_parent_fd,
+                dst_dir_fd=target_parent_fd,
+            )
+        finally:
+            if source_fd >= 0:
+                os.close(source_fd)
+            if destination_fd >= 0:
+                os.close(destination_fd)
+            if target_parent_fd >= 0:
+                try:
+                    os.unlink(temporary, dir_fd=target_parent_fd)
+                except FileNotFoundError:
+                    pass
+            if source_parent_fd >= 0:
+                os.close(source_parent_fd)
+            if target_parent_fd >= 0:
+                os.close(target_parent_fd)
+
+    def same_content_as(self, relative: str | Path, source: str | Path) -> bool:
+        parent_fd = -1
+        stored_fd = -1
+        source_fd = -1
+        try:
+            parent_fd, name = self._open_parent(relative, create=False)
+            stored_fd = os.open(name, os.O_RDONLY | _NOFOLLOW, dir_fd=parent_fd)
+            source_fd = os.open(source, os.O_RDONLY)
+            if not stat.S_ISREG(os.fstat(stored_fd).st_mode):
+                return False
+            if not stat.S_ISREG(os.fstat(source_fd).st_mode):
+                return False
+            while True:
+                stored = _read_up_to(stored_fd, _COPY_CHUNK_BYTES)
+                current = _read_up_to(source_fd, _COPY_CHUNK_BYTES)
+                if stored != current:
+                    return False
+                if not stored:
+                    return True
+        except (OSError, RuntimeError):
+            return False
+        finally:
+            if stored_fd >= 0:
+                os.close(stored_fd)
+            if source_fd >= 0:
+                os.close(source_fd)
+            if parent_fd >= 0:
+                os.close(parent_fd)
+
+    def matches_path(self) -> bool:
+        if self._fd < 0 or self.path.is_symlink():
+            return False
+        try:
+            current = self.path.stat()
+            anchored = os.fstat(self._fd)
+        except OSError:
+            return False
+        return (current.st_dev, current.st_ino) == (anchored.st_dev, anchored.st_ino)
+
+    def close(self) -> None:
+        with self._lock:
+            fd, self._fd = self._fd, -1
+        if fd >= 0:
+            os.close(fd)
+
+    def __enter__(self) -> SecureDirectory:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/src/lib/smolagents/agent/base_agent.py
+++ b/src/lib/smolagents/agent/base_agent.py
@@ -60,7 +60,7 @@ from src.lib.config.defaults import DEFAULT_MAX_TOKENS
 from src.lib.config import C, build_effective_agent_config, get_code_agent_config, get_default_toolsets
 from src.lib.config.config_validation import BoolParser  # noqa: F401 — used elsewhere
 from src.lib.utils.workspace import ensure_workspace_mounted_once
-from src.tools import resolve_toolsets
+from src.tools.tool_meta import resolve_toolsets
 from src.trace import (
     bind_explicit_execution_context,
     capture_explicit_execution_context,
@@ -569,13 +569,13 @@ class BaseAgent(ABC):
     def _resolve_runtime_logger_backend(provided_logger: Any) -> Any:
         if provided_logger is not None:
             return provided_logger
-        global_backend = get_global_logger(create_if_missing=False)
-        if global_backend is None:
+        current_backend = get_global_logger(create_if_missing=False)
+        if current_backend is None:
             raise RuntimeError(
                 "No logger available for runtime agent construction. "
-                "Call initialize_global_logger_once(app_name) before creating agents."
+                "Pass a logger or bind a run-scoped logger backend first."
             )
-        return global_backend
+        return current_backend
 
     @staticmethod
     def _deduplicate_tools(tools: List[Any]) -> List[Any]:
@@ -812,13 +812,13 @@ class RoleDrivenAgent(BaseAgent):
         if provided_logger is not None:
             return provided_logger
 
-        global_backend = get_global_logger(create_if_missing=False)
-        if global_backend is None:
+        current_backend = get_global_logger(create_if_missing=False)
+        if current_backend is None:
             raise RuntimeError(
                 "No logger available for role-driven agent initialization. "
-                "Call initialize_global_logger_once(app_name) before creating agents."
+                "Pass a logger or bind a run-scoped logger backend first."
             )
-        return global_backend
+        return current_backend
 
     @staticmethod
     def _normalize_skills_config_items(skills_conf: Any) -> list[Any]:
@@ -1264,6 +1264,7 @@ class RoleDrivenAgent(BaseAgent):
         self,
         task: str,
         task_id: Optional[str] = None,
+        run_id: Optional[str] = None,
         checkpoint_manager: Optional[Any] = None,
         resume: bool = False,
         additional_args: Optional[dict[str, Any]] = None,
@@ -1280,7 +1281,7 @@ class RoleDrivenAgent(BaseAgent):
             # invocation gets a fresh local id. The outermost invocation also
             # owns that id as the root, while delegated workers retain the
             # parent's root and use their fresh id only for leaf attribution.
-            local_run_id = str(uuid.uuid4())
+            local_run_id = run_id or str(uuid.uuid4())
             with bind_local_run(local_run_id):
                 with bind_root_run(local_run_id) as owns_root_run:
                     return self._run_with_root_context(
@@ -1334,6 +1335,7 @@ class RoleDrivenAgent(BaseAgent):
                 final_task_id,
                 transformed_task,
                 resume=resume,
+                effective_config=self._effective_agent_config or self._config,
             )
         else:
             coord = CheckpointCoordinator.current()
@@ -1402,9 +1404,9 @@ class RoleDrivenAgent(BaseAgent):
                         # Supervisor: register and store callback for workers.
                         coord.register_supervisor_step_callback(runtime_agent)
                     else:
-                        # Worker: inherit the supervisor's callback and store
-                        # runtime_agent for later step-tracker registration in
-                        # record_worker_start() (which knows call_index).
+                        # Worker: inherit the supervisor's callback.  The
+                        # invocation later passes that runtime explicitly when
+                        # atomic preparation allocates its call_index.
                         coord.register_worker_step_callback(
                             runtime_agent, agent_name=self.name
                         )
@@ -1582,9 +1584,9 @@ class SubTaskTrackedAgent:
         these events via its frontmatter ``hooks:`` — the framework does not
         know which skills are listening.
 
-        **P1 skip-on-resume**: if a previous checkpoint shows this worker
-        completed with the same ``input_hash``, return the cached result
-        immediately without re-executing.
+        Worker preparation is atomic: a resumed invocation claims unfinished
+        work first, otherwise claims one completed result, or allocates a new
+        call.  Fresh runs always allocate and execute.
         """
         from src.lib.checkpoint.coordinator import CheckpointCoordinator
 
@@ -1594,15 +1596,25 @@ class SubTaskTrackedAgent:
             coord = CheckpointCoordinator.current()
             input_hash = self._compute_input_hash(task)
 
-            # ── P1: Skip completed worker on resume ──
+            # Claim/allocate exactly one logical call before side effects.  The
+            # explicit outcome distinguishes a cached ``None``/empty result
+            # from an invocation that still needs execution.
             if coord is not None:
-                cached = coord.check_worker_skip(self._agent_name, input_hash)
-                if cached is not None:
+                preparation = coord.prepare_worker_call(
+                    self._agent_name,
+                    input_hash,
+                    str(task),
+                    runtime_agent=self._agent,
+                )
+                if not preparation.should_execute:
                     self._log.info(
                         "Skipping completed worker %s (input_hash=%s)",
                         self._agent_name, input_hash[:8],
                     )
-                    return cached
+                    return preparation.cached_result
+                call_index = preparation.call_index
+            else:
+                call_index = 0
 
             hook_manager = get_current_hook_manager()
             event_payload = {
@@ -1620,12 +1632,6 @@ class SubTaskTrackedAgent:
                 except Exception as hook_err:
                     self._log.warning("SubagentStart hook error: %s", hook_err)
 
-            # ── Worker checkpoint: record start ──
-            # Note: record_worker_start() also triggers register_worker_step_tracker()
-            # using the runtime_agent stored by register_worker_step_callback().
-            call_index = coord.record_worker_start(
-                self._agent_name, input_hash, str(task)
-            ) if coord is not None else 0
             worker_restored = (
                 coord.restore_worker(self._agent, self._agent_name, call_index)
                 if coord is not None

--- a/src/lib/smolagents/agent/yaml_agent_factory.py
+++ b/src/lib/smolagents/agent/yaml_agent_factory.py
@@ -18,7 +18,7 @@ from src.lib.smolagents.agent.agent_validation import AgentConfigNormalizer, Nor
 from src.lib.utils.dynamic_import import load_function
 from src.workflows.workflow_manager import get_worker_agent_yaml_path, infer_category_from_yaml_path
 from src.lib.config import C, get_code_agent_config, get_default_toolsets
-from src.tools import resolve_tool_function, resolve_toolsets
+from src.tools.tool_meta import resolve_tool_function, resolve_toolsets
 
 # Keep module-level symbol for legacy tests that monkeypatch this path root.
 AGENT_ROOT = C.agent_root

--- a/src/lib/smolagents/hooks/hook_manager.py
+++ b/src/lib/smolagents/hooks/hook_manager.py
@@ -17,6 +17,7 @@ import os
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextvars import copy_context
 from threading import Event, RLock, Thread
 from typing import Any, Callable, Dict, List, Optional
 
@@ -455,8 +456,10 @@ class HookManager:
                 finally:
                     completed.set()
 
+            worker_context = copy_context()
             worker = Thread(
-                target=_run_in_worker,
+                target=worker_context.run,
+                args=(_run_in_worker,),
                 name=f"hook-timeout-{func_name}-{uuid.uuid4().hex[:8]}",
                 daemon=True,
             )
@@ -738,6 +741,7 @@ class HookManager:
             with ThreadPoolExecutor(max_workers=worker_count) as pool:
                 future_map = {
                     pool.submit(
+                        copy_context().run,
                         self._execute_single_hook_in_context,
                         h,
                         context,

--- a/src/lib/smolagents/skills/executors.py
+++ b/src/lib/smolagents/skills/executors.py
@@ -8,22 +8,207 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 from src.lib.logging import get_logger
-from ..hooks.types import HookContext, HookEvent, HookResult
+
+from ..hooks.types import HookContext, HookResult
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
 SUPPORTED_HOOK_ACTION_TYPE = "command"
+HOOK_STDOUT_MAX_BYTES = 1024 * 1024
+OUTPUT_PREVIEW_MAX_BYTES = 4000
+
+
+@dataclass(frozen=True, slots=True)
+class SkillOutputSnapshot:
+    stdout: str
+    stderr: str
+    stdout_bytes: int
+    stderr_bytes: int
+    stdout_truncated: bool
+    stderr_truncated: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SkillProcessResult:
+    returncode: int | None
+    timed_out: bool
+
+
+class SkillSubprocessCapture:
+    """Redirect a skill subprocess directly to run-owned output files.
+
+    Outside a bound run, anonymous temporary files preserve the same bounded
+    memory behavior without creating a persistent artifact in an unrelated
+    runtime directory.
+    """
+
+    def __init__(self, audit_dir: Path | None = None) -> None:
+        from src.lib.runtime import get_current_run_context
+
+        self.runtime_context = get_current_run_context()
+        self.audit_dir = audit_dir
+        self.stdout_path: Path | None = None
+        self.stderr_path: Path | None = None
+        self._temporary_files: list[Any] = []
+        self._closed = False
+
+        if audit_dir is not None:
+            if self.runtime_context is None:
+                raise RuntimeError("skill audit directory requires a bound run context")
+            self.stdout_path = audit_dir / "stdout.txt"
+            self.stderr_path = audit_dir / "stderr.txt"
+            self.stdout_fd = self.runtime_context.create_run_file(self.stdout_path)
+            try:
+                self.stderr_fd = self.runtime_context.create_run_file(self.stderr_path)
+            except BaseException:
+                os.close(self.stdout_fd)
+                raise
+        else:
+            stdout_file = tempfile.TemporaryFile(mode="w+b", buffering=0)
+            try:
+                stderr_file = tempfile.TemporaryFile(mode="w+b", buffering=0)
+            except BaseException:
+                stdout_file.close()
+                raise
+            self._temporary_files = [stdout_file, stderr_file]
+            self.stdout_fd = stdout_file.fileno()
+            self.stderr_fd = stderr_file.fileno()
+
+    def snapshot(
+        self,
+        *,
+        stdout_limit: int,
+        stderr_limit: int,
+    ) -> SkillOutputSnapshot:
+        stdout, stdout_size, stdout_truncated = _read_fd_preview(
+            self.stdout_fd,
+            stdout_limit,
+        )
+        stderr, stderr_size, stderr_truncated = _read_fd_preview(
+            self.stderr_fd,
+            stderr_limit,
+        )
+        return SkillOutputSnapshot(
+            stdout=stdout,
+            stderr=stderr,
+            stdout_bytes=stdout_size,
+            stderr_bytes=stderr_size,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._temporary_files:
+            for stream in self._temporary_files:
+                stream.close()
+            self._temporary_files.clear()
+            return
+        first_error: OSError | None = None
+        for fd in (self.stdout_fd, self.stderr_fd):
+            try:
+                os.close(fd)
+            except OSError as exc:
+                first_error = first_error or exc
+        if first_error is not None:
+            raise first_error
+
+    def __enter__(self) -> SkillSubprocessCapture:
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.close()
+
+
+def _read_fd_preview(fd: int, limit: int) -> tuple[str, int, bool]:
+    limit = max(0, int(limit))
+    size = os.fstat(fd).st_size
+    remaining = min(size, limit)
+    chunks: list[bytes] = []
+    offset = 0
+    while remaining:
+        try:
+            chunk = os.pread(fd, remaining, offset)
+        except InterruptedError:
+            continue
+        if not chunk:
+            break
+        chunks.append(chunk)
+        offset += len(chunk)
+        remaining -= len(chunk)
+    payload = b"".join(chunks)
+    return payload.decode("utf-8", errors="replace"), size, size > limit
+
+
+def run_skill_subprocess(
+    command: str,
+    *,
+    cwd: str,
+    env: dict[str, str],
+    stdout_fd: int,
+    stderr_fd: int,
+    timeout: float | None,
+) -> SkillProcessResult:
+    """Run one shell command and terminate its entire process group on timeout."""
+
+    process = subprocess.Popen(
+        command,
+        shell=True,
+        cwd=cwd,
+        env=env,
+        stdout=stdout_fd,
+        stderr=stderr_fd,
+        start_new_session=os.name == "posix",
+    )
+    try:
+        return SkillProcessResult(
+            returncode=process.wait(timeout=timeout),
+            timed_out=False,
+        )
+    except subprocess.TimeoutExpired:
+        _terminate_skill_process(process)
+        return SkillProcessResult(returncode=None, timed_out=True)
+    except BaseException:
+        if process.poll() is None:
+            _terminate_skill_process(process)
+        raise
+
+
+def _terminate_skill_process(process: subprocess.Popen[Any]) -> None:
+    if os.name == "posix":
+        import signal
+
+        from src.tools.shell.tree_kill import tree_kill
+
+        tree_kill(process.pid, signal.SIGTERM)
+        try:
+            process.wait(timeout=0.2)
+        except subprocess.TimeoutExpired:
+            pass
+        # The group may outlive its shell leader, so always issue SIGKILL to
+        # the original process-group id before declaring the capture stable.
+        tree_kill(process.pid, signal.SIGKILL)
+    else:
+        process.kill()
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
 
 
 # ---------------------------------------------------------------------------
@@ -438,19 +623,103 @@ def _create_shell_executor(
                 truncated_payload, ensure_ascii=False, default=str,
             )
 
+        from src.lib.runtime import get_current_run_context
+
+        runtime_context = get_current_run_context()
+        audit_dir: Path | None = None
+        capture: SkillSubprocessCapture | None = None
+        process_result: SkillProcessResult | None = None
+        timed_out = False
+        execution_error: Exception | None = None
+        started = time.monotonic()
+        snapshot = SkillOutputSnapshot("", "", 0, 0, False, False)
         try:
+            if runtime_context is not None:
+                audit_dir = runtime_context.new_skill_execution_dir(skill_name)
+            capture = SkillSubprocessCapture(audit_dir)
             if runtime_logger:
                 runtime_logger.debug(f"Executing shell hook from skill {skill_name}")
-            completed = subprocess.run(
+            process_result = run_skill_subprocess(
                 command,
-                shell=True,
                 cwd=execution_cwd,
                 env=env,
-                capture_output=True,
-                text=True,
+                stdout_fd=capture.stdout_fd,
+                stderr_fd=capture.stderr_fd,
                 timeout=timeout,
             )
-        except subprocess.TimeoutExpired:
+        except Exception as exc:
+            execution_error = exc
+        finally:
+            if capture is not None:
+                try:
+                    snapshot = capture.snapshot(
+                        stdout_limit=HOOK_STDOUT_MAX_BYTES,
+                        stderr_limit=OUTPUT_PREVIEW_MAX_BYTES,
+                    )
+                finally:
+                    capture.close()
+            # Clean up the context payload regardless of execution outcome.
+            if context_tmp_path:
+                try:
+                    os.remove(context_tmp_path)
+                except OSError:
+                    pass
+
+        duration = round(time.monotonic() - started, 3)
+        timed_out = process_result.timed_out if process_result is not None else False
+        returncode = process_result.returncode if process_result is not None else None
+        stdout_path = str(capture.stdout_path) if capture and capture.stdout_path else None
+        stderr_path = str(capture.stderr_path) if capture and capture.stderr_path else None
+        audit = {
+            "skill": skill_name,
+            "hook_event_name": context.hook_event_name,
+            "command": command,
+            "cwd": execution_cwd,
+            "timeout": timeout,
+            "timed_out": timed_out,
+            "returncode": returncode,
+            "duration_seconds": duration,
+            "stdout_path": stdout_path,
+            "stderr_path": stderr_path,
+            "stdout_bytes": snapshot.stdout_bytes,
+            "stderr_bytes": snapshot.stderr_bytes,
+            "stdout_contract_truncated": snapshot.stdout_truncated,
+            "stderr_preview_truncated": snapshot.stderr_truncated,
+        }
+        if execution_error is not None:
+            audit["execution_error"] = type(execution_error).__name__
+        if runtime_context is not None and audit_dir is not None:
+            try:
+                runtime_context.atomic_write_run_file(
+                    audit_dir / "audit.json",
+                    json.dumps(audit, ensure_ascii=False, indent=2),
+                )
+            except Exception as audit_error:
+                if runtime_logger:
+                    runtime_logger.error(
+                        "Failed to persist shell hook audit for skill %s: %s",
+                        skill_name,
+                        audit_error,
+                    )
+                return invalid_hook_contract(
+                    "Shell hook audit persistence failed.",
+                    skill_name=skill_name,
+                    hook_event_name=context.hook_event_name,
+                    telemetry={"exception": type(audit_error).__name__},
+                )
+
+        telemetry: Dict[str, Any] = {
+            "returncode": returncode,
+            "duration_seconds": duration,
+            "stdout_bytes": snapshot.stdout_bytes,
+            "stderr_bytes": snapshot.stderr_bytes,
+        }
+        if stdout_path:
+            telemetry["stdout_path"] = stdout_path
+        if stderr_path:
+            telemetry["stderr_path"] = stderr_path
+
+        if timed_out:
             if runtime_logger:
                 runtime_logger.error(
                     f"Shell hook from skill {skill_name} timed out after {timeout}s"
@@ -459,28 +728,31 @@ def _create_shell_executor(
                 f"Shell hook timed out after {timeout}s",
                 skill_name=skill_name,
                 hook_event_name=context.hook_event_name,
-                telemetry={"exception": "TimeoutExpired", "timeout": timeout},
+                telemetry={**telemetry, "exception": "TimeoutExpired", "timeout": timeout},
             )
-        except Exception as e:
+        if execution_error is not None:
             if runtime_logger:
-                runtime_logger.error(f"Error executing shell hook in skill {skill_name}: {e}")
+                runtime_logger.error(
+                    f"Error executing shell hook in skill {skill_name}: {execution_error}"
+                )
             return invalid_hook_contract(
-                f"Shell hook execution failed: {e}",
+                f"Shell hook execution failed: {execution_error}",
                 skill_name=skill_name,
                 hook_event_name=context.hook_event_name,
-                telemetry={"exception": type(e).__name__},
+                telemetry={**telemetry, "exception": type(execution_error).__name__},
             )
-        finally:
-            # Clean up the temp file (mirrors process.py cleanup pattern).
-            if context_tmp_path:
-                try:
-                    os.remove(context_tmp_path)
-                except OSError:
-                    pass
+        if snapshot.stdout_truncated:
+            return invalid_hook_contract(
+                f"Shell hook JSON output exceeds {HOOK_STDOUT_MAX_BYTES} bytes.",
+                skill_name=skill_name,
+                hook_event_name=context.hook_event_name,
+                telemetry={**telemetry, "stdout_truncated": True},
+            )
 
-        stdout_text = completed.stdout.rstrip()
-        stderr_text = completed.stderr.rstrip()
-        telemetry: Dict[str, Any] = {"returncode": completed.returncode}
+        assert process_result is not None
+        assert returncode is not None
+        stdout_text = snapshot.stdout.rstrip()
+        stderr_text = snapshot.stderr.rstrip()
         if stderr_text:
             telemetry["stderr"] = stderr_text
 
@@ -488,8 +760,8 @@ def _create_shell_executor(
         #   0   = success
         #   2   = blocking error (hard block, always prevents continuation)
         #   1/3+ = non-blocking error (logged as warning, does not halt)
-        is_blocking = completed.returncode == 2
-        is_success = completed.returncode == 0
+        is_blocking = returncode == 2
+        is_success = returncode == 0
         is_non_blocking_error = (not is_success) and (not is_blocking)
 
         if not stdout_text:
@@ -513,12 +785,12 @@ def _create_shell_executor(
             if runtime_logger:
                 runtime_logger.warning(
                     "Shell hook from skill %s exited with code %d (non-blocking)",
-                    skill_name, completed.returncode,
+                    skill_name, returncode,
                 )
             return HookResult(
                 success=False,
                 decision="allow",
-                reason=stderr_text or f"Shell hook exited with code {completed.returncode} (non-blocking)",
+                reason=stderr_text or f"Shell hook exited with code {returncode} (non-blocking)",
                 telemetry={
                     **telemetry,
                     "skill_name": skill_name,
@@ -534,7 +806,7 @@ def _create_shell_executor(
                 "Shell hook output must be structured JSON.",
                 skill_name=skill_name,
                 hook_event_name=context.hook_event_name,
-                telemetry={**telemetry, "stdout": stdout_text},
+                telemetry={**telemetry, "stdout_preview": stdout_text[:OUTPUT_PREVIEW_MAX_BYTES]},
             )
 
         if not isinstance(payload, dict):
@@ -542,12 +814,12 @@ def _create_shell_executor(
                 "Shell hook output must be a JSON object.",
                 skill_name=skill_name,
                 hook_event_name=context.hook_event_name,
-                telemetry={**telemetry, "stdout": stdout_text},
+                telemetry={**telemetry, "stdout_preview": stdout_text[:OUTPUT_PREVIEW_MAX_BYTES]},
             )
 
         fallback_reason = None
         if not is_success:
-            fallback_reason = stderr_text or f"Shell hook exited with code {completed.returncode}"
+            fallback_reason = stderr_text or f"Shell hook exited with code {returncode}"
 
         telemetry["exit_code_class"] = (
             "success" if is_success

--- a/src/lib/smolagents/skills/skills.py
+++ b/src/lib/smolagents/skills/skills.py
@@ -11,17 +11,25 @@ import os
 import re
 import shlex
 import shutil
-import subprocess
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from smolagents import AgentLogger
-
 from src.lib.logging import get_logger
+
 from ..hooks.hook_manager import HookManager
 from ..hooks.types import HookEvent
+from .executors import (  # noqa: F401
+    OUTPUT_PREVIEW_MAX_BYTES,
+    SUPPORTED_HOOK_ACTION_TYPE,
+    SkillOutputSnapshot,
+    SkillSubprocessCapture,
+    create_hook_executor,
+    run_skill_subprocess,
+    validate_hook,
+)
 
 # Re-export data classes so existing ``from .skills import ...`` still works.
 from .parser import (  # noqa: F401
@@ -31,11 +39,6 @@ from .parser import (  # noqa: F401
     SkillMetadata,
     build_skills_prompt,
     parse_skill_file,
-)
-from .executors import (  # noqa: F401
-    SUPPORTED_HOOK_ACTION_TYPE,
-    create_hook_executor,
-    validate_hook,
 )
 
 SKILL_INLINE_MAX_CHARS = 18000
@@ -393,7 +396,6 @@ class SkillsManager:
 
         base_dir = Path(skill.file_path).resolve().parent
         workspace_dir = _skill_workspace_dir(name)
-        workspace_dir.mkdir(parents=True, exist_ok=True)
 
         cwd_normalized = (cwd or "skill").strip().lower()
         if cwd_normalized == "skill":
@@ -412,9 +414,7 @@ class SkillsManager:
         if args:
             final_command = f"{final_command} {args}"
 
-        run_id = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        audit_dir = workspace_dir / "runs" / run_id
-        audit_dir.mkdir(parents=True, exist_ok=True)
+        audit_dir = _new_skill_execution_dir(name)
 
         effective_allow_network = bool(allow_network) and bool(skill.metadata.allow_network)
         blocked_reason = None
@@ -447,53 +447,60 @@ class SkillsManager:
             return audit
 
         started = time.monotonic()
+        capture: SkillSubprocessCapture | None = None
+        process_result = None
+        execution_error: Exception | None = None
+        snapshot = SkillOutputSnapshot("", "", 0, 0, False, False)
         try:
-            completed = subprocess.run(
+            capture = SkillSubprocessCapture(audit_dir)
+            process_result = run_skill_subprocess(
                 final_command,
                 cwd=str(run_cwd),
                 env=env,
-                shell=True,
-                text=True,
-                capture_output=True,
+                stdout_fd=capture.stdout_fd,
+                stderr_fd=capture.stderr_fd,
                 timeout=timeout,
             )
-            stdout = completed.stdout or ""
-            stderr = completed.stderr or ""
+        except Exception as exc:
+            execution_error = exc
+        finally:
+            if capture is not None:
+                try:
+                    snapshot = capture.snapshot(
+                        stdout_limit=OUTPUT_PREVIEW_MAX_BYTES,
+                        stderr_limit=OUTPUT_PREVIEW_MAX_BYTES,
+                    )
+                finally:
+                    capture.close()
+
+        timed_out = process_result.timed_out if process_result is not None else False
+        audit.update(
+            {
+                "blocked": False,
+                "timed_out": timed_out,
+                "returncode": process_result.returncode if process_result is not None else None,
+                "duration_seconds": round(time.monotonic() - started, 3),
+                "stdout_path": str(audit_dir / "stdout.txt"),
+                "stderr_path": str(audit_dir / "stderr.txt"),
+                "stdout_bytes": snapshot.stdout_bytes,
+                "stderr_bytes": snapshot.stderr_bytes,
+                "stdout_preview_truncated": snapshot.stdout_truncated,
+                "stderr_preview_truncated": snapshot.stderr_truncated,
+                "stdout_preview": snapshot.stdout,
+                "stderr_preview": snapshot.stderr,
+            }
+        )
+        if execution_error is not None:
             audit.update(
                 {
-                    "blocked": False,
-                    "timed_out": False,
-                    "returncode": completed.returncode,
-                    "duration_seconds": round(time.monotonic() - started, 3),
-                    "stdout_path": str(audit_dir / "stdout.txt"),
-                    "stderr_path": str(audit_dir / "stderr.txt"),
-                    "stdout_preview": stdout[:4000],
-                    "stderr_preview": stderr[:4000],
+                    "execution_error": type(execution_error).__name__,
+                    "execution_error_message": str(execution_error),
                 }
             )
-            _write_audit(audit_dir, audit, stdout, stderr)
-            return audit
-        except subprocess.TimeoutExpired as exc:
-            stdout = exc.stdout or ""
-            stderr = exc.stderr or ""
-            if isinstance(stdout, bytes):
-                stdout = stdout.decode("utf-8", errors="replace")
-            if isinstance(stderr, bytes):
-                stderr = stderr.decode("utf-8", errors="replace")
-            audit.update(
-                {
-                    "blocked": False,
-                    "timed_out": True,
-                    "returncode": None,
-                    "duration_seconds": round(time.monotonic() - started, 3),
-                    "stdout_path": str(audit_dir / "stdout.txt"),
-                    "stderr_path": str(audit_dir / "stderr.txt"),
-                    "stdout_preview": stdout[:4000],
-                    "stderr_preview": stderr[:4000],
-                }
-            )
-            _write_audit(audit_dir, audit, stdout, stderr)
-            return audit
+        _write_audit_record(audit_dir, audit)
+        if execution_error is not None:
+            raise execution_error
+        return audit
 
     # -- Eager support ------------------------------------------------------
 
@@ -766,24 +773,19 @@ def _needs_shell(base_dir: Path) -> bool:
 
 
 def _skill_workspace_dir(skill_name: str) -> Path:
-    safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in skill_name).strip("._")
-    if not safe:
-        safe = "skill"
-    try:
-        from src.lib.logging.logger_manager import get_current_run_log_dir
+    from src.lib.runtime import get_current_run_context
 
-        run_dir = get_current_run_log_dir()
-    except Exception:
-        run_dir = None
-    if run_dir is not None:
-        return Path(run_dir) / "skill_runs" / safe
-    try:
-        from src.lib.config import C
+    runtime_context = get_current_run_context(required=True)
+    assert runtime_context is not None
+    return runtime_context.prepare_skill_workspace(skill_name)
 
-        root = Path(C.agent_root).resolve()
-    except Exception:
-        root = Path.cwd().resolve()
-    return root / ".runtime" / "skill_runs" / safe
+
+def _new_skill_execution_dir(skill_name: str) -> Path:
+    from src.lib.runtime import get_current_run_context
+
+    runtime_context = get_current_run_context(required=True)
+    assert runtime_context is not None
+    return runtime_context.new_skill_execution_dir(skill_name)
 
 
 def _substitute_skill_placeholders(command: str, *, skill_dir: Path, workspace_dir: Path) -> str:
@@ -870,9 +872,24 @@ def _blocked_network_reason(command: str) -> Optional[str]:
 
 
 def _write_audit(audit_dir: Path, audit: Dict[str, Any], stdout: str, stderr: str) -> None:
-    (audit_dir / "stdout.txt").write_text(stdout, encoding="utf-8")
-    (audit_dir / "stderr.txt").write_text(stderr, encoding="utf-8")
-    (audit_dir / "audit.json").write_text(
+    from src.lib.runtime import get_current_run_context
+
+    runtime_context = get_current_run_context(required=True)
+    assert runtime_context is not None
+    runtime_context.atomic_write_run_file(audit_dir / "stdout.txt", stdout)
+    runtime_context.atomic_write_run_file(audit_dir / "stderr.txt", stderr)
+    runtime_context.atomic_write_run_file(
+        audit_dir / "audit.json",
         json.dumps(audit, ensure_ascii=False, indent=2),
-        encoding="utf-8",
+    )
+
+
+def _write_audit_record(audit_dir: Path, audit: Dict[str, Any]) -> None:
+    from src.lib.runtime import get_current_run_context
+
+    runtime_context = get_current_run_context(required=True)
+    assert runtime_context is not None
+    runtime_context.atomic_write_run_file(
+        audit_dir / "audit.json",
+        json.dumps(audit, ensure_ascii=False, indent=2),
     )

--- a/src/runner.py
+++ b/src/runner.py
@@ -17,22 +17,50 @@ Usage (CLI)::
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from src.lib.checkpoint import CheckpointManager
 from src.lib.checkpoint.file_history import FileHistoryManager
 from src.lib.config import C, build_effective_agent_config
 from src.lib.heartbeat import SupervisorHeartbeat
-from src.lib.logging import get_logger, initialize_global_logger_once
+from src.lib.logging import (
+    LoggingConfigBuilder,
+    bind_logger_backend,
+    get_logger,
+    initialize_run_logger,
+)
+from src.lib.runtime import (
+    bind_run_context,
+    generate_runtime_id,
+    resolve_application_id,
+    resolve_runtime_home,
+)
 from src.lib.smolagents.agent.yaml_agent_factory import (
     YamlAgentFactory,
     YamlConfiguredSupervisorAgent,
 )
-from src.trace import generate_id
 
 #: 启动 agent 时 YAML 中必须提供的字段。
 _REQUIRED_YAML_FIELDS = ("name", "workflow", "description")
+
+
+def _checkpoint_age_seconds(created_at: Any) -> float:
+    """Return checkpoint age in UTC, rejecting ambiguous lifecycle anchors."""
+
+    if not isinstance(created_at, str) or not created_at.strip():
+        raise ValueError("checkpoint created_at is missing")
+    try:
+        parsed = datetime.fromisoformat(created_at.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("checkpoint created_at is invalid") from exc
+    # Legacy migration interprets naive timestamps as UTC. Resume must use the
+    # same rule so a migrated task is not selected and then rejected solely
+    # because its original timestamp omitted an offset.
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - parsed.astimezone(UTC)).total_seconds()
 
 
 def _resolve_yaml_path(yaml_path: str | Path) -> Path:
@@ -101,7 +129,7 @@ def run_app(
     yaml_path: str | Path,
     resume_task_id: str | None = None,
     task_override: str | None = None,
-    log_to_file: bool = False,
+    file_logging: bool | None = None,
 ) -> str:
     """Run a supervisor agent from a YAML configuration file.
 
@@ -120,6 +148,8 @@ def run_app(
             starting fresh.
         task_override: If provided, use this string as the task instead
             of the YAML ``description`` field.
+        file_logging: Optional per-invocation override for
+            ``logging.file_enabled``. ``None`` uses configuration.
 
     Returns:
         The string result produced by the supervisor agent.
@@ -129,7 +159,7 @@ def run_app(
         ValueError: If required YAML fields are missing.
         RuntimeError: If the agent execution fails.
     """
-    # 1. Resolve config path and load config first (needed for logger init).
+    # Resolve configuration before any runtime component is constructed.
     resolved_path = _resolve_yaml_path(yaml_path)
     config = YamlAgentFactory._load_config_from_file(resolved_path)
     validate_required_yaml_fields(config, resolved_path)
@@ -138,210 +168,295 @@ def run_app(
         source_name=str(config.get("_yaml_file_path") or resolved_path),
     )
 
-    # 2. Initialise logging with the YAML app name.
     agent_name = config["name"]
-    global_logger = initialize_global_logger_once(agent_name)
-    log = get_logger(global_logger, __name__)
-    log.info("Loading supervisor config: %s", resolved_path)
-
-    # 3. Extract task from description.
     effective_task = task_override.strip() if task_override else config["description"].strip()
-
-    # 4. Pre-warm LSP servers (long-lived, aligned with Claude Code).
-    try:
-        from src.services.lsp import LSPServerManager
-        from src.services.lsp.config import LSPConfig
-
-        lsp_yaml = C.get("lsp_servers", {})
-        lsp_config = LSPConfig.from_yaml(lsp_yaml)
-        lsp_manager = LSPServerManager.get_instance()
-        lsp_manager.initialize(lsp_config, project_root=str(C.agent_root))
-    except Exception as exc:
-        log.debug("LSP pre-warm skipped: %s", exc)
-
-    # 5. Create supervisor agent.
-    supervisor = YamlConfiguredSupervisorAgent(
-        config=config,
-        logger=global_logger,
+    application_id = resolve_application_id(
+        config,
+        resolved_path,
+        agent_root=C.agent_root,
     )
-
-    # 5. Checkpoint & heartbeat setup. Application-level system.yaml is part of
-    # the effective configuration, so isolated validation apps can disable raw
-    # checkpoint artifacts without changing the global project setting.
-    checkpoint_config = effective_config.get("checkpoint", {})
-    if not isinstance(checkpoint_config, dict):
-        checkpoint_config = {}
-    ckpt_enabled = checkpoint_config.get("enabled", True)
-    heartbeat_interval = checkpoint_config.get("heartbeat_interval", 5.0)
-    cleanup_on_success = checkpoint_config.get("cleanup_on_success", True)
-    max_resume_age = checkpoint_config.get("max_resume_age", 604800)
-
-    # Obtain the current per-run log directory (already created by logger init).
-    from src.lib.logging.logger_manager import get_current_run_log_dir as _get_run_dir
-    _current_run_log_dir = _get_run_dir()
-
+    runtime_home = resolve_runtime_home(effective_config, agent_root=C.agent_root)
     is_resume = resume_task_id is not None
-
-    if ckpt_enabled:
-        if is_resume:
-            # Resume: create a scan-only manager first to locate the task,
-            # then re-create with the resolved run_log_dir.
-            _scan_mgr = CheckpointManager(agent_name)
-            _resolved_dir = _scan_mgr._resolve_task_run_dir(resume_task_id)
-            if _resolved_dir is None:
-                raise FileNotFoundError(
-                    f"No checkpoint found for task_id={resume_task_id} "
-                    f"under .logs/{agent_name}/*/checkpoints/"
-                )
-            checkpoint_mgr: CheckpointManager | None = CheckpointManager(
-                agent_name, run_log_dir=_resolved_dir,
-            )
-        else:
-            checkpoint_mgr = CheckpointManager(
-                agent_name, run_log_dir=_current_run_log_dir,
-            )
-    else:
-        checkpoint_mgr = None
-
-    if is_resume and checkpoint_mgr is not None:
-        task_id = resume_task_id
-        tree = checkpoint_mgr.load_task_tree(task_id)
-        if tree is None:
-            raise FileNotFoundError(
-                f"No checkpoint found for task_id={task_id} "
-                f"under .logs/{agent_name}/*/checkpoints/"
-            )
-        # Check expiry
-        created_at = tree.get("created_at", "")
-        if created_at and max_resume_age > 0:
-            try:
-                from datetime import datetime as _dt
-                age = (datetime.now().astimezone() - _dt.fromisoformat(created_at)).total_seconds()
-                if age > max_resume_age:
-                    raise FileNotFoundError(
-                        f"Checkpoint {task_id} expired ({age:.0f}s > {max_resume_age}s)"
-                    )
-            except (ValueError, TypeError):
-                pass
-        tree_status = tree.get("status", "unknown")
-        # Detect crashed: if status is still "running" but process is dead
-        if tree_status == "running":
-            from src.lib.heartbeat.status import detect_crashed_status as _detect_crashed_status
-            hb = checkpoint_mgr._read_json(checkpoint_mgr._heartbeat_path(task_id))
-            detected = _detect_crashed_status(hb)
-            if detected == "crashed":
-                tree_status = "crashed"
-                log.info("Detected crashed task (process dead, heartbeat stale)")
-        log.info("Resuming task %s (status=%s)", task_id, tree_status)
-    elif is_resume and checkpoint_mgr is None:
-        raise RuntimeError("Cannot resume: checkpoint is disabled in system.yaml")
-    else:
-        task_id = generate_id(f"supervisor_{agent_name}", prefix="task")
-        if checkpoint_mgr is not None:
-            checkpoint_mgr.record_task_created(
-                task_id,
-                yaml_path=str(yaml_path),
-                agent_name=agent_name,
-                task_text=effective_task,
-                created_at=datetime.now().astimezone().isoformat(),
-            )
-            # Record task_id → run_log_dir mapping in index for resume lookup.
-            checkpoint_mgr.save_task_to_index(task_id)
-
-    # 6. File history manager (pre-edit backups for rewind).
-    file_history = None
-    if ckpt_enabled and checkpoint_mgr is not None:
-        fh_dir = checkpoint_mgr._task_dir(task_id) / "file-history"
-        file_history = FileHistoryManager(fh_dir)
-        if is_resume:
-            # Restore file history state from persisted index.
-            try:
-                import json as _json
-                idx_path = fh_dir / "snapshots.json"
-                if idx_path.exists():
-                    data = _json.loads(idx_path.read_text(encoding="utf-8"))
-                    file_history.restore_from_index(data)
-                    log.info("Restored file history: %d snapshots, %d tracked files",
-                             file_history.snapshot_count, file_history.tracked_file_count)
-            except Exception as exc:
-                log.warning("Failed to restore file history: %s", exc)
-
-    heartbeat = SupervisorHeartbeat(
-        path=checkpoint_mgr._heartbeat_path(task_id) if checkpoint_mgr else Path(f"/tmp/heartbeat_{task_id}.json"),
-        agent_name=agent_name,
-        interval=heartbeat_interval,
+    task_id = resume_task_id or generate_runtime_id("task")
+    run_id = generate_runtime_id("run")
+    runtime_context = runtime_home.context(
+        application_id=application_id,
+        task_id=task_id,
+        run_id=run_id,
     )
-    heartbeat.start()
-
-    # Register heartbeat + file history so coordinator.activate() can inject them.
+    runtime_context.prepare_run()
+    run_attempt_lease = runtime_context.run_lease()
+    run_attempt_lease.acquire()
     try:
-        from src.lib.checkpoint.coordinator import CheckpointCoordinator as _CC
-        _CC.set_pending_heartbeat(heartbeat)
-        if file_history is not None:
-            _CC.set_pending_file_history(file_history)
-    except Exception:
-        pass
-
-    # File-history hooks are registered on each agent's own HookManager inside
-    # the agent run lifecycle. Registering on the global singleton would miss
-    # the per-agent tool shim path.
-    if file_history is not None:
-        log.info("File history manager prepared for pre-edit backups")
-
-    log.info("=" * 70)
-    log.info("Application: %s", agent_name)
-    log.info("Task ID:     %s", task_id)
-    log.info("Mode:        %s", "RESUME" if is_resume else "NEW")
-    log.info("Task: %s", effective_task[:200])
-    log.info("=" * 70)
-
-    # 6. Execute.
-    try:
-        result = supervisor.run(
-            effective_task,
-            task_id=task_id,
-            checkpoint_manager=checkpoint_mgr,
-            resume=is_resume,
+        runtime_context.write_manifest(
+            yaml_path=str(resolved_path),
+            agent_name=agent_name,
+            mode="resume" if is_resume else "new",
         )
-        result_str = "" if result is None else str(result)
-        log.info("=" * 70)
-        log.info("Execution completed successfully.")
-        log.info("=" * 70)
-        return result_str
-    except KeyboardInterrupt:
-        # P4: checkpoint is already saved by base_agent — only log here.
-        log.warning("Interrupted by user. Checkpoint saved for task_id=%s", task_id)
-        log.warning("Resume with:  loom run %s --resume %s", yaml_path, task_id)
+
+        checkpoint_config = effective_config.get("checkpoint", {})
+        if not isinstance(checkpoint_config, dict):
+            checkpoint_config = {}
+        ckpt_enabled = checkpoint_config.get("enabled", True)
+        heartbeat_interval = checkpoint_config.get("heartbeat_interval", 5.0)
+        cleanup_on_success = checkpoint_config.get("cleanup_on_success", True)
+        max_resume_age = checkpoint_config.get("max_resume_age", 604800)
+        logging_builder = LoggingConfigBuilder().apply_mapping(
+            effective_config.get("logging", {}),
+            source="effective logging config",
+        )
+    except BaseException:
+        run_attempt_lease.release()
         raise
-    except Exception as exc:
-        log.error("Execution failed: %s", exc)
-        raise RuntimeError(f"Agent execution failed: {exc}") from exc
-    finally:
-        heartbeat.stop()
-        # Stop worker heartbeat writers (managed by coordinator).
+
+    outcome = "failed"
+    outcome_error: str | None = None
+    checkpoint_mgr: CheckpointManager | None = None
+    task_lease: Any | None = None
+    heartbeat: SupervisorHeartbeat | None = None
+    file_history: FileHistoryManager | None = None
+    supervisor: YamlConfiguredSupervisorAgent | None = None
+
+    with run_attempt_lease, bind_run_context(runtime_context):
         try:
-            from src.lib.checkpoint.coordinator import CheckpointCoordinator
-            coord = CheckpointCoordinator.current()
-            if coord is not None:
-                coord.stop_all_worker_heartbeats()
-        except Exception:
-            pass
-        # Disconnect MCP clients (if any).
-        try:
-            mcp_mgr = getattr(supervisor, "_mcp_manager", None)
-            if mcp_mgr is not None:
-                mcp_mgr.disconnect_all()
-        except Exception:
-            pass
-        # Self-learning history is recorded live by canonical lifecycle hooks
-        # under .agentloom/sessions/events and indexed independently of
-        # checkpoint retention.
-        # M1: cleanup_on_success — remove checkpoint after successful completion.
-        if cleanup_on_success and checkpoint_mgr is not None:
+            logger_backend = initialize_run_logger(
+                runtime_context,
+                logging_builder=logging_builder,
+                file_logging=file_logging,
+            )
+        except Exception as exc:
+            runtime_context.update_manifest(
+                status="failed",
+                ended_at=datetime.now().astimezone().isoformat(),
+                error=str(exc),
+            )
+            raise
+        with bind_logger_backend(logger_backend, context=runtime_context):
+            log = get_logger(logger_backend, __name__)
             try:
-                tree = checkpoint_mgr.load_task_tree(task_id)
-                if tree and tree.get("status") == "completed":
-                    checkpoint_mgr.delete_task(task_id)
-                    log.info("Cleaned up checkpoint for completed task %s", task_id)
-            except Exception:
-                pass
+                log.info("Loading supervisor config: %s", resolved_path)
+
+                try:
+                    from src.lib.runtime.retention import prune_runtime_if_due
+
+                    prune_runtime_if_due(
+                        runtime_home.root_dir,
+                        effective_config.get("runtime", {}),
+                    )
+                except Exception as exc:
+                    log.debug("Runtime cleanup skipped: %s", exc)
+
+                if is_resume and not ckpt_enabled:
+                    raise RuntimeError("Cannot resume: checkpoint is disabled in system.yaml")
+                if ckpt_enabled:
+                    if is_resume:
+                        try:
+                            runtime_context.validate_checkpoint_path(
+                                require_exists=True,
+                            )
+                        except FileNotFoundError as exc:
+                            raise FileNotFoundError(
+                                f"No checkpoint found for application={application_id}, task_id={task_id}"
+                            ) from exc
+                    else:
+                        runtime_context.prepare_checkpoint()
+                    checkpoint_mgr = CheckpointManager(
+                        agent_name,
+                        checkpoint_dir=runtime_context.checkpoint_dir,
+                        run_id=run_id,
+                    )
+                    task_lease = checkpoint_mgr.task_lease(
+                        require_exists=is_resume,
+                    )
+                    task_lease.acquire()
+                    if is_resume:
+                        # Validate again under the lease: the pre-lease check
+                        # rejects symlinked ancestors, while require_exists
+                        # prevents a cleanup race from recreating an empty task.
+                        runtime_context.validate_checkpoint_path(
+                            require_exists=True,
+                        )
+
+                if is_resume and checkpoint_mgr is not None:
+                    tree = checkpoint_mgr.load_task_tree(task_id)
+                    if tree is None:
+                        raise FileNotFoundError(
+                            f"No checkpoint found for application={application_id}, task_id={task_id}"
+                        )
+                    if max_resume_age > 0:
+                        try:
+                            age = _checkpoint_age_seconds(tree.get("created_at"))
+                        except (ValueError, TypeError) as exc:
+                            raise FileNotFoundError(
+                                f"Checkpoint {task_id} has invalid created_at"
+                            ) from exc
+                        if age > max_resume_age:
+                            raise FileNotFoundError(
+                                f"Checkpoint {task_id} expired ({age:.0f}s > {max_resume_age}s)"
+                            )
+                    tree_status = tree.get("status", "unknown")
+                    if tree_status == "running":
+                        from src.lib.heartbeat.status import detect_crashed_status
+
+                        heartbeat_payload = checkpoint_mgr._read_json(runtime_context.heartbeat_path)
+                        if detect_crashed_status(heartbeat_payload) == "crashed":
+                            tree_status = "crashed"
+                            log.info("Detected crashed task (process dead, heartbeat stale)")
+                    resumable_statuses = {"interrupted", "failed", "crashed"}
+                    if tree_status not in resumable_statuses:
+                        raise ValueError(
+                            f"Checkpoint {task_id} is not resumable "
+                            f"(status={tree_status}); start a new task instead"
+                        )
+                    checkpoint_mgr.record_run_resumed(task_id)
+                    log.info("Resuming task %s (status=%s)", task_id, tree_status)
+                elif checkpoint_mgr is not None:
+                    checkpoint_mgr.record_task_created(
+                        task_id,
+                        yaml_path=str(resolved_path),
+                        agent_name=agent_name,
+                        task_text=effective_task,
+                        created_at=datetime.now().astimezone().isoformat(),
+                    )
+                    checkpoint_mgr.record_run_started(task_id)
+
+                file_history = None
+                if checkpoint_mgr is not None:
+                    file_history = FileHistoryManager(
+                        runtime_context.file_history_dir,
+                        storage=checkpoint_mgr.directory_storage(
+                            task_id,
+                            runtime_context.file_history_dir,
+                        ),
+                    )
+                    if is_resume:
+                        try:
+                            if file_history.restore_persisted_index():
+                                log.info(
+                                    "Restored file history: %d snapshots, %d tracked files",
+                                    file_history.snapshot_count,
+                                    file_history.tracked_file_count,
+                                )
+                        except Exception as exc:
+                            log.warning("Failed to restore file history: %s", exc)
+
+                    heartbeat = SupervisorHeartbeat(
+                        path=runtime_context.heartbeat_path,
+                        agent_name=agent_name,
+                        run_id=run_id,
+                        interval=heartbeat_interval,
+                        storage=checkpoint_mgr.task_storage(task_id),
+                    )
+                    heartbeat.start()
+
+                    from src.lib.checkpoint.coordinator import CheckpointCoordinator as _CC
+
+                    _CC.set_pending_heartbeat(heartbeat)
+                    _CC.set_pending_file_history(file_history)
+                    log.info("File history manager prepared for pre-edit backups")
+
+                # Pre-warm LSP servers after the run logger is bound.
+                try:
+                    from src.services.lsp import LSPServerManager
+                    from src.services.lsp.config import LSPConfig
+
+                    lsp_config = LSPConfig.from_yaml(C.get("lsp_servers", {}))
+                    LSPServerManager.get_instance().initialize(
+                        lsp_config,
+                        project_root=str(C.agent_root),
+                    )
+                except Exception as exc:
+                    log.debug("LSP pre-warm skipped: %s", exc)
+
+                supervisor = YamlConfiguredSupervisorAgent(
+                    config=config,
+                    logger=logger_backend,
+                )
+
+                log.info("=" * 70)
+                log.info("Application: %s", application_id)
+                log.info("Task ID:     %s", task_id)
+                log.info("Run ID:      %s", run_id)
+                log.info("Mode:        %s", "RESUME" if is_resume else "NEW")
+                log.info("Task: %s", effective_task[:200])
+                log.info("=" * 70)
+
+                result = supervisor.run(
+                    effective_task,
+                    task_id=task_id,
+                    run_id=run_id,
+                    checkpoint_manager=checkpoint_mgr,
+                    resume=is_resume,
+                )
+                result_str = "" if result is None else str(result)
+                outcome = "completed"
+                log.info("=" * 70)
+                log.info("Execution completed successfully.")
+                log.info("=" * 70)
+                return result_str
+            except KeyboardInterrupt:
+                outcome = "interrupted"
+                log.warning("Interrupted by user. Checkpoint saved for task_id=%s", task_id)
+                log.warning("Resume with: loom run %s --resume %s", yaml_path, task_id)
+                raise
+            except (FileNotFoundError, ValueError) as exc:
+                outcome_error = str(exc)
+                raise
+            except Exception as exc:
+                outcome_error = str(exc)
+                log.error("Execution failed: %s", exc)
+                raise RuntimeError(f"Agent execution failed: {exc}") from exc
+            finally:
+                try:
+                    from src.tools.shell.background_task import BackgroundTaskRegistry
+
+                    BackgroundTaskRegistry.get_instance().terminate_current_run()
+                except Exception as exc:
+                    log.debug("Background task teardown skipped: %s", exc)
+                try:
+                    from src.tools.shell.process import ShellProcessRegistry
+
+                    ShellProcessRegistry.get_instance().release_current_run()
+                except Exception as exc:
+                    log.debug("Shell session teardown skipped: %s", exc)
+                if heartbeat is not None:
+                    try:
+                        heartbeat.stop()
+                    except Exception:
+                        pass
+                    try:
+                        heartbeat.close()
+                    except Exception:
+                        pass
+                try:
+                    mcp_manager = getattr(supervisor, "_mcp_manager", None)
+                    if mcp_manager is not None:
+                        mcp_manager.disconnect_all()
+                except Exception:
+                    pass
+                if file_history is not None:
+                    try:
+                        file_history.close()
+                    except Exception:
+                        pass
+                if outcome == "completed" and cleanup_on_success and checkpoint_mgr is not None:
+                    try:
+                        tree = checkpoint_mgr.load_task_tree(task_id)
+                        if tree and tree.get("status") == "completed":
+                            checkpoint_mgr.delete_task(task_id)
+                            log.info("Cleaned up checkpoint for completed task %s", task_id)
+                    except Exception:
+                        pass
+                manifest_updates = {
+                    "status": outcome,
+                    "ended_at": datetime.now().astimezone().isoformat(),
+                }
+                if outcome_error:
+                    manifest_updates["error"] = outcome_error
+                try:
+                    runtime_context.update_manifest(**manifest_updates)
+                finally:
+                    if task_lease is not None:
+                        task_lease.release()
+                    if checkpoint_mgr is not None:
+                        checkpoint_mgr.close()

--- a/src/tools/shell/background_task.py
+++ b/src/tools/shell/background_task.py
@@ -12,7 +12,6 @@ Design aligned with Claude Code's LocalShellTask + ShellCommand
 state machine (LocalShellTask.tsx, ShellCommand.ts).
 """
 
-import os
 import threading
 import time
 import uuid
@@ -21,6 +20,8 @@ from typing import Dict, List, Literal, Optional
 
 from src.lib.config import C
 from src.lib.logging import get_logger
+from src.lib.runtime import copy_runtime_context, get_current_run_context
+from src.tools.shell.output_reader import AnchoredOutputReader
 from src.tools.shell.tree_kill import SizeWatchdog, graceful_kill
 
 logger = get_logger(__name__)
@@ -29,11 +30,13 @@ logger = get_logger(__name__)
 _DEFAULT_MAX_CONCURRENT = 10
 _DEFAULT_MAX_OUTPUT_BYTES = 100_000_000  # 100 MB
 _DEFAULT_STALL_THRESHOLD = 45  # seconds
+RuntimeKey = tuple[str, str, str, str] | None
 
 
 # ---------------------------------------------------------------------------
 # Background task state
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class BackgroundTaskState:
@@ -66,6 +69,18 @@ class BackgroundTaskState:
     _process: Optional[object] = field(default=None, repr=False)
     _size_watchdog: Optional[SizeWatchdog] = field(default=None, repr=False)
     _stall_watchdog: Optional[object] = field(default=None, repr=False)
+    _runtime_key: RuntimeKey = field(default=None, repr=False)
+    _output_reader: Optional[AnchoredOutputReader] = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        # Directly-created states are supported by a few local callers.  Anchor
+        # once here; all later reads are descriptor-based.  The registry passes
+        # a reader derived from the writer FD and does not take this fallback.
+        if self._output_reader is None:
+            try:
+                self._output_reader = AnchoredOutputReader.from_path(self.output_path)
+            except OSError:
+                self._output_reader = None
 
     @property
     def elapsed_seconds(self) -> float:
@@ -81,34 +96,30 @@ class BackgroundTaskState:
     @property
     def output_size(self) -> int:
         """Current size of the output file in bytes."""
-        try:
-            return os.path.getsize(self.output_path)
-        except OSError:
-            return 0
+        reader = self._output_reader
+        return reader.size() if reader is not None else 0
 
     def read_output_tail(self, n_lines: int = 20) -> str:
         """Read the last *n_lines* lines from the output file."""
-        try:
-            if not os.path.exists(self.output_path):
-                return ""
-            with open(self.output_path, "r", errors="replace") as f:
-                # Seek to the last 64 KB for efficiency.
-                try:
-                    f.seek(0, 2)
-                    size = f.tell()
-                    f.seek(max(0, size - 65536))
-                except OSError:
-                    f.seek(0)
-                tail_text = f.read()
-            lines = tail_text.splitlines()
-            return "\n".join(lines[-n_lines:])
-        except (OSError, IOError):
+        reader = self._output_reader
+        if reader is None:
             return ""
+        tail_text = reader.read_tail(65536).decode("utf-8", errors="replace")
+        lines = tail_text.splitlines()
+        return "\n".join(lines[-n_lines:])
+
+    def close_output_reader(self) -> None:
+        """Release the retained output inode capability."""
+
+        reader, self._output_reader = self._output_reader, None
+        if reader is not None:
+            reader.close()
 
 
 # ---------------------------------------------------------------------------
 # Background task registry (singleton)
 # ---------------------------------------------------------------------------
+
 
 class BackgroundTaskRegistry:
     """Thread-safe singleton registry for background shell tasks.
@@ -124,7 +135,7 @@ class BackgroundTaskRegistry:
         with cls._instance_lock:
             if cls._instance is None:
                 inst = super().__new__(cls)
-                inst._tasks: Dict[str, BackgroundTaskState] = {}
+                inst._tasks: Dict[tuple[RuntimeKey, str], BackgroundTaskState] = {}
                 inst._lock = threading.Lock()
                 cls._instance = inst
         return cls._instance
@@ -152,6 +163,7 @@ class BackgroundTaskRegistry:
                             task._size_watchdog.stop()
                         if task._stall_watchdog:
                             task._stall_watchdog.stop()
+                        task.close_output_reader()
                     inst._tasks.clear()
             cls._instance = None
 
@@ -162,48 +174,69 @@ class BackgroundTaskRegistry:
     @staticmethod
     def _cfg_max_concurrent() -> int:
         return C.get_nested(
-            "shell_settings", "background_tasks", "max_concurrent",
+            "shell_settings",
+            "background_tasks",
+            "max_concurrent",
             default=_DEFAULT_MAX_CONCURRENT,
         )
 
     @staticmethod
     def _cfg_enabled() -> bool:
         return C.get_nested(
-            "shell_settings", "background_tasks", "enabled",
+            "shell_settings",
+            "background_tasks",
+            "enabled",
             default=True,
         )
 
     @staticmethod
     def _cfg_auto_background() -> bool:
         return C.get_nested(
-            "shell_settings", "background_tasks", "auto_background_on_timeout",
+            "shell_settings",
+            "background_tasks",
+            "auto_background_on_timeout",
             default=True,
         )
 
     @staticmethod
     def _cfg_max_output_bytes() -> int:
         return C.get_nested(
-            "shell_settings", "background_tasks", "max_output_bytes",
+            "shell_settings",
+            "background_tasks",
+            "max_output_bytes",
             default=_DEFAULT_MAX_OUTPUT_BYTES,
         )
 
     @staticmethod
     def _cfg_stall_detection() -> bool:
         return C.get_nested(
-            "shell_settings", "background_tasks", "stall_detection",
+            "shell_settings",
+            "background_tasks",
+            "stall_detection",
             default=True,
         )
 
     @staticmethod
     def _cfg_stall_threshold() -> int:
         return C.get_nested(
-            "shell_settings", "background_tasks", "stall_threshold_seconds",
+            "shell_settings",
+            "background_tasks",
+            "stall_threshold_seconds",
             default=_DEFAULT_STALL_THRESHOLD,
         )
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _current_runtime_key() -> RuntimeKey:
+        context = get_current_run_context()
+        return context.runtime_key if context is not None else None
+
+    @staticmethod
+    def _task_key(task_id: str, runtime_key: RuntimeKey) -> tuple[RuntimeKey, str]:
+        return runtime_key, task_id
 
     def register(
         self,
@@ -212,6 +245,7 @@ class BackgroundTaskRegistry:
         output_path: str,
         description: str = "",
         size_watchdog: Optional[SizeWatchdog] = None,
+        output_fd: Optional[int] = None,
     ) -> str:
         """Register a running process as a background task.
 
@@ -221,6 +255,8 @@ class BackgroundTaskRegistry:
             output_path: Path to the output file being written by the process.
             description: Human-readable description (defaults to command).
             size_watchdog: An existing SizeWatchdog instance to transfer.
+            output_fd: Original output descriptor.  When supplied, registry
+                reads stay attached to its inode even if the path is replaced.
 
         Returns:
             The task_id assigned to this background task.
@@ -228,35 +264,44 @@ class BackgroundTaskRegistry:
         Raises:
             RuntimeError: If the max-concurrent limit is reached.
         """
-        with self._lock:
-            running = sum(1 for t in self._tasks.values() if not t.is_terminal)
-            max_c = self._cfg_max_concurrent()
-            if running >= max_c:
-                raise RuntimeError(
-                    f"Maximum concurrent background tasks reached ({max_c}). "
-                    "Kill or wait for existing tasks before starting new ones."
-                )
-
-            task_id = uuid.uuid4().hex[:12]
-            task = BackgroundTaskState(
-                task_id=task_id,
-                command=command,
-                description=description or command[:80],
-                pid=process.pid,
-                output_path=output_path,
-                _process=process,
-                _size_watchdog=size_watchdog,
+        runtime_key = self._current_runtime_key()
+        if output_fd is None:
+            output_reader = AnchoredOutputReader.from_path(output_path)
+        else:
+            output_reader = AnchoredOutputReader.from_fd(
+                output_fd,
+                path=output_path,
             )
-            self._tasks[task_id] = task
+        try:
+            with self._lock:
+                running = sum(
+                    1 for (owner, _), task in self._tasks.items() if owner == runtime_key and not task.is_terminal
+                )
+                task_id = uuid.uuid4().hex[:12]
+                max_c = self._cfg_max_concurrent()
+                if running >= max_c:
+                    raise RuntimeError(
+                        f"Maximum concurrent background tasks reached ({max_c}). "
+                        "Kill or wait for existing tasks before starting new ones."
+                    )
 
-        # Start monitoring thread (outside lock).
-        monitor = threading.Thread(
-            target=self._monitor_task,
-            args=(task_id,),
-            daemon=True,
-            name=f"bg-monitor-{task_id}",
-        )
-        monitor.start()
+                while self._task_key(task_id, runtime_key) in self._tasks:
+                    task_id = uuid.uuid4().hex[:12]
+                task = BackgroundTaskState(
+                    task_id=task_id,
+                    command=command,
+                    description=description or command[:80],
+                    pid=process.pid,
+                    output_path=output_path,
+                    _process=process,
+                    _size_watchdog=size_watchdog,
+                    _runtime_key=runtime_key,
+                    _output_reader=output_reader,
+                )
+                self._tasks[self._task_key(task_id, runtime_key)] = task
+        except BaseException:
+            output_reader.close()
+            raise
 
         # Start stall watchdog if enabled.
         if self._cfg_stall_detection():
@@ -264,7 +309,7 @@ class BackgroundTaskRegistry:
 
             def _record_stall(message: str) -> None:
                 with self._lock:
-                    current = self._tasks.get(task_id)
+                    current = self._tasks.get(self._task_key(task_id, runtime_key))
                     if current is not None and not current.is_terminal:
                         current.stall_message = message
 
@@ -273,6 +318,7 @@ class BackgroundTaskRegistry:
             sw = StallWatchdog(
                 task_id=task_id,
                 output_path=output_path,
+                output_reader=output_reader,
                 poll_interval=max(0.2, min(5.0, stall_threshold / 2.0)),
                 stall_threshold=stall_threshold,
                 on_stall=_record_stall,
@@ -280,21 +326,37 @@ class BackgroundTaskRegistry:
             task._stall_watchdog = sw
             sw.start()
 
+        # Start monitoring only after every watchdog is attached.  Otherwise a
+        # fast child can exit between monitor start and stall-watchdog setup,
+        # leaving the late watchdog alive forever.
+        monitor_context = copy_runtime_context()
+        monitor = threading.Thread(
+            target=monitor_context.run,
+            args=(self._monitor_task, task_id, runtime_key),
+            daemon=True,
+            name=f"bg-monitor-{task_id}",
+        )
+        monitor.start()
+
         logger.info(
             "Background task %s registered: pid=%d, command=%s",
-            task_id, process.pid, command[:120],
+            task_id,
+            process.pid,
+            command[:120],
         )
         return task_id
 
     def get(self, task_id: str) -> Optional[BackgroundTaskState]:
         """Return the task state, or None if not found."""
+        runtime_key = self._current_runtime_key()
         with self._lock:
-            return self._tasks.get(task_id)
+            return self._tasks.get(self._task_key(task_id, runtime_key))
 
     def remove(self, task_id: str) -> bool:
         """Remove a task from the registry. Returns True if found."""
+        runtime_key = self._current_runtime_key()
         with self._lock:
-            task = self._tasks.pop(task_id, None)
+            task = self._tasks.pop(self._task_key(task_id, runtime_key), None)
         if task is None:
             return False
         # Clean up watchdogs.
@@ -302,17 +364,22 @@ class BackgroundTaskRegistry:
             task._size_watchdog.stop()
         if task._stall_watchdog:
             task._stall_watchdog.stop()
+        task.close_output_reader()
         return True
 
     def list_all(self) -> List[BackgroundTaskState]:
         """Return a snapshot of all tracked tasks."""
+        runtime_key = self._current_runtime_key()
         with self._lock:
-            return list(self._tasks.values())
+            return [task for (owner, _), task in self._tasks.items() if owner == runtime_key]
 
     def list_running(self) -> List[BackgroundTaskState]:
         """Return only tasks that are still running."""
+        runtime_key = self._current_runtime_key()
         with self._lock:
-            return [t for t in self._tasks.values() if t.status == "running"]
+            return [
+                task for (owner, _), task in self._tasks.items() if owner == runtime_key and task.status == "running"
+            ]
 
     def cleanup_completed(self, max_age_seconds: float = 3600) -> int:
         """Remove completed/failed/killed tasks older than *max_age_seconds*.
@@ -321,8 +388,11 @@ class BackgroundTaskRegistry:
         """
         now = time.monotonic()
         to_remove: List[str] = []
+        runtime_key = self._current_runtime_key()
         with self._lock:
-            for tid, task in self._tasks.items():
+            for (owner, tid), task in self._tasks.items():
+                if owner != runtime_key:
+                    continue
                 if task.is_terminal and task.end_time is not None:
                     if (now - task.end_time) > max_age_seconds:
                         to_remove.append(tid)
@@ -337,8 +407,7 @@ class BackgroundTaskRegistry:
 
         Returns the updated task state, or None if not found.
         """
-        with self._lock:
-            task = self._tasks.get(task_id)
+        task = self.get(task_id)
         if task is None:
             return None
         if task.is_terminal:
@@ -360,14 +429,60 @@ class BackgroundTaskRegistry:
 
         return task
 
+    def terminate_current_run(self) -> int:
+        """Kill and forget every background task owned by the bound run.
+
+        The registry is process-global, so teardown must select by the full
+        runtime key.  A caller without an explicit ``RuntimeContext`` is not
+        allowed to touch any task, including legacy no-context entries.
+        """
+        runtime_key = self._current_runtime_key()
+        if runtime_key is None:
+            return 0
+
+        with self._lock:
+            owned_keys = [key for key in self._tasks if key[0] == runtime_key]
+            tasks = [self._tasks.pop(key) for key in owned_keys]
+            now = time.monotonic()
+            for task in tasks:
+                if not task.is_terminal:
+                    task.status = "killed"
+                    task.end_time = now
+                    task.exit_code = -15
+
+        for task in tasks:
+            if task._size_watchdog:
+                try:
+                    task._size_watchdog.stop()
+                except Exception:
+                    pass
+            if task._stall_watchdog:
+                try:
+                    task._stall_watchdog.stop()
+                except Exception:
+                    pass
+            process = task._process
+            if process is not None and process.poll() is None:
+                try:
+                    graceful_kill(task.pid, grace_ms=500)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to terminate background task %s for run teardown: %s",
+                        task.task_id,
+                        exc,
+                    )
+            task.close_output_reader()
+
+        return len(tasks)
+
     # ------------------------------------------------------------------
     # Background monitoring
     # ------------------------------------------------------------------
 
-    def _monitor_task(self, task_id: str) -> None:
+    def _monitor_task(self, task_id: str, runtime_key: RuntimeKey) -> None:
         """Daemon thread: poll the process until it exits."""
         with self._lock:
-            task = self._tasks.get(task_id)
+            task = self._tasks.get(self._task_key(task_id, runtime_key))
         if task is None or task._process is None:
             return
 
@@ -376,9 +491,10 @@ class BackgroundTaskRegistry:
             ret = proc.poll()
             if ret is not None:
                 # Process exited.
-                task.exit_code = ret
-                task.end_time = time.monotonic()
-                task.status = "completed" if ret == 0 else "failed"
+                if not task.is_terminal:
+                    task.exit_code = ret
+                    task.end_time = time.monotonic()
+                    task.status = "completed" if ret == 0 else "failed"
 
                 # Stop watchdogs.
                 if task._size_watchdog:
@@ -388,7 +504,9 @@ class BackgroundTaskRegistry:
 
                 logger.info(
                     "Background task %s finished: exit_code=%d, elapsed=%.1fs",
-                    task_id, ret, task.elapsed_seconds,
+                    task_id,
+                    ret,
+                    task.elapsed_seconds,
                 )
                 break
             time.sleep(0.5)

--- a/src/tools/shell/output_interceptor.py
+++ b/src/tools/shell/output_interceptor.py
@@ -1,7 +1,8 @@
 import os
 import uuid
-import tempfile
-from typing import Optional
+from pathlib import Path
+
+from src.lib.runtime import get_current_run_context
 
 
 class OutputInterceptor:
@@ -15,7 +16,11 @@ class OutputInterceptor:
     If output exceeds the preview threshold, it spills the entire unbroken output to disk.
     """
 
-    def __init__(self, preview_bytes: int = 30000, storage_dir: Optional[str] = None):
+    def __init__(
+        self,
+        preview_bytes: int = 30000,
+        storage_dir: str | Path | None = None,
+    ):
         """
         Initializes the output interceptor for shell commands.
         """
@@ -30,13 +35,17 @@ class OutputInterceptor:
 
         self.pending_chunks = []
         self.spilled_to_disk = False
+        self._disk_spill_unavailable = False
 
+        self._runtime_context = None
         if storage_dir is None:
-            storage_dir = os.path.join(os.getcwd(), ".logs", "shell_outputs")
-        self.storage_dir = storage_dir
+            runtime_context = get_current_run_context()
+            self._runtime_context = runtime_context
+            storage_dir = runtime_context.shell_artifacts_dir if runtime_context else None
+        self.storage_dir = str(Path(storage_dir).resolve()) if storage_dir else None
         # artifact_path is assigned lazily in _spill_to_disk() — only when we
         # actually need to write to disk. No UUID is generated for small outputs.
-        self.artifact_path: Optional[str] = None
+        self.artifact_path: str | None = None
         self.file_stream = None
 
     def write(self, chunk: str) -> None:
@@ -54,7 +63,7 @@ class OutputInterceptor:
 
         if not self.spilled_to_disk:
             self.pending_chunks.append(chunk_bytes)
-            if self.total_bytes > self.preview_bytes:
+            if self.total_bytes > self.preview_bytes and not self._disk_spill_unavailable:
                 self._spill_to_disk()
         else:
             if self.file_stream:
@@ -98,10 +107,35 @@ class OutputInterceptor:
             self.tail_buffer = self.tail_buffer[excess:]
 
     def _spill_to_disk(self) -> None:
-        os.makedirs(self.storage_dir, exist_ok=True)
-        # Generate UUID filename only now — when we know we actually need it.
-        self.artifact_path = os.path.join(self.storage_dir, f"cmd-{uuid.uuid4().hex}.txt")
-        self.file_stream = open(self.artifact_path, "wb")
+        if self.storage_dir is None:
+            # Standalone shell helpers have no canonical owner for a raw
+            # artifact. Keep the bounded preview and discard the full buffer.
+            self.pending_chunks = []
+            self._disk_spill_unavailable = True
+            return
+        try:
+            if self._runtime_context is not None:
+                fd, artifact_path = self._runtime_context.allocate_artifact(
+                    "shell",
+                    prefix="cmd-",
+                    suffix=".txt",
+                )
+                self.artifact_path = str(artifact_path)
+                self.file_stream = os.fdopen(fd, "wb")
+            else:
+                os.makedirs(self.storage_dir, exist_ok=True)
+                # Explicit standalone storage remains available to low-level callers.
+                self.artifact_path = os.path.join(
+                    self.storage_dir,
+                    f"cmd-{uuid.uuid4().hex}.txt",
+                )
+                self.file_stream = open(self.artifact_path, "xb")
+        except (OSError, RuntimeError):
+            self.pending_chunks = []
+            self._disk_spill_unavailable = True
+            self.artifact_path = None
+            self.file_stream = None
+            return
         for chunk in self.pending_chunks:
             self.file_stream.write(chunk)
         self.pending_chunks = []
@@ -121,7 +155,7 @@ class OutputInterceptor:
 
         if self.omitted_bytes > 0:
             omission = f"\n\n[...{self.omitted_bytes} bytes omitted...]\n"
-            if self.spilled_to_disk:
+            if self.spilled_to_disk and self.artifact_path is not None:
                 abs_path = os.path.abspath(self.artifact_path)
                 omission += (
                     f"<system_notice>\n"

--- a/src/tools/shell/output_reader.py
+++ b/src/tools/shell/output_reader.py
@@ -1,0 +1,141 @@
+"""Descriptor-anchored reads for shell output artifacts.
+
+Runtime artifact paths are useful labels, but they are not stable capabilities:
+an ancestor directory can be renamed or replaced after a process starts.  This
+module opens the output inode once and performs every subsequent size/tail read
+through that descriptor, so another run can never be observed through a stale
+pathname.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import threading
+from pathlib import Path
+
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+
+def _open_regular_file_no_follow(path: str | os.PathLike[str]) -> int:
+    """Open a regular final path component without following that component.
+
+    Runtime callers should pass the already-open writer FD, which gives a
+    stronger inode identity than any pathname can.  This fallback exists for
+    legacy standalone callers and anchors the file once; later reads never
+    resolve the path again.
+    """
+
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    if not absolute.name:
+        raise OSError(f"output path is not a regular file: {absolute}")
+    fd = os.open(absolute, os.O_RDONLY | _NOFOLLOW)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise OSError(f"output path is not a regular file: {absolute}")
+        os.set_inheritable(fd, False)
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+class AnchoredOutputReader:
+    """Own a read descriptor for one immutable output-file identity."""
+
+    def __init__(self, fd: int):
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise OSError("shell output descriptor is not a regular file")
+        self._fd = fd
+        self._identity = (file_stat.st_dev, file_stat.st_ino)
+        self._lock = threading.Lock()
+
+    @classmethod
+    def from_path(cls, path: str | os.PathLike[str]) -> AnchoredOutputReader:
+        """Securely anchor an existing regular file by pathname."""
+
+        return cls(_open_regular_file_no_follow(path))
+
+    @classmethod
+    def from_fd(
+        cls,
+        fd: int,
+        *,
+        path: str | os.PathLike[str] | None = None,
+    ) -> AnchoredOutputReader:
+        """Anchor *fd*, reopening and inode-checking write-only descriptors."""
+
+        expected = os.fstat(fd)
+        if not stat.S_ISREG(expected.st_mode):
+            raise OSError("shell output descriptor is not a regular file")
+
+        duplicate = os.dup(fd)
+        os.set_inheritable(duplicate, False)
+        try:
+            # A zero-byte positional read checks access mode without changing
+            # the shared file offset.
+            os.pread(duplicate, 0, 0)
+        except OSError as exc:
+            os.close(duplicate)
+            if path is None:
+                raise OSError("a write-only output descriptor requires its original path") from exc
+            duplicate = _open_regular_file_no_follow(path)
+            actual = os.fstat(duplicate)
+            if (actual.st_dev, actual.st_ino) != (expected.st_dev, expected.st_ino):
+                os.close(duplicate)
+                raise RuntimeError("shell output path no longer identifies its writer inode") from None
+
+        return cls(duplicate)
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._fd < 0
+
+    @property
+    def identity(self) -> tuple[int, int]:
+        return self._identity
+
+    def size(self) -> int:
+        """Return the current inode size, or zero once unavailable."""
+
+        with self._lock:
+            if self._fd < 0:
+                return 0
+            try:
+                return os.fstat(self._fd).st_size
+            except OSError:
+                return 0
+
+    def read_tail(self, max_bytes: int) -> bytes:
+        """Read at most *max_bytes* from the current inode tail."""
+
+        if max_bytes <= 0:
+            return b""
+        with self._lock:
+            if self._fd < 0:
+                return b""
+            try:
+                size = os.fstat(self._fd).st_size
+                offset = max(0, size - max_bytes)
+                return os.pread(self._fd, min(max_bytes, size), offset)
+            except OSError:
+                return b""
+
+    def close(self) -> None:
+        """Close the owned descriptor exactly once."""
+
+        with self._lock:
+            if self._fd < 0:
+                return
+            fd, self._fd = self._fd, -1
+            os.close(fd)
+
+    def __del__(self) -> None:
+        # Keep direct BackgroundTaskState construction from leaking a file
+        # descriptor.  Registry-owned readers are still closed deterministically.
+        try:
+            self.close()
+        except (AttributeError, OSError):
+            pass

--- a/src/tools/shell/process.py
+++ b/src/tools/shell/process.py
@@ -28,16 +28,16 @@ import functools
 import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from src.lib.config import C
 from src.lib.logging import get_logger
+from src.lib.runtime import get_current_run_context
 from src.tools.shell.ansi_stripper import strip_ansi
 from src.tools.shell.pipe_redirect import rearrange_pipe_command
 from src.tools.shell.shell_session import ShellSession
@@ -52,6 +52,7 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 # Execution result
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class ExecResult:
@@ -106,10 +107,14 @@ def _foreground_stall_threshold(timeout: int) -> float:
     than the command timeout; otherwise it is promoted to background and leaves
     the interactive process alive.
     """
-    configured = float(C.get_nested(
-        "shell_settings", "background_tasks",
-        "stall_threshold_seconds", default=45,
-    ))
+    configured = float(
+        C.get_nested(
+            "shell_settings",
+            "background_tasks",
+            "stall_threshold_seconds",
+            default=45,
+        )
+    )
     half_timeout = max(float(timeout) * 0.5, 1.0)
     return max(1.0, min(configured, half_timeout, 15.0))
 
@@ -222,20 +227,18 @@ def _resolve_shell_path_windows() -> str:
 
     for path in WINDOWS_SHELL_FALLBACK_PATHS:
         if os.path.isfile(path) and os.access(path, os.X_OK):
-            logger.warning(
-                "Windows shell not found via $COMSPEC. Falling back to: %s", path
-            )
+            logger.warning("Windows shell not found via $COMSPEC. Falling back to: %s", path)
             return path
 
     raise FileNotFoundError(
-        "No suitable Windows shell found. Tried $COMSPEC and standard "
-        "PowerShell/cmd.exe locations."
+        "No suitable Windows shell found. Tried $COMSPEC and standard PowerShell/cmd.exe locations."
     )
 
 
 # ---------------------------------------------------------------------------
 # ShellProcess — the main execution engine
 # ---------------------------------------------------------------------------
+
 
 class ShellProcess:
     """Execute shell commands via stateless subprocesses.
@@ -350,9 +353,7 @@ class ShellProcess:
                 if isinstance(partial, bytes):
                     partial = partial.decode(errors="replace")
                 return self._format_output(
-                    f"{partial}\n\n"
-                    f"[Timeout Error: Command took longer than "
-                    f"{self.timeout} seconds]"
+                    f"{partial}\n\n[Timeout Error: Command took longer than {self.timeout} seconds]"
                 )
             except Exception as e:
                 return self._format_output(f"Execution failed: {str(e)}")
@@ -361,10 +362,7 @@ class ShellProcess:
         is_zsh = "zsh" in os.path.basename(self._shell_path).lower()
         composite = command
         if not self.load_profile and is_zsh:
-            composite = (
-                "setopt NO_EXTENDED_GLOB 2>/dev/null || true ; "
-                f"{command}"
-            )
+            composite = f"setopt NO_EXTENDED_GLOB 2>/dev/null || true ; {command}"
 
         if self.load_profile:
             shell_args = [self._shell_path, "-l", "-c", composite]
@@ -381,7 +379,10 @@ class ShellProcess:
 
         try:
             result = self._exec_subprocess(
-                shell_args, env, self.timeout, command=command,
+                shell_args,
+                env,
+                self.timeout,
+                command=command,
             )
         except Exception as e:
             result = ExecResult(output=f"Execution failed: {str(e)}")
@@ -427,10 +428,7 @@ class ShellProcess:
         # aliases, shell options, and PATH captured from the login shell
         # at session start.  Re-sourcing ~/.bashrc on every call is
         # unnecessary overhead (100-300ms).
-        has_snapshot = (
-            self._snapshot_path
-            and os.path.exists(self._snapshot_path)
-        )
+        has_snapshot = self._snapshot_path and os.path.exists(self._snapshot_path)
         is_zsh = "zsh" in os.path.basename(self._shell_path).lower()
 
         if has_snapshot:
@@ -494,7 +492,10 @@ class ShellProcess:
         # Execute as a new subprocess
         try:
             result = self._exec_subprocess(
-                shell_args, env, self.timeout, command=command,
+                shell_args,
+                env,
+                self.timeout,
+                command=command,
             )
         except Exception as e:
             result = ExecResult(output=f"Execution failed: {str(e)}")
@@ -514,11 +515,7 @@ class ShellProcess:
                 f"Use check_background_task('{result.background_task_id}') to monitor."
             )
         elif result.timed_out:
-            output = (
-                f"{output}\n\n"
-                f"[Timeout Error: Command took longer than "
-                f"{self.timeout} seconds]"
-            )
+            output = f"{output}\n\n[Timeout Error: Command took longer than {self.timeout} seconds]"
         return self._format_output(output)
 
     def _exec_subprocess(
@@ -546,15 +543,28 @@ class ShellProcess:
         watchdog = None
         fg_stall = None
         out_fd = -1
+        read_fd = -1
+        runtime_context = None
+        runtime_output_path = None
         promoted = False  # True if promoted to background
 
         try:
-            fd, output_file = tempfile.mkstemp(
-                prefix="agentloom_output_", suffix=".txt"
-            )
-            # Close the fd from mkstemp and open with O_WRONLY | O_APPEND
-            os.close(fd)
-            out_fd = os.open(output_file, os.O_WRONLY | os.O_APPEND)
+            from src.lib.runtime import get_current_run_context
+
+            runtime_context = get_current_run_context()
+            if runtime_context is not None:
+                out_fd, runtime_output_path = runtime_context.allocate_artifact(
+                    "background",
+                    prefix="shell-process-",
+                    suffix=".txt",
+                )
+                output_file = str(runtime_output_path)
+            else:
+                out_fd, output_file = tempfile.mkstemp(
+                    prefix="shell-process-",
+                    suffix=".txt",
+                )
+            read_fd = os.dup(out_fd)
 
             proc = subprocess.Popen(
                 args,
@@ -569,9 +579,31 @@ class ShellProcess:
             os.close(out_fd)
             out_fd = -1
 
+            def read_output() -> str:
+                try:
+                    size = os.fstat(read_fd).st_size
+                    chunks: list[bytes] = []
+                    offset = 0
+                    while offset < size:
+                        chunk = os.pread(
+                            read_fd,
+                            min(1024 * 1024, size - offset),
+                            offset,
+                        )
+                        if not chunk:
+                            break
+                        chunks.append(chunk)
+                        offset += len(chunk)
+                    return b"".join(chunks).decode("utf-8", errors="replace")
+                except OSError:
+                    return ""
+
             # Start size watchdog for long-running commands.
             watchdog = SizeWatchdog(
-                proc.pid, output_file, max_bytes=_MAX_OUTPUT_BYTES
+                proc.pid,
+                output_file,
+                max_bytes=_MAX_OUTPUT_BYTES,
+                output_fd=read_fd,
             )
             watchdog.start()
 
@@ -584,6 +616,7 @@ class ShellProcess:
             fg_stall = StallWatchdog(
                 task_id=f"fg-{proc.pid}",
                 output_path=output_file,
+                output_fd=read_fd,
                 poll_interval=_foreground_stall_poll_interval(stall_threshold),
                 stall_threshold=stall_threshold,
             )
@@ -610,21 +643,18 @@ class ShellProcess:
                     # running.  The proc.poll() guard prevents a
                     # race condition where the process exits at the
                     # exact moment the watchdog sets stall_message.
-                    if (
-                        fg_stall
-                        and fg_stall.stall_message
-                        and proc.poll() is None
-                    ):
+                    if fg_stall and fg_stall.stall_message and proc.poll() is None:
                         logger.info(
-                            "Foreground stall detected for pid %d "
-                            "after %.0fs — killing process",
-                            proc.pid, elapsed,
+                            "Foreground stall detected for pid %d after %.0fs — killing process",
+                            proc.pid,
+                            elapsed,
                         )
                         # Write to per-agent shell audit log
                         try:
                             from src.tools.shell.shell_audit_log import (
                                 get_shell_audit_logger,
                             )
+
                             audit = get_shell_audit_logger()
                             audit.log_stall_detected(
                                 command=command,
@@ -647,22 +677,25 @@ class ShellProcess:
                 # kill).
                 partial = ""
                 try:
-                    with open(output_file, "r", errors="replace") as f:
-                        partial = f.read()
+                    partial = read_output()
                 except Exception:
                     pass
 
-                prompt_message = detect_stall_prompt(f"fg-{proc.pid}", output_file)
+                prompt_message = detect_stall_prompt(
+                    f"fg-{proc.pid}",
+                    output_file,
+                    output_fd=read_fd,
+                )
                 if prompt_message and proc.poll() is None:
                     logger.info(
-                        "Foreground prompt detected at timeout for pid %d — "
-                        "killing instead of promoting",
+                        "Foreground prompt detected at timeout for pid %d — killing instead of promoting",
                         proc.pid,
                     )
                     try:
                         from src.tools.shell.shell_audit_log import (
                             get_shell_audit_logger,
                         )
+
                         audit = get_shell_audit_logger()
                         audit.log_stall_detected(
                             command=command,
@@ -678,28 +711,33 @@ class ShellProcess:
                     except subprocess.TimeoutExpired:
                         pass
                     return ExecResult(
-                        output=(
-                            f"{partial}\n\n"
-                            f"[Stall Warning: {prompt_message}]"
-                        ),
+                        output=(f"{partial}\n\n[Stall Warning: {prompt_message}]"),
                         interrupted=True,
                         exit_code=-9,
                     )
 
                 # Check if auto-background is enabled.
                 bg_enabled = C.get_nested(
-                    "shell_settings", "background_tasks", "enabled",
+                    "shell_settings",
+                    "background_tasks",
+                    "enabled",
                     default=True,
                 )
                 auto_bg = C.get_nested(
-                    "shell_settings", "background_tasks",
-                    "auto_background_on_timeout", default=True,
+                    "shell_settings",
+                    "background_tasks",
+                    "auto_background_on_timeout",
+                    default=True,
                 )
 
-                if bg_enabled and auto_bg:
+                if bg_enabled and auto_bg and runtime_context is not None:
                     # Promote to background instead of killing.
                     task_id = self._promote_to_background(
-                        proc, output_file, command, watchdog,
+                        proc,
+                        output_file,
+                        command,
+                        watchdog,
+                        output_fd=read_fd,
                     )
                     promoted = True
                     # Audit the background promotion
@@ -707,6 +745,7 @@ class ShellProcess:
                         from src.tools.shell.shell_audit_log import (
                             get_shell_audit_logger,
                         )
+
                         audit = get_shell_audit_logger()
                         audit.log_timeout(
                             command=command,
@@ -728,9 +767,12 @@ class ShellProcess:
                     from src.tools.shell.shell_audit_log import (
                         get_shell_audit_logger,
                     )
+
                     audit = get_shell_audit_logger()
                     audit.log_timeout(
-                        command=command, timeout=timeout, promoted=False,
+                        command=command,
+                        timeout=timeout,
+                        promoted=False,
                     )
                 except Exception:
                     pass
@@ -745,15 +787,11 @@ class ShellProcess:
             if stall_killed:
                 partial = ""
                 try:
-                    with open(output_file, "r", errors="replace") as f:
-                        partial = f.read()
+                    partial = read_output()
                 except Exception:
                     pass
                 return ExecResult(
-                    output=(
-                        f"{partial}\n\n"
-                        f"[Stall Warning: {fg_stall.stall_message}]"
-                    ),
+                    output=(f"{partial}\n\n[Stall Warning: {fg_stall.stall_message}]"),
                     interrupted=True,
                     exit_code=-9,
                 )
@@ -761,8 +799,7 @@ class ShellProcess:
             # ---- Process completed normally ----
             exit_code = proc.returncode
             try:
-                with open(output_file, "r", errors="replace") as f:
-                    output = f.read()
+                output = read_output()
             except Exception:
                 output = ""
 
@@ -770,13 +807,12 @@ class ShellProcess:
             # a prompt but the process still exited on its own (e.g.
             # a timeout built into the command itself).
             if fg_stall.stall_message:
-                output = (
-                    f"{output}\n\n"
-                    f"[Stall Warning: {fg_stall.stall_message}]"
-                )
+                output = f"{output}\n\n[Stall Warning: {fg_stall.stall_message}]"
 
             return ExecResult(
-                output=output, timed_out=False, exit_code=exit_code,
+                output=output,
+                timed_out=False,
+                exit_code=exit_code,
             )
 
         finally:
@@ -798,7 +834,18 @@ class ShellProcess:
                         os.close(out_fd)
                     except OSError:
                         pass
-                if output_file and os.path.exists(output_file):
+                if read_fd >= 0:
+                    try:
+                        os.close(read_fd)
+                    except OSError:
+                        pass
+                    read_fd = -1
+                if runtime_context is not None and runtime_output_path is not None:
+                    try:
+                        runtime_context.remove_run_file(runtime_output_path)
+                    except (FileNotFoundError, RuntimeError):
+                        pass
+                elif output_file and os.path.exists(output_file):
                     try:
                         os.remove(output_file)
                     except OSError:
@@ -810,6 +857,11 @@ class ShellProcess:
                         os.close(out_fd)
                     except OSError:
                         pass
+                if read_fd >= 0:
+                    try:
+                        os.close(read_fd)
+                    except OSError:
+                        pass
 
     def _promote_to_background(
         self,
@@ -817,6 +869,7 @@ class ShellProcess:
         output_path: str,
         command: str,
         watchdog: Optional[SizeWatchdog] = None,
+        output_fd: int | None = None,
     ) -> str:
         """Register a running process as a background task.
 
@@ -828,16 +881,22 @@ class ShellProcess:
         from src.tools.shell.background_task import BackgroundTaskRegistry
 
         registry = BackgroundTaskRegistry.get_instance()
-        task_id = registry.register(
-            process=proc,
-            command=command,
-            output_path=output_path,
-            description=command[:80],
-            size_watchdog=watchdog,
-        )
+        try:
+            task_id = registry.register(
+                process=proc,
+                command=command,
+                output_path=output_path,
+                description=command[:80],
+                size_watchdog=watchdog,
+                output_fd=output_fd,
+            )
+        except BaseException:
+            graceful_kill(proc.pid, grace_ms=500)
+            raise
         logger.info(
             "Command promoted to background task %s: pid=%d",
-            task_id, proc.pid,
+            task_id,
+            proc.pid,
         )
         return task_id
 
@@ -851,7 +910,7 @@ class ShellProcess:
         output = output.strip()
 
         # Clean up terminal-style artifacts at the end (prompt chars).
-        output = re.sub(r'[%$#>]\s*$', '', output).strip()
+        output = re.sub(r"[%$#>]\s*$", "", output).strip()
         return output
 
     # ------------------------------------------------------------------
@@ -878,14 +937,19 @@ class ShellProcess:
 # ShellProcessRegistry — per-agent process management (singleton)
 # ---------------------------------------------------------------------------
 
-class ShellProcessRegistry:
-    """Thread-safe singleton registry for per-agent ShellProcess instances.
+RuntimeKey = tuple[str, str, str, str]
+ShellProcessOwner = tuple[RuntimeKey, str]
 
-    Each agent (identified by agent_id) gets its own dedicated
+
+class ShellProcessRegistry:
+    """Thread-safe singleton registry for run-and-agent shell sessions.
+
+    Each explicit ``RuntimeContext`` + ``agent_id`` pair gets its own dedicated
     ShellProcess, which is created on first use and reused on subsequent
     calls.  This allows the shell session to maintain CWD across multiple
-    tool invocations within the same agent run. Environment variable exports
-    remain per-command and do not persist.
+    tool invocations within one run.  Calls without a bound runtime are
+    intentionally one-shot and are never added to this process-wide registry.
+    Environment variable exports remain per-command and do not persist.
     """
 
     _instance: Optional["ShellProcessRegistry"] = None
@@ -895,7 +959,7 @@ class ShellProcessRegistry:
         with cls._instance_lock:
             if cls._instance is None:
                 cls._instance = super().__new__(cls)
-                cls._instance._registry: Dict[str, ShellProcess] = {}
+                cls._instance._registry: Dict[ShellProcessOwner, ShellProcess] = {}
                 cls._instance._registry_lock = threading.Lock()
         return cls._instance
 
@@ -913,17 +977,32 @@ class ShellProcessRegistry:
         return_err_output: bool = True,
         load_profile: bool = True,
     ) -> ShellProcess:
-        """Return the ShellProcess bound to *agent_id*, creating if needed."""
+        """Return the shell bound to the current run and ``agent_id``.
+
+        Without a bound runtime, return a fresh one-shot process instead of
+        consulting shared state.  Missing context must never cause a caller to
+        inherit another run's CWD or shell snapshot.
+        """
+        context = get_current_run_context()
+        if context is None:
+            return ShellProcess(
+                timeout=timeout,
+                session_scoped=False,
+                strip_newlines=strip_newlines,
+                return_err_output=return_err_output,
+                load_profile=load_profile,
+            )
+        owner = (context.runtime_key, agent_id)
         with self._registry_lock:
-            if agent_id not in self._registry:
-                self._registry[agent_id] = ShellProcess(
+            if owner not in self._registry:
+                self._registry[owner] = ShellProcess(
                     timeout=timeout,
                     session_scoped=session_scoped,
                     strip_newlines=strip_newlines,
                     return_err_output=return_err_output,
                     load_profile=load_profile,
                 )
-            process = self._registry[agent_id]
+            process = self._registry[owner]
             process.timeout = timeout
             process.strip_newlines = strip_newlines
             process.return_err_output = return_err_output
@@ -931,14 +1010,38 @@ class ShellProcessRegistry:
             return process
 
     def release(self, agent_id: str) -> None:
-        """Release and destroy the ShellProcess associated with *agent_id*."""
+        """Release ``agent_id`` only within the current run."""
+        context = get_current_run_context()
+        if context is None:
+            return
+        owner = (context.runtime_key, agent_id)
         with self._registry_lock:
-            process = self._registry.pop(agent_id, None)
-            if process is not None:
-                try:
-                    process.cleanup()
-                except Exception:
-                    pass
+            process = self._registry.pop(owner, None)
+        if process is not None:
+            try:
+                process.cleanup()
+            except Exception:
+                pass
+
+    def release_current_run(self) -> int:
+        """Release every shell session owned by the bound run.
+
+        Returns the number of removed sessions.  With no bound runtime this is
+        a no-op, which prevents teardown code from touching another run.
+        """
+        context = get_current_run_context()
+        if context is None:
+            return 0
+        runtime_key = context.runtime_key
+        with self._registry_lock:
+            owners = [owner for owner in self._registry if owner[0] == runtime_key]
+            processes = [self._registry.pop(owner) for owner in owners]
+        for process in processes:
+            try:
+                process.cleanup()
+            except Exception:
+                pass
+        return len(processes)
 
     def get_session_cwd(self, agent_id: str) -> Optional[str]:
         """Return the current working directory of the shell session for *agent_id*.
@@ -948,13 +1051,21 @@ class ShellProcessRegistry:
         path validation to resolve relative paths against the shell
         session's actual CWD rather than the Python process's CWD.
         """
+        context = get_current_run_context()
+        if context is None:
+            return None
+        owner = (context.runtime_key, agent_id)
         with self._registry_lock:
-            process = self._registry.get(agent_id)
+            process = self._registry.get(owner)
             if process is not None:
                 return process.cwd
         return None
 
     def registered_agent_ids(self) -> List[str]:
-        """Return a snapshot of all currently registered agent IDs."""
+        """Return agent IDs registered only within the current run."""
+        context = get_current_run_context()
+        if context is None:
+            return []
+        runtime_key = context.runtime_key
         with self._registry_lock:
-            return list(self._registry.keys())
+            return [agent_id for (owner, agent_id) in self._registry if owner == runtime_key]

--- a/src/tools/shell/shell_audit_log.py
+++ b/src/tools/shell/shell_audit_log.py
@@ -1,13 +1,8 @@
-"""Per-agent shell security audit logger.
+"""Run-scoped shell security audit logger.
 
-Writes structured, human-readable audit entries to a dedicated log file
-that shares the same per-run timestamp directory as the main agent log::
-
-    .logs/{agent_name}/{timestamp}/shell_audit.log
-
-When no main agent log context is available (standalone usage), it
-falls back to creating its own timestamp directory under the configured
-log base directory.
+Every entry is one JSON object in ``RuntimeContext.shell_audit_path``.  The
+logger never derives a storage location from cwd, logger state, timestamps, or
+agent names.  Without a RuntimeContext it has no file sink.
 
 Each entry records a shell security event (blocked command, path
 violation, stall detection, timeout, etc.) together with an actionable
@@ -38,22 +33,40 @@ Usage::
 
 from __future__ import annotations
 
-import os
+import contextvars
+import json
+import logging
 import threading
-from datetime import datetime
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from src.lib.config import C
 from src.lib.logging import get_logger
+from src.lib.runtime import (
+    RuntimeContext,
+    RuntimeRotatingTextSink,
+    get_current_run_context,
+)
 
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# Module-level cache
+# Run-scoped cache
 # ---------------------------------------------------------------------------
-_AUDIT_LOGGERS: dict[str, "ShellAuditLogger"] = {}
-_CACHE_LOCK = threading.Lock()
+
+
+@dataclass
+class _AuditScope:
+    runtime_key: tuple[str, str, str, str]
+    sink: _AuditSink | None = None
+    loggers: dict[str, ShellAuditLogger] = field(default_factory=dict)
+
+
+_CURRENT_AUDIT_SCOPE: contextvars.ContextVar[_AuditScope | None] = (
+    contextvars.ContextVar("agentloom_shell_audit_scope", default=None)
+)
 
 # ---------------------------------------------------------------------------
 # Event type constants
@@ -128,12 +141,132 @@ _SUGGESTIONS: dict[str, str] = {
 }
 
 
-def _sanitize_component(value: str) -> str:
-    """Sanitize a string for use as a filesystem path component."""
-    import re
-    normalized = re.sub(r"[^A-Za-z0-9._-]+", "_", value.strip())
-    normalized = normalized.strip("._")
-    return normalized or "unknown"
+def _context_key(
+    context: RuntimeContext | None,
+) -> tuple[str, str, str, str] | None:
+    if context is None:
+        return None
+    return (
+        str(context.root_dir),
+        context.application_id,
+        context.task_id,
+        context.run_id,
+    )
+
+
+class _SecureAuditHandler(logging.Handler):
+    """Logging handler backed by a no-follow run-scoped rotating sink."""
+
+    def __init__(
+        self,
+        runtime_context: RuntimeContext,
+        *,
+        max_file_bytes: int,
+        backup_count: int,
+    ) -> None:
+        super().__init__()
+        self._sink = RuntimeRotatingTextSink(
+            runtime_context,
+            runtime_context.shell_audit_path,
+            max_file_bytes=max_file_bytes,
+            backup_count=backup_count,
+        )
+
+    @property
+    def stream(self):
+        return self._sink.stream
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self._sink.write(self.format(record) + "\n")
+
+    def close(self) -> None:
+        try:
+            self._sink.close()
+        finally:
+            super().close()
+
+
+class _AuditSink:
+    """One rotating file handler and lock shared by every agent in a run."""
+
+    def __init__(
+        self,
+        runtime_context: RuntimeContext,
+        *,
+        max_file_bytes: int,
+        backup_count: int,
+    ) -> None:
+        self.runtime_key = _context_key(runtime_context)
+        self.file_path = runtime_context.shell_audit_path
+        self.max_file_bytes = max(1, int(max_file_bytes))
+        self.backup_count = max(0, int(backup_count))
+        self._lock = threading.RLock()
+        self._handler: logging.Handler | None = None
+        self._closed = False
+        try:
+            self._handler = _SecureAuditHandler(
+                runtime_context,
+                max_file_bytes=self.max_file_bytes,
+                backup_count=self.backup_count,
+            )
+            self._handler.setFormatter(logging.Formatter("%(message)s"))
+        except (OSError, RuntimeError):
+            self._handler = None
+
+    def _get_handler_unlocked(self) -> logging.Handler | None:
+        if self._closed:
+            return None
+        return self._handler
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if _context_key(get_current_run_context()) != self.runtime_key:
+            return
+        with self._lock:
+            handler = self._get_handler_unlocked()
+            if handler is not None:
+                handler.emit(record)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            if self._handler is not None:
+                self._handler.close()
+                self._handler = None
+
+
+def _scope_for_context(
+    runtime_context: RuntimeContext,
+    *,
+    max_file_bytes: int = 10 * 1024 * 1024,
+    backup_count: int = 2,
+) -> _AuditScope:
+    runtime_key = _context_key(runtime_context)
+    assert runtime_key is not None
+    scope = _CURRENT_AUDIT_SCOPE.get()
+    if scope is None or scope.runtime_key != runtime_key:
+        if scope is not None:
+            _close_scope(scope)
+        scope = _AuditScope(runtime_key=runtime_key)
+        _CURRENT_AUDIT_SCOPE.set(scope)
+    if scope.sink is None:
+        scope.sink = _AuditSink(
+            runtime_context,
+            max_file_bytes=max_file_bytes,
+            backup_count=backup_count,
+        )
+    return scope
+
+
+def _close_scope(scope: _AuditScope) -> None:
+    for audit_logger in scope.loggers.values():
+        audit_logger.close()
+    if scope.sink is not None:
+        scope.sink.close()
+
+
+def initialize_shell_audit_scope(runtime_context: RuntimeContext) -> None:
+    """Bind the run sink before worker contexts are copied to threads."""
+    _scope_for_context(runtime_context)
 
 
 def _coerce_bool(value: Any) -> bool:
@@ -197,24 +330,36 @@ def _format_list(value: Any) -> str:
 # ---------------------------------------------------------------------------
 
 class ShellAuditLogger:
-    """Writes structured shell security events to a per-agent audit file.
+    """Writes structured shell security events to one run's audit file."""
 
-    Each instance is bound to a specific agent name and writes to a
-    single audit log file for the lifetime of the process.  Instances
-    are cached by agent name via :func:`get_shell_audit_logger`.
-
-    Thread-safe: all writes are serialized through an internal lock.
-    """
-
-    def __init__(self, agent_name: str, log_dir: Optional[str] = None):
+    def __init__(
+        self,
+        agent_name: str,
+        *,
+        runtime_context: RuntimeContext | None = None,
+        max_file_bytes: int = 10 * 1024 * 1024,
+        backup_count: int = 2,
+    ):
         self._agent_name = agent_name
         self._lock = threading.Lock()
-        self._file_path: Optional[Path] = None
-        self._enabled: Optional[bool] = None
-        self._log_success: Optional[bool] = None
-        self._log_policy_snapshot: Optional[bool] = None
+        self._file_path: Path | None = None
+        self._enabled: bool | None = None
+        self._log_success: bool | None = None
+        self._log_policy_snapshot: bool | None = None
         self._policy_snapshot_logged = False
-        self._log_dir = log_dir
+        self._runtime_context = runtime_context or get_current_run_context()
+        self._runtime_key = _context_key(self._runtime_context)
+        self._max_file_bytes = max(1, int(max_file_bytes))
+        self._backup_count = max(0, int(backup_count))
+        self._sink: _AuditSink | None = None
+        if self._runtime_context is not None:
+            scope = _scope_for_context(
+                self._runtime_context,
+                max_file_bytes=self._max_file_bytes,
+                backup_count=self._backup_count,
+            )
+            self._sink = scope.sink
+        self._closed = False
 
     # -- lazy initialization ------------------------------------------------
 
@@ -263,59 +408,23 @@ class ShellAuditLogger:
     def file_path(self) -> Path:
         """Lazily resolve and create the audit log file path."""
         if self._file_path is None:
-            self._file_path = self._resolve_path()
+            path = self._resolve_path()
+            if path is None:
+                raise RuntimeError("shell audit file logging requires a RuntimeContext")
+            self._file_path = path
         return self._file_path
 
-    def _resolve_path(self) -> Path:
-        """Resolve the audit log file path.
+    def _resolve_path(self) -> Path | None:
+        if self._runtime_context is not None:
+            return self._runtime_context.shell_audit_path
+        return None
 
-        Strategy:
-        1. If a process-level run directory already exists (set by the
-           main logger), place ``shell_audit.log`` in that same directory
-           so that agent log and audit log live side-by-side::
+    def _is_current_run(self) -> bool:
+        return _context_key(get_current_run_context()) == self._runtime_key
 
-               .logs/{agent_name}/{timestamp}/shell_audit.log
-
-        2. Otherwise (standalone usage / tests with explicit *log_dir*),
-           create our own timestamp sub-directory under
-           ``{log_dir}/{agent_name}/{timestamp}/shell_audit.log``.
-        """
-        # -- try to share the run directory created by the main logger ------
-        if not self._log_dir:
-            try:
-                from src.lib.logging.logger_manager import get_current_run_log_dir
-                run_dir = get_current_run_log_dir()
-                if run_dir is not None:
-                    run_dir.mkdir(parents=True, exist_ok=True)
-                    return run_dir / "shell_audit.log"
-            except Exception:
-                pass
-
-        # -- fallback: build our own timestamp directory --------------------
-        base_dir_str = self._log_dir or C.get_nested(
-            "logging", "dir", default=".logs",
-        )
-        base_dir = Path(base_dir_str).expanduser()
-        if not base_dir.is_absolute():
-            try:
-                agent_root = Path(C.agent_root).resolve()
-            except Exception:
-                agent_root = Path.cwd().resolve()
-            base_dir = agent_root / base_dir
-        base_dir = base_dir.resolve()
-
-        safe_name = _sanitize_component(self._agent_name)
-        now = datetime.now()
-        ts = now.strftime("%Y%m%d_%H%M%S")
-
-        target_dir = base_dir / safe_name / ts
-        suffix = 1
-        while target_dir.exists():
-            target_dir = base_dir / safe_name / f"{ts}_{suffix}"
-            suffix += 1
-        target_dir.mkdir(parents=True, exist_ok=True)
-
-        return target_dir / "shell_audit.log"
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
 
     # -- core write ---------------------------------------------------------
 
@@ -327,7 +436,7 @@ class ShellAuditLogger:
         check_id: str = "",
         message: str = "",
         suggestion: str = "",
-        extra: Optional[dict] = None,
+        extra: dict | None = None,
     ) -> None:
         """Write a single structured entry to the audit log file."""
         if not self.enabled:
@@ -335,31 +444,37 @@ class ShellAuditLogger:
         if event_type != EVENT_POLICY_SNAPSHOT:
             self.log_effective_policy()
 
-        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        lines = [
-            f"[{now}] [{event_type}] agent={self._agent_name}",
-        ]
-        # Truncate very long commands for readability
         cmd_display = command if len(command) <= 500 else command[:497] + "..."
-        lines.append(f"  command: {cmd_display}")
-
+        event: dict[str, Any] = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "event_type": event_type,
+            "agent": self._agent_name,
+            "command": cmd_display,
+        }
         if check_id:
-            lines.append(f"  check: {check_id}")
+            event["check_id"] = check_id
         if message:
-            lines.append(f"  message: {message}")
+            event["message"] = message
         if suggestion:
-            lines.append(f"  suggestion: {suggestion}")
+            event["suggestion"] = suggestion
         if extra:
-            for k, v in extra.items():
-                lines.append(f"  {k}: {v}")
-
-        lines.append("")  # blank separator between entries
-        entry = "\n".join(lines) + "\n"
+            event["details"] = extra
+        entry = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
 
         with self._lock:
             try:
-                with open(self.file_path, "a", encoding="utf-8") as f:
-                    f.write(entry)
+                if self._closed or not self._is_current_run() or self._sink is None:
+                    return
+                record = logging.LogRecord(
+                    name="agentloom.shell.audit",
+                    level=logging.INFO,
+                    pathname=__file__,
+                    lineno=0,
+                    msg=entry,
+                    args=(),
+                    exc_info=None,
+                )
+                self._sink.emit(record)
             except OSError as exc:
                 # Never let audit logging crash the shell pipeline
                 logger.debug(
@@ -621,11 +736,12 @@ class ShellAuditLogger:
             message=f"exit_code={exit_code}, duration={duration:.2f}s",
         )
 
-    def get_log_path(self) -> Optional[str]:
+    def get_log_path(self) -> str | None:
         """Return the audit log file path, or None if audit is disabled."""
-        if not self.enabled:
+        if not self.enabled or not self._is_current_run():
             return None
-        return str(self.file_path)
+        path = self._resolve_path()
+        return str(path) if path is not None else None
 
 
 # ---------------------------------------------------------------------------
@@ -633,39 +749,58 @@ class ShellAuditLogger:
 # ---------------------------------------------------------------------------
 
 def get_shell_audit_logger(
-    agent_name: Optional[str] = None,
-    log_dir: Optional[str] = None,
+    agent_name: str | None = None,
 ) -> ShellAuditLogger:
     """Get or create the audit logger for the current agent.
 
-    If *agent_name* is not provided, it is resolved from the current
-    task context (``get_current_agent_name()``).  Falls back to
-    ``"_global"`` when no agent context is available.
+    If *agent_name* is not provided, it is resolved from the explicit
+    execution ContextVar snapshot. Falls back to ``"_global"`` when no
+    agent context is bound; process-global trace fallbacks are never used.
 
-    Instances are cached per agent name for the lifetime of the process.
+    Instances are cached per agent name only inside the current run context
+    and are closed when that run's logger scope exits.
 
     Args:
         agent_name: Override the agent name (useful for testing).
-        log_dir: Override the base log directory (useful for testing).
-
     Returns:
         A :class:`ShellAuditLogger` bound to the resolved agent name.
     """
     if agent_name is None:
         try:
-            from src.trace import get_current_agent_name
-            agent_name = get_current_agent_name() or "_global"
+            from src.trace import capture_explicit_execution_context
+
+            agent_name = capture_explicit_execution_context().agent_name or "_global"
         except Exception:
             agent_name = "_global"
 
-    with _CACHE_LOCK:
-        key = f"{agent_name}:{log_dir or ''}"
-        if key not in _AUDIT_LOGGERS:
-            _AUDIT_LOGGERS[key] = ShellAuditLogger(agent_name, log_dir=log_dir)
-        return _AUDIT_LOGGERS[key]
+    runtime_context = get_current_run_context()
+    runtime_key = _context_key(runtime_context)
+    if runtime_key is None:
+        # A no-sink logger preserves the public API for standalone validation
+        # while guaranteeing that no file descriptor or path is created.
+        return ShellAuditLogger(agent_name, runtime_context=None)
+
+    assert runtime_context is not None
+    scope = _scope_for_context(runtime_context)
+
+    audit_logger = scope.loggers.get(agent_name)
+    if audit_logger is None:
+        audit_logger = ShellAuditLogger(
+            agent_name,
+            runtime_context=runtime_context,
+        )
+        scope.loggers[agent_name] = audit_logger
+    return audit_logger
+
+
+def close_current_shell_audit_loggers() -> None:
+    """Close and forget all audit sinks owned by the current run context."""
+    scope = _CURRENT_AUDIT_SCOPE.get()
+    if scope is not None:
+        _close_scope(scope)
+    _CURRENT_AUDIT_SCOPE.set(None)
 
 
 def reset_audit_loggers() -> None:
-    """Clear the cached audit logger instances (for testing only)."""
-    with _CACHE_LOCK:
-        _AUDIT_LOGGERS.clear()
+    """Testing alias for closing the current run-scoped audit cache."""
+    close_current_shell_audit_loggers()

--- a/src/tools/shell/shell_tool.py
+++ b/src/tools/shell/shell_tool.py
@@ -1,26 +1,20 @@
 from src.lib.logging import get_logger
-from src.tools.shell.command_semantics import interpret_exit_code
+from src.lib.runtime import get_current_run_context
 from src.tools.shell.output_interceptor import OutputInterceptor
 from src.tools.shell.process import ShellProcess, ShellProcessRegistry
 from src.tools.shell.should_use_sandbox import get_sandbox_manager, should_use_sandbox
 from src.tools.shell.validator import validate_command
-from src.trace import get_current_agent_id
+from src.trace import capture_explicit_execution_context
 
 logger = get_logger(__name__)
 
 
 def _no_command_message() -> str:
-    return (
-        "No shell command was provided; nothing was executed. "
-        "Please provide a non-empty shell command string."
-    )
+    return "No shell command was provided; nothing was executed. Please provide a non-empty shell command string."
 
 
 def _no_output_message(command: str) -> str:
-    return (
-        "Shell command executed successfully but produced no output.\n"
-        f"Executed command: {command}"
-    )
+    return f"Shell command executed successfully but produced no output.\nExecuted command: {command}"
 
 
 def shell_tool(
@@ -118,6 +112,7 @@ def shell_tool(
 
     try:
         from src.tools.shell.shell_audit_log import get_shell_audit_logger
+
         get_shell_audit_logger().log_effective_policy()
     except Exception:
         pass
@@ -136,7 +131,9 @@ def shell_tool(
     # Resolve agent context early so we can pass the shell session's
     # actual CWD to the path validator.  This closes a security gap
     # where the session CWD diverges from os.getcwd().
-    agent_id = get_current_agent_id()
+    runtime_context = get_current_run_context()
+    execution_context = capture_explicit_execution_context()
+    agent_id = execution_context.agent_id if runtime_context is not None else None
     session_cwd = None
     if agent_id:
         registry = ShellProcessRegistry.get_instance()
@@ -153,8 +150,10 @@ def shell_tool(
             logger.info("Command sandboxed via %s", sandbox_mgr.config.mode)
             try:
                 from src.tools.shell.shell_audit_log import get_shell_audit_logger
+
                 get_shell_audit_logger().log_sandbox_wrap(
-                    command, sandbox_mgr.config.mode,
+                    command,
+                    sandbox_mgr.config.mode,
                 )
             except Exception:
                 pass
@@ -163,8 +162,11 @@ def shell_tool(
             logger.warning("Sandbox requested but unavailable: %s", reason)
             try:
                 from src.tools.shell.shell_audit_log import get_shell_audit_logger
+
                 get_shell_audit_logger().log_sandbox_unavailable(
-                    command, sandbox_mgr.config.mode, reason or "unknown",
+                    command,
+                    sandbox_mgr.config.mode,
+                    reason or "unknown",
                 )
             except Exception:
                 pass
@@ -218,12 +220,12 @@ def _run_in_background(
     """
     import os
     import subprocess
-    import tempfile
 
+    from src.lib.runtime import get_current_run_context
     from src.tools.shell.background_task import BackgroundTaskRegistry
-    from src.tools.shell.process import find_suitable_shell, _MAX_OUTPUT_BYTES
+    from src.tools.shell.process import _MAX_OUTPUT_BYTES, find_suitable_shell
     from src.tools.shell.subprocess_env import build_subprocess_env
-    from src.tools.shell.tree_kill import SizeWatchdog
+    from src.tools.shell.tree_kill import SizeWatchdog, graceful_kill
 
     shell_path = find_suitable_shell()
     env = build_subprocess_env()
@@ -233,11 +235,14 @@ def _run_in_background(
     shell_args = [shell_path, "-c", f"eval '{escaped}'"]
 
     # Create durable output file.
-    fd, output_path = tempfile.mkstemp(
-        prefix="agentloom_bg_", suffix=".txt",
+    runtime_context = get_current_run_context(required=True)
+    assert runtime_context is not None
+    out_fd, output_path_obj = runtime_context.allocate_artifact(
+        "background",
+        prefix="background-",
+        suffix=".txt",
     )
-    os.close(fd)
-    out_fd = os.open(output_path, os.O_WRONLY | os.O_APPEND)
+    output_path = str(output_path_obj)
 
     try:
         proc = subprocess.Popen(
@@ -248,22 +253,45 @@ def _run_in_background(
             env=env,
             start_new_session=True,
         )
-    finally:
+    except BaseException:
         os.close(out_fd)
+        try:
+            runtime_context.remove_run_file(output_path_obj)
+        except FileNotFoundError:
+            pass
+        raise
 
-    # Start size watchdog.
-    watchdog = SizeWatchdog(proc.pid, output_path, max_bytes=_MAX_OUTPUT_BYTES)
-    watchdog.start()
-
-    # Register as background task.
-    registry = BackgroundTaskRegistry.get_instance()
-    task_id = registry.register(
-        process=proc,
-        command=original_command,
-        output_path=output_path,
-        description=original_command[:80],
-        size_watchdog=watchdog,
-    )
+    watchdog = None
+    try:
+        # Start size watchdog and transfer ownership to the registry.
+        watchdog = SizeWatchdog(
+            proc.pid,
+            output_path,
+            max_bytes=_MAX_OUTPUT_BYTES,
+            output_fd=out_fd,
+        )
+        watchdog.start()
+        registry = BackgroundTaskRegistry.get_instance()
+        task_id = registry.register(
+            process=proc,
+            command=original_command,
+            output_path=output_path,
+            description=original_command[:80],
+            size_watchdog=watchdog,
+            output_fd=out_fd,
+        )
+    except BaseException:
+        os.close(out_fd)
+        if watchdog is not None:
+            watchdog.stop()
+        graceful_kill(proc.pid, grace_ms=500)
+        try:
+            runtime_context.remove_run_file(output_path_obj)
+        except FileNotFoundError:
+            pass
+        raise
+    else:
+        os.close(out_fd)
 
     logger.info("Background task %s started: pid=%d", task_id, proc.pid)
     return (

--- a/src/tools/shell/stall_watchdog.py
+++ b/src/tools/shell/stall_watchdog.py
@@ -9,13 +9,14 @@ Design aligned with Claude Code's startStallWatchdog() in
 LocalShellTask.tsx (5s poll, 45s threshold, pattern-based detection).
 """
 
-import os
 import re
 import threading
 import time
 from typing import Callable, Optional
 
 from src.lib.logging import get_logger
+from src.lib.runtime import copy_runtime_context
+from src.tools.shell.output_reader import AnchoredOutputReader
 
 logger = get_logger(__name__)
 
@@ -50,29 +51,57 @@ def _build_stall_message(task_id: str, last_line: str) -> str:
     )
 
 
-def detect_stall_prompt(task_id: str, output_path: str) -> Optional[str]:
+def detect_stall_prompt(
+    task_id: str,
+    output_path: str,
+    *,
+    output_fd: int | None = None,
+    output_reader: AnchoredOutputReader | None = None,
+) -> Optional[str]:
     """Return a stall warning if the current output tail ends in a prompt."""
-    tail = _read_tail(output_path)
-    if not tail:
-        return None
+    owned_reader = None
+    reader = output_reader
+    if reader is None:
+        try:
+            if output_fd is None:
+                owned_reader = AnchoredOutputReader.from_path(output_path)
+            else:
+                owned_reader = AnchoredOutputReader.from_fd(
+                    output_fd,
+                    path=output_path,
+                )
+        except OSError:
+            return None
+        reader = owned_reader
 
-    last_line = tail.rstrip().rsplit("\n", 1)[-1]
-    if _matches_prompt(last_line):
-        return _build_stall_message(task_id, last_line)
-    return None
+    try:
+        tail = _read_tail_from_reader(reader)
+        if not tail:
+            return None
+
+        last_line = tail.rstrip().rsplit("\n", 1)[-1]
+        if _matches_prompt(last_line):
+            return _build_stall_message(task_id, last_line)
+        return None
+    finally:
+        if owned_reader is not None:
+            owned_reader.close()
 
 
 def _read_tail(output_path: str) -> str:
     """Read the last _TAIL_BYTES from the output file."""
     try:
-        with open(output_path, "rb") as f:
-            f.seek(0, 2)
-            size = f.tell()
-            f.seek(max(0, size - _TAIL_BYTES))
-            data = f.read()
-        return data.decode(errors="replace")
-    except (OSError, IOError):
+        reader = AnchoredOutputReader.from_path(output_path)
+    except OSError:
         return ""
+    try:
+        return _read_tail_from_reader(reader)
+    finally:
+        reader.close()
+
+
+def _read_tail_from_reader(reader: AnchoredOutputReader) -> str:
+    return reader.read_tail(_TAIL_BYTES).decode(errors="replace")
 
 
 def _matches_prompt(line: str) -> bool:
@@ -103,12 +132,28 @@ class StallWatchdog:
         poll_interval: float = 5.0,
         stall_threshold: float = 45.0,
         on_stall: Optional[Callable[[str], None]] = None,
+        output_reader: AnchoredOutputReader | None = None,
+        output_fd: int | None = None,
     ):
         self._task_id = task_id
         self._output_path = output_path
         self._poll_interval = poll_interval
         self._stall_threshold = stall_threshold
         self._on_stall = on_stall
+        self._owns_output_reader = output_reader is None
+        if output_reader is not None:
+            self._output_reader = output_reader
+        else:
+            try:
+                if output_fd is None:
+                    self._output_reader = AnchoredOutputReader.from_path(output_path)
+                else:
+                    self._output_reader = AnchoredOutputReader.from_fd(
+                        output_fd,
+                        path=output_path,
+                    )
+            except OSError:
+                self._output_reader = None
 
         self._stopped = False
         self._thread: Optional[threading.Thread] = None
@@ -117,8 +162,10 @@ class StallWatchdog:
     def start(self) -> None:
         """Start the polling thread."""
         self._stopped = False
+        runtime_context = copy_runtime_context()
         self._thread = threading.Thread(
-            target=self._poll_loop,
+            target=runtime_context.run,
+            args=(self._poll_loop,),
             daemon=True,
             name=f"stall-watchdog-{self._task_id}",
         )
@@ -127,6 +174,8 @@ class StallWatchdog:
     def stop(self) -> None:
         """Stop the watchdog (idempotent)."""
         self._stopped = True
+        if self._owns_output_reader and self._output_reader is not None:
+            self._output_reader.close()
 
     def _poll_loop(self) -> None:
         """Main polling loop — runs on a daemon thread."""
@@ -135,10 +184,11 @@ class StallWatchdog:
 
         while not self._stopped:
             try:
-                if os.path.exists(self._output_path):
-                    current_size = os.path.getsize(self._output_path)
-                else:
-                    current_size = 0
+                reader = self._output_reader
+                if reader is None:
+                    self._sleep(self._poll_interval)
+                    continue
+                current_size = reader.size() if reader is not None else 0
 
                 if current_size > last_size:
                     last_size = current_size
@@ -153,9 +203,13 @@ class StallWatchdog:
                     continue
 
                 # Output has been stalled long enough — check for prompt.
-                message = detect_stall_prompt(self._task_id, self._output_path)
+                message = detect_stall_prompt(
+                    self._task_id,
+                    self._output_path,
+                    output_reader=reader,
+                )
                 if not message:
-                    tail = _read_tail(self._output_path)
+                    tail = _read_tail_from_reader(reader) if reader is not None else ""
                     if not tail:
                         # No output yet — reset and keep watching.
                         last_growth = time.monotonic()
@@ -167,7 +221,7 @@ class StallWatchdog:
                     self._sleep(self._poll_interval)
                     continue
 
-                last_line = _read_tail(self._output_path).rstrip().rsplit("\n", 1)[-1]
+                last_line = _read_tail_from_reader(reader).rstrip().rsplit("\n", 1)[-1] if reader is not None else ""
                 self.stall_message = message
                 if self._on_stall is not None:
                     try:
@@ -181,6 +235,8 @@ class StallWatchdog:
                 )
                 # One-shot: stop after detection.
                 self._stopped = True
+                if self._owns_output_reader and reader is not None:
+                    reader.close()
                 return
 
             except Exception:

--- a/src/tools/shell/tree_kill.py
+++ b/src/tools/shell/tree_kill.py
@@ -17,6 +17,7 @@ import time
 from typing import Optional
 
 from src.lib.logging import get_logger
+from src.tools.shell.output_reader import AnchoredOutputReader
 
 logger = get_logger(__name__)
 
@@ -24,6 +25,8 @@ logger = get_logger(__name__)
 _KILL_GRACE_MS = 200
 
 DEFAULT_KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
+
+
 def tree_kill(pid: int, sig: int = DEFAULT_KILL_SIGNAL) -> bool:
     """Kill a process tree rooted at *pid*.
 
@@ -97,9 +100,7 @@ def graceful_kill(pid: int, grace_ms: int = _KILL_GRACE_MS) -> bool:
 
     # Phase 3: SIGKILL
     if _is_alive(pid):
-        logger.debug(
-            "Process %d still alive after %dms grace — sending SIGKILL", pid, grace_ms
-        )
+        logger.debug("Process %d still alive after %dms grace — sending SIGKILL", pid, grace_ms)
         tree_kill(pid, signal.SIGKILL)
 
     return True
@@ -142,6 +143,8 @@ class SizeWatchdog:
         output_path: str,
         max_bytes: int = 100_000_000,  # 100 MB
         poll_interval_s: float = 5.0,
+        output_reader: AnchoredOutputReader | None = None,
+        output_fd: int | None = None,
     ):
         self._pid = pid
         self._output_path = output_path
@@ -149,13 +152,30 @@ class SizeWatchdog:
         self._poll_interval = poll_interval_s
         self._stopped = False
         self._thread: Optional["threading.Thread"] = None
+        self._owns_output_reader = output_reader is None
+        if output_reader is not None:
+            self._output_reader = output_reader
+        else:
+            try:
+                if output_fd is None:
+                    self._output_reader = AnchoredOutputReader.from_path(output_path)
+                else:
+                    self._output_reader = AnchoredOutputReader.from_fd(
+                        output_fd,
+                        path=output_path,
+                    )
+            except OSError:
+                self._output_reader = None
 
     def start(self) -> None:
         """Start the watchdog polling thread."""
-        import threading
+        from src.lib.runtime import copy_runtime_context
+
         self._stopped = False
+        runtime_context = copy_runtime_context()
         self._thread = threading.Thread(
-            target=self._poll_loop,
+            target=runtime_context.run,
+            args=(self._poll_loop,),
             daemon=True,
             name=f"size-watchdog-{self._pid}",
         )
@@ -164,23 +184,26 @@ class SizeWatchdog:
     def stop(self) -> None:
         """Stop the watchdog (idempotent)."""
         self._stopped = True
+        if self._owns_output_reader and self._output_reader is not None:
+            self._output_reader.close()
 
     def _poll_loop(self) -> None:
         while not self._stopped:
-            try:
-                if os.path.exists(self._output_path):
-                    size = os.path.getsize(self._output_path)
-                    if size > self._max_bytes:
-                        logger.warning(
-                            "Output file %s exceeded %d bytes (size=%d) — "
-                            "killing process %d",
-                            self._output_path, self._max_bytes, size, self._pid,
-                        )
-                        tree_kill(self._pid, signal.SIGKILL)
-                        self._stopped = True
-                        return
-            except OSError:
-                pass
+            reader = self._output_reader
+            size = reader.size() if reader is not None else 0
+            if size > self._max_bytes:
+                logger.warning(
+                    "Output file %s exceeded %d bytes (size=%d) — killing process %d",
+                    self._output_path,
+                    self._max_bytes,
+                    size,
+                    self._pid,
+                )
+                tree_kill(self._pid, signal.SIGKILL)
+                self._stopped = True
+                if self._owns_output_reader and reader is not None:
+                    reader.close()
+                return
 
             # Sleep in small increments so stop() takes effect quickly.
             elapsed = 0.0

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -14,13 +14,14 @@ Keyboard shortcuts:
 
 from __future__ import annotations
 
-import time
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
 
 from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.widgets import DataTable, Footer, Header, Static
-
 
 # ── Status formatting ────────────────────────────────────────────────
 
@@ -66,13 +67,55 @@ def _fmt_created(created_at: str) -> str:
         return created_at[:16]
 
 
-def _get_row_task_id(table: DataTable) -> str | None:
-    """Extract the real task_id string from the current cursor row."""
+TaskIdentity = tuple[str, str]
+
+
+def _task_row_key(application_id: str, task_id: str) -> str:
+    """Build a collision-free row key for the canonical task identity."""
+
+    return f"task:{len(application_id)}:{application_id}:{task_id}"
+
+
+def _find_task(
+    tasks: Iterable[Mapping[str, Any]],
+    identity: TaskIdentity,
+) -> Mapping[str, Any] | None:
+    application_id, task_id = identity
+    return next(
+        (
+            task
+            for task in tasks
+            if task.get("application_id") == application_id
+            and task.get("task_id") == task_id
+        ),
+        None,
+    )
+
+
+def _get_row_key(table: DataTable) -> str | None:
+    """Extract the opaque key from the current cursor row."""
+
     if table.row_count == 0:
         return None
     row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
-    task_id = row_key.value if hasattr(row_key, "value") else str(row_key)
-    return task_id
+    return row_key.value if hasattr(row_key, "value") else str(row_key)
+
+
+def _checkpoints_root() -> Path:
+    from src.lib.config import C
+    from src.lib.runtime import resolve_runtime_home
+
+    return resolve_runtime_home(C.raw, agent_root=C.agent_root).checkpoints_root
+
+
+def _delete_dashboard_task(target: Mapping[str, Any]) -> bool:
+    """Delete through the same inactive-task lease used by the CLI cleaner."""
+
+    from src.lib.checkpoint.checkpoint_manager import (
+        delete_checkpoint_task_if_inactive,
+    )
+
+    return delete_checkpoint_task_if_inactive(Path(str(target["checkpoint_dir"])))
 
 
 # ── Textual App ──────────────────────────────────────────────────────
@@ -107,14 +150,15 @@ class TaskDashboardApp(App):
 
     def __init__(self) -> None:
         super().__init__()
-        self._expanded_tasks: set[str] = set()
+        self._expanded_tasks: set[TaskIdentity] = set()
+        self._row_identities: dict[str, tuple[TaskIdentity, bool]] = {}
 
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static("Loading…", id="summary")
         table = DataTable(id="tasks", zebra_stripes=True, cursor_type="row")
         table.add_columns(
-            "Task ID", "Agent", "Status", "Steps", "PID",
+            "Task ID", "Application", "Agent", "Status", "Steps", "PID",
             "Heartbeat", "Files", "Created",
         )
         yield table
@@ -127,13 +171,14 @@ class TaskDashboardApp(App):
     def _refresh_tasks(self) -> None:
         from src.lib.checkpoint.checkpoint_manager import list_all_tasks
 
-        tasks = list_all_tasks()
+        tasks = list_all_tasks(checkpoints_root=_checkpoints_root())
         table: DataTable = self.query_one("#tasks")
         summary: Static = self.query_one("#summary")
 
         cursor_row = table.cursor_row if table.row_count > 0 else 0
 
         table.clear()
+        self._row_identities.clear()
         if not tasks:
             summary.update("  No tasks found.  Press [bold]q[/] to quit.")
             return
@@ -151,9 +196,13 @@ class TaskDashboardApp(App):
 
         for t in tasks:
             task_id = t.get("task_id", "")
+            application_id = t.get("application_id", "")
+            identity = (application_id, task_id)
+            row_key = _task_row_key(application_id, task_id)
+            self._row_identities[row_key] = (identity, False)
             workers = t.get("workers", [])
             has_workers = len(workers) > 0
-            is_expanded = task_id in self._expanded_tasks
+            is_expanded = identity in self._expanded_tasks
 
             expand_icon = ""
             if has_workers:
@@ -165,6 +214,7 @@ class TaskDashboardApp(App):
 
             table.add_row(
                 task_id,                             # ← full task_id, no truncation
+                application_id,
                 expand_icon + t.get("agent_name", ""),
                 _fmt_status(t.get("status", "unknown")),
                 (str(t.get("step")) if t.get("step") is not None else "—"),
@@ -172,7 +222,7 @@ class TaskDashboardApp(App):
                 _fmt_heartbeat_age(t.get("heartbeat_age")),
                 fh_text,
                 _fmt_created(t.get("created_at", "")),
-                key=task_id,
+                key=row_key,
             )
 
             if is_expanded and workers:
@@ -186,7 +236,10 @@ class TaskDashboardApp(App):
                     w_hb_age = _fmt_heartbeat_age(w.get("heartbeat_age"))
                     w_started = _fmt_created(w.get("started_at", ""))
 
+                    worker_key = f"{row_key}::worker::{i}"
+                    self._row_identities[worker_key] = (identity, True)
                     table.add_row(
+                        "",
                         "",
                         Text.from_markup(f"[dim]{w_name}[/]"),
                         _fmt_status(w_status),
@@ -195,7 +248,7 @@ class TaskDashboardApp(App):
                         w_hb_age,
                         "—",
                         w_started,
-                        key=f"{task_id}::worker::{w.get('agent_name', '')}::{ci}",
+                        key=worker_key,
                     )
 
         if cursor_row < table.row_count:
@@ -210,24 +263,25 @@ class TaskDashboardApp(App):
     def action_expand(self) -> None:
         """Toggle worker expansion for the selected supervisor task."""
         table: DataTable = self.query_one("#tasks")
-        task_id = _get_row_task_id(table)
-        if task_id is None or "::worker::" in task_id:
+        row_key = _get_row_key(table)
+        selected = self._row_identities.get(row_key or "")
+        if selected is None or selected[1]:
             return
-        if task_id in self._expanded_tasks:
-            self._expanded_tasks.discard(task_id)
+        identity = selected[0]
+        if identity in self._expanded_tasks:
+            self._expanded_tasks.discard(identity)
         else:
-            self._expanded_tasks.add(task_id)
+            self._expanded_tasks.add(identity)
         self._refresh_tasks()
 
     def action_copy_id(self) -> None:
         """Copy the full task_id of the selected row to the system clipboard."""
         table: DataTable = self.query_one("#tasks")
-        task_id = _get_row_task_id(table)
-        if task_id is None:
+        row_key = _get_row_key(table)
+        selected = self._row_identities.get(row_key or "")
+        if selected is None:
             return
-        # If on a worker row, extract the parent supervisor task_id.
-        if "::worker::" in task_id:
-            task_id = task_id.split("::worker::")[0]
+        task_id = selected[0][1]
 
         try:
             import subprocess
@@ -255,30 +309,34 @@ class TaskDashboardApp(App):
 
     def action_delete_task(self) -> None:
         table: DataTable = self.query_one("#tasks")
-        task_id = _get_row_task_id(table)
-        if task_id is None:
+        row_key = _get_row_key(table)
+        selected = self._row_identities.get(row_key or "")
+        if selected is None:
             self.notify("No tasks to delete", severity="warning", timeout=1)
             return
-        if "::worker::" in task_id:
+        identity, is_worker = selected
+        if is_worker:
             self.notify("Select a supervisor row to delete", severity="warning", timeout=1)
             return
+        task_id = identity[1]
 
         from src.lib.checkpoint.checkpoint_manager import list_all_tasks
-        tasks = list_all_tasks()
-        target = next((t for t in tasks if t.get("task_id") == task_id), None)
+        tasks = list_all_tasks(checkpoints_root=_checkpoints_root())
+        target = _find_task(tasks, identity)
         if not target:
             self.notify(f"Task {task_id} not found", severity="error", timeout=1)
             return
 
-        from src.lib.checkpoint.checkpoint_manager import CheckpointManager, _resolve_checkpoint_base_dir
-        base_dir = _resolve_checkpoint_base_dir()
-        cm = CheckpointManager(target["agent_name"], base_dir=base_dir)
-        if cm.delete_task(task_id):
-            self._expanded_tasks.discard(task_id)
+        if _delete_dashboard_task(target):
+            self._expanded_tasks.discard(identity)
             self.notify(f"Deleted {task_id}", severity="information", timeout=1)
             self._refresh_tasks()
         else:
-            self.notify(f"Failed to delete {task_id}", severity="error", timeout=1)
+            self.notify(
+                f"Task {task_id} is active or could not be deleted",
+                severity="warning",
+                timeout=2,
+            )
 
 
 def run_dashboard() -> None:

--- a/tests/agent_test/context_engine/real_context_engine_application_validation.py
+++ b/tests/agent_test/context_engine/real_context_engine_application_validation.py
@@ -138,8 +138,11 @@ def run_case(case: ValidationCase, *, runtime_root: Path) -> dict[str, object]:
         shutil.rmtree(runtime_root)
     runtime_root.mkdir(parents=True, exist_ok=True)
 
-    previous_runtime_root = os.environ.get("AGENT_LOOM_RUNTIME_ROOT")
-    os.environ["AGENT_LOOM_RUNTIME_ROOT"] = str(runtime_root)
+    previous_runtime_config = dict(C.raw.get("runtime", {}))
+    C.raw["runtime"] = {
+        **previous_runtime_config,
+        "root_dir": str(runtime_root),
+    }
     C.raw.setdefault("checkpoint", {})["cleanup_on_success"] = False
     C.raw.setdefault("lsp_servers", {})["enabled"] = False
 
@@ -148,14 +151,11 @@ def run_case(case: ValidationCase, *, runtime_root: Path) -> dict[str, object]:
             run_app(
                 case.workflow,
                 task_override=case.task,
-                log_to_file=True,
+                file_logging=True,
             )
         )
     finally:
-        if previous_runtime_root is None:
-            os.environ.pop("AGENT_LOOM_RUNTIME_ROOT", None)
-        else:
-            os.environ["AGENT_LOOM_RUNTIME_ROOT"] = previous_runtime_root
+        C.raw["runtime"] = previous_runtime_config
 
     missing = [fragment for fragment in case.expected_fragments if fragment not in result]
     entry_paths = list(_iter_context_entries(runtime_root))

--- a/tests/agent_test/e2e_checkpoint_test.py
+++ b/tests/agent_test/e2e_checkpoint_test.py
@@ -61,9 +61,12 @@ def phase_interrupt():
 def phase_check():
     """List all saved checkpoints."""
     print("[E2E] Phase 2: Checking saved checkpoints...")
+    from src.lib.config import C
     from src.lib.checkpoint.checkpoint_manager import list_all_tasks
+    from src.lib.runtime import resolve_runtime_home
 
-    tasks = list_all_tasks()
+    checkpoints_root = resolve_runtime_home(C.raw, agent_root=C.agent_root).root_dir / "checkpoints"
+    tasks = list_all_tasks(checkpoints_root=checkpoints_root)
     if not tasks:
         print("[E2E] No checkpoints found!")
         return
@@ -77,7 +80,7 @@ def phase_check():
     import json
     from pathlib import Path
     for t in tasks:
-        base = Path(f".runtime/{t['agent_name']}/checkpoints/{t['task_id']}")
+        base = Path(t["checkpoint_dir"])
         ckpt = base / "checkpoint.json"
         hb = base / "heartbeat.json"
         if ckpt.exists():

--- a/tests/agent_test/logging_test/test_default_logger_fallback_demo.py
+++ b/tests/agent_test/logging_test/test_default_logger_fallback_demo.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 
-def test_default_logger_fallback_demo_script_runs_and_writes_log():
+def test_default_logger_fallback_demo_is_console_only_without_runtime_context():
     repo_root = Path(__file__).resolve().parents[3]
     demo_script = repo_root / "applications" / "test_demo" / "test_default_logger_fallback_demo.py"
     env = dict(os.environ)
@@ -25,11 +25,7 @@ def test_default_logger_fallback_demo_script_runs_and_writes_log():
     assert "log file path: " in result.stdout
 
     log_file_line = next(line for line in result.stdout.splitlines() if line.startswith("log file path: "))
-    log_path = Path(log_file_line.split("log file path: ", 1)[1].strip())
-    assert log_path.exists()
-
-    content = log_path.read_text(encoding="utf-8")
-    assert "[INFO]" in content
-    assert "default logger fallback demo start" in content
+    assert log_file_line == "log file path: None"
+    assert "default logger fallback demo start" in result.stdout
     assert "default logger fallback active: True" in result.stdout
     assert "skip run: true" in result.stdout

--- a/tests/agent_test/logging_test/test_log_levels.py
+++ b/tests/agent_test/logging_test/test_log_levels.py
@@ -9,63 +9,32 @@ Covers:
 from __future__ import annotations
 
 import re
-import sys
 from pathlib import Path
 
-import src.lib.config.config as config_module
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Helpers (mirrors conventions in test_logging_v4.py)
 # ---------------------------------------------------------------------------
 
-def _patch_config(monkeypatch, raw: dict, root: Path) -> None:
-    monkeypatch.setattr(
-        config_module,
-        "_ACTIVE_CONFIG",
-        config_module.UnifiedConfig(
-            raw,
-            agent_root=root,
-            llm_config=config_module.LLMConfig(),
-        ),
-        raising=True,
-    )
-
-
-def _make_script(path: Path) -> Path:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if not path.exists():
-        path.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
-    return path
-
-
-def _patch_main_script(monkeypatch, script: Path | None) -> None:
-    main_module = sys.modules.get("__main__")
-    if main_module is not None:
-        monkeypatch.setattr(
-            main_module,
-            "__file__",
-            str(script) if script is not None else None,
-            raising=False,
-        )
-
-
 def _build_backend(monkeypatch, tmp_path: Path, level: str):
     """Build an EnhancedAgentLogger backend with the given level string."""
-    from src.lib.logging import LoggingConfigBuilder, build_logger_backend_from_config
-    import src.lib.logging.logger_manager as logger_manager
+    from src.lib.logging import LoggingConfigBuilder, initialize_run_logger
+    from src.lib.runtime import RuntimeHome
 
-    _patch_config(
-        monkeypatch,
-        {"logging": {"enabled": True, "level": level, "dir": ".logs"}},
-        tmp_path,
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="test-log-levels", task_id="task", run_id="run"
     )
-    monkeypatch.setattr(logger_manager, "_PROCESS_LOG_FILE_PATH", None, raising=True)
-
-    return build_logger_backend_from_config(
-        "test_log_levels",
-        logging_builder=LoggingConfigBuilder().apply_mapping({"level": level}, source="test"),
+    return initialize_run_logger(
+        context,
+        logging_builder=LoggingConfigBuilder().apply_mapping(
+            {
+                "level": level,
+                "console_enabled": False,
+                "file_enabled": True,
+            },
+            source="test",
+        ),
     )
 
 
@@ -240,6 +209,7 @@ def test_agent_loom_log_level_from_str_invalid():
 
 def test_agent_loom_log_level_from_int():
     import logging as _logging
+
     from src.lib.logging.agent_logger import AgentLoomLogLevel
 
     assert AgentLoomLogLevel.from_int(_logging.DEBUG)   == AgentLoomLogLevel.DEBUG

--- a/tests/agent_test/logging_test/test_logging_v4.py
+++ b/tests/agent_test/logging_test/test_logging_v4.py
@@ -1,163 +1,76 @@
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 
-import src.lib.config.config as config_module
 import pytest
 
 
-def _patch_config(monkeypatch, raw: dict, root: Path) -> None:
-    monkeypatch.setattr(
-        config_module,
-        "_ACTIVE_CONFIG",
-        config_module.UnifiedConfig(raw, agent_root=root, llm_config=config_module.LLMConfig()),
-        raising=True,
+def test_logging_overlay_exposes_only_bounded_run_settings() -> None:
+    from src.lib.logging import LoggingConfigOverlay
+
+    overlay = LoggingConfigOverlay(
+        level="DEBUG",
+        console_enabled=False,
+        file_enabled=True,
+        max_file_bytes=1024,
+        backup_count=2,
     )
+    assert overlay.to_mapping() == {
+        "level": "DEBUG",
+        "console_enabled": False,
+        "file_enabled": True,
+        "max_file_bytes": 1024,
+        "backup_count": 2,
+    }
 
 
-def _reset_logger_manager_state(monkeypatch) -> None:
-    import src.lib.logging.logger_manager as logger_manager
+@pytest.mark.parametrize("removed_key", ["enabled", "dir", "file_path"])
+def test_removed_path_settings_are_rejected(removed_key: str) -> None:
+    from src.lib.logging import validate_logging_config
 
-    monkeypatch.setattr(logger_manager, "_INITIALIZED", False, raising=True)
-    monkeypatch.setattr(logger_manager, "_ACTIVE_LOG_FILE_PATH", None, raising=True)
-    monkeypatch.setattr(logger_manager, "_PROCESS_LOG_FILE_PATH", None, raising=True)
-
-
-def test_build_default_log_filename_uses_app_name_without_timestamp():
-    from src.lib.logging import build_default_log_filename
-
-    fixed_now = datetime(2026, 1, 14, 15, 1, 11)
-    # Timestamp is now in the parent directory, not the filename.
-    assert build_default_log_filename("my_agent", now=fixed_now) == "my_agent.log"
+    with pytest.raises(ValueError, match=removed_key):
+        validate_logging_config(
+            {"level": "INFO", removed_key: "legacy"},
+            source="test",
+        )
 
 
-def test_build_default_log_filename_sanitizes_app_name():
-    from src.lib.logging import build_default_log_filename
+def test_arbitrary_unknown_logging_setting_is_rejected() -> None:
+    from src.lib.logging import LoggingConfigBuilder
 
-    fixed_now = datetime(2026, 1, 14, 15, 1, 11)
-    assert build_default_log_filename("my agent/v2", now=fixed_now) == "my_agent_v2.log"
-
-
-def test_build_run_timestamp_dirname():
-    from src.lib.logging import build_run_timestamp_dirname
-
-    fixed_now = datetime(2026, 1, 14, 15, 1, 11)
-    assert build_run_timestamp_dirname(now=fixed_now) == "20260114_150111"
+    with pytest.raises(ValueError, match="surprise"):
+        LoggingConfigBuilder().apply_mapping(
+            {"surprise": True},
+            source="python overlay",
+        )
 
 
-def test_resolve_log_file_path_uses_timestamp_subdir(monkeypatch, tmp_path: Path):
-    from src.lib.logging import resolve_log_file_path
-
-    _patch_config(monkeypatch, {"logging": {"enabled": True, "level": "INFO", "dir": ".logs"}}, tmp_path)
-    _reset_logger_manager_state(monkeypatch)
-    fixed_now = datetime(2026, 1, 14, 15, 1, 11)
-
-    resolved = resolve_log_file_path("code_review_agent", now=fixed_now)
-
-    # New layout: .logs/{agent}/{timestamp}/{agent}.log
-    assert resolved.parent == (tmp_path / ".logs" / "code_review_agent" / "20260114_150111")
-    assert resolved.name == "code_review_agent.log"
-
-
-def test_resolve_log_file_path_collision_adds_suffix_to_dir(monkeypatch, tmp_path: Path):
-    from src.lib.logging import resolve_log_file_path
-
-    _patch_config(monkeypatch, {"logging": {"enabled": True, "level": "INFO", "dir": ".logs"}}, tmp_path)
-    _reset_logger_manager_state(monkeypatch)
-    fixed_now = datetime(2026, 1, 14, 15, 1, 11)
-
-    first = resolve_log_file_path("test_agent", now=fixed_now)
-    # first creates .logs/test_agent/20260114_150111/
-    assert first.parent.name == "20260114_150111"
-    assert first.name == "test_agent.log"
-
-    # Same timestamp → directory already exists → suffix on dir name
-    second = resolve_log_file_path("test_agent", now=fixed_now)
-    assert second.parent.name == "20260114_150111_1"
-    assert second.name == "test_agent.log"
-    assert first.parent != second.parent
-
-
-def test_resolve_log_file_path_explicit_path_has_highest_priority(monkeypatch, tmp_path: Path):
-    from src.lib.logging import resolve_log_file_path
-
-    _patch_config(
-        monkeypatch,
-        {
-            "logging": {
-                "enabled": True,
-                "level": "INFO",
-                "dir": ".logs",
-                "file_path": ".logs/from_config.log",
-            }
-        },
-        tmp_path,
-    )
-    explicit = tmp_path / "my_logs" / "custom.log"
-
-    resolved = resolve_log_file_path("ignored_name", log_file_path=str(explicit), now=datetime(2026, 1, 14, 15, 1, 11))
-
-    assert resolved == explicit.resolve()
-    assert resolved.parent.exists()
-    explicit.touch()
-    resolved_again = resolve_log_file_path("ignored_name", log_file_path=str(explicit), now=datetime(2026, 1, 14, 15, 1, 11))
-    assert resolved_again == explicit.resolve()
-
-
-def test_build_logger_backend_from_config_inherits_global_dir(monkeypatch, tmp_path: Path):
+def test_backend_without_runtime_context_has_no_file_sink(tmp_path: Path) -> None:
     from src.lib.logging import LoggingConfigBuilder, build_logger_backend_from_config
 
-    _patch_config(monkeypatch, {"logging": {"enabled": True, "level": "INFO", "dir": ".logs"}}, tmp_path)
-    _reset_logger_manager_state(monkeypatch)
-
     backend = build_logger_backend_from_config(
-        "my_app",
-        logging_builder=LoggingConfigBuilder().apply_mapping({"level": "DEBUG"}, source="test"),
+        "standalone",
+        logging_builder=LoggingConfigBuilder().apply_mapping(
+            {"console_enabled": True, "file_enabled": True}, source="test"
+        ),
     )
-
-    file_path = Path(getattr(getattr(backend, "console", None), "log_file_path", ""))
-    # New layout: .logs/my_app/{timestamp}/my_app.log
-    assert file_path.parent.parent == (tmp_path / ".logs" / "my_app")
-    assert file_path.name == "my_app.log"
+    assert getattr(getattr(backend, "console", None), "log_file_path", None) is None
+    assert not (tmp_path / ".logs").exists()
 
 
-def test_build_logger_backend_from_config_enabled_false_returns_null(monkeypatch, tmp_path: Path):
-    from src.lib.logging import LoggingConfigBuilder, NullLoggerBackend, build_logger_backend_from_config
+def test_file_logging_override_can_disable_only_the_file_sink(tmp_path: Path) -> None:
+    from src.lib.logging import LoggingConfigBuilder, initialize_run_logger
+    from src.lib.runtime import RuntimeHome
 
-    _patch_config(monkeypatch, {"logging": {"enabled": True, "level": "INFO", "dir": ".logs"}}, tmp_path)
-    backend = build_logger_backend_from_config(
-        "my_app",
-        logging_builder=LoggingConfigBuilder().apply_mapping({"enabled": False}, source="test"),
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="app", task_id="task", run_id="run"
     )
-
-    assert isinstance(backend, NullLoggerBackend)
-    assert getattr(backend, "console", None) is None
-
-
-def test_role_driven_agent_logger_resolution_uses_global_logger(monkeypatch, tmp_path: Path):
-    from src.lib.logging import get_global_logger, initialize_global_logger_once, set_global_logger
-    from src.lib.smolagents.agent.base_agent import RoleDrivenAgent
-
-    _patch_config(monkeypatch, {"logging": {"enabled": True, "level": "INFO", "dir": ".logs"}}, tmp_path)
-    _reset_logger_manager_state(monkeypatch)
-
-    previous_global = get_global_logger(create_if_missing=False)
-    set_global_logger(None)
-    try:
-        initialize_global_logger_once("test_app")
-        backend = RoleDrivenAgent.resolve_agent_logger_from_config(
-            {
-                "name": "sample_worker",
-                "logging": {"level": "DEBUG"},
-            }
-        )
-        file_path = Path(getattr(getattr(backend, "console", None), "log_file_path", ""))
-        assert backend is get_global_logger(create_if_missing=False)
-        # New layout: .logs/test_app/{timestamp}/test_app.log
-        assert file_path.parent.parent == (tmp_path / ".logs" / "test_app")
-        assert file_path.name == "test_app.log"
-    finally:
-        set_global_logger(previous_global)
-
-
+    backend = initialize_run_logger(
+        context,
+        logging_builder=LoggingConfigBuilder().apply_mapping(
+            {"console_enabled": True, "file_enabled": True}, source="test"
+        ),
+        file_logging=False,
+    )
+    backend.info("console-only")
+    assert not context.log_path.exists()

--- a/tests/agent_test/logging_test/test_run_scoped_logging.py
+++ b/tests/agent_test/logging_test/test_run_scoped_logging.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from src.lib.runtime import RuntimeHome, bind_run_context, copy_runtime_context
+
+
+def test_lazy_logger_is_bound_to_each_run_without_cross_writes(tmp_path: Path) -> None:
+    from src.lib.logging import (
+        LoggingConfigBuilder,
+        bind_logger_backend,
+        get_logger,
+        initialize_run_logger,
+    )
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="alpha", task_id="task-a", run_id="run-a")
+    second = home.context(application_id="beta", task_id="task-b", run_id="run-b")
+    logging_config = LoggingConfigBuilder().apply_mapping(
+        {
+            "level": "INFO",
+            "console_enabled": False,
+            "file_enabled": True,
+            "max_file_bytes": 1024,
+            "backup_count": 3,
+        },
+        source="test",
+    )
+    logger = get_logger("tests.run_scope")
+
+    with bind_run_context(first):
+        backend = initialize_run_logger(first, logging_builder=logging_config)
+        with bind_logger_backend(backend, context=first):
+            logger.info("only-first-run")
+
+    # With no RuntimeContext, the adapter must not borrow the previous file sink.
+    logger.info("outside-any-run")
+
+    with bind_run_context(second):
+        backend = initialize_run_logger(second, logging_builder=logging_config)
+        with bind_logger_backend(backend, context=second):
+            logger.info("only-second-run")
+
+    first_text = first.log_path.read_text(encoding="utf-8")
+    second_text = second.log_path.read_text(encoding="utf-8")
+    assert "only-first-run" in first_text
+    assert "only-second-run" not in first_text
+    assert "outside-any-run" not in first_text
+    assert "only-second-run" in second_text
+    assert "only-first-run" not in second_text
+    assert "outside-any-run" not in second_text
+
+
+def test_thread_logging_requires_explicit_context_propagation(tmp_path: Path) -> None:
+    from src.lib.logging import (
+        LoggingConfigBuilder,
+        bind_logger_backend,
+        get_logger,
+        initialize_run_logger,
+    )
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(application_id="threaded", task_id="task", run_id="run")
+    config = LoggingConfigBuilder().apply_mapping({"console_enabled": False, "file_enabled": True}, source="test")
+    logger = get_logger("tests.thread_scope")
+
+    with bind_run_context(context):
+        backend = initialize_run_logger(context, logging_builder=config)
+        with bind_logger_backend(backend, context=context):
+            unpropagated = threading.Thread(target=lambda: logger.info("must-not-borrow-run"))
+            unpropagated.start()
+            unpropagated.join()
+
+            propagated_context = copy_runtime_context()
+            propagated = threading.Thread(
+                target=propagated_context.run,
+                args=(lambda: logger.info("explicitly-propagated"),),
+            )
+            propagated.start()
+            propagated.join()
+
+    text = context.log_path.read_text(encoding="utf-8")
+    assert "explicitly-propagated" in text
+    assert "must-not-borrow-run" not in text
+
+
+def test_bound_run_logger_rejects_missing_or_different_runtime_context(
+    tmp_path: Path,
+) -> None:
+    from src.lib.logging import (
+        LoggingConfigBuilder,
+        bind_logger_backend,
+        get_logger,
+        initialize_run_logger,
+    )
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="alpha", task_id="task-a", run_id="run-a")
+    second = home.context(application_id="beta", task_id="task-b", run_id="run-b")
+    config = LoggingConfigBuilder().apply_mapping(
+        {"console_enabled": False, "file_enabled": True},
+        source="test",
+    )
+
+    with bind_run_context(first):
+        first_backend = initialize_run_logger(first, logging_builder=config)
+        with bind_logger_backend(first_backend, context=first):
+            bound_to_first = get_logger(first_backend, "tests.bound_scope")
+            bound_to_first.info("valid-first")
+
+            missing_context = threading.Thread(
+                target=lambda: bound_to_first.info("missing-context")
+            )
+            missing_context.start()
+            missing_context.join()
+
+            with bind_run_context(second):
+                second_backend = initialize_run_logger(second, logging_builder=config)
+                with bind_logger_backend(second_backend, context=second):
+                    bound_to_first.info("wrong-run")
+                    get_logger(second_backend, "tests.bound_scope").info("valid-second")
+
+    first_text = first.log_path.read_text(encoding="utf-8")
+    second_text = second.log_path.read_text(encoding="utf-8")
+    assert "valid-first" in first_text
+    assert "valid-second" in second_text
+    assert "missing-context" not in first_text
+    assert "wrong-run" not in first_text
+    assert "wrong-run" not in second_text
+
+
+def test_runtime_log_rotation_is_bounded_per_run(tmp_path: Path) -> None:
+    from src.lib.logging import (
+        LoggingConfigBuilder,
+        bind_logger_backend,
+        get_logger,
+        initialize_run_logger,
+    )
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(application_id="rotating", task_id="task", run_id="run")
+    config = LoggingConfigBuilder().apply_mapping(
+        {
+            "console_enabled": False,
+            "file_enabled": True,
+            "max_file_bytes": 180,
+            "backup_count": 3,
+        },
+        source="test",
+    )
+    logger = get_logger("tests.rotation")
+    with bind_run_context(context):
+        backend = initialize_run_logger(context, logging_builder=config)
+        with bind_logger_backend(backend, context=context):
+            for index in range(30):
+                logger.info("rotation-record-%02d", index)
+
+    assert context.log_path.exists()
+    assert Path(f"{context.log_path}.1").exists()
+    assert Path(f"{context.log_path}.3").exists()
+    assert not Path(f"{context.log_path}.4").exists()
+
+
+def test_runtime_log_rotation_keeps_opened_directory_when_path_is_replaced(
+    tmp_path: Path,
+) -> None:
+    from src.lib.logging import (
+        LoggingConfigBuilder,
+        bind_logger_backend,
+        get_logger,
+        initialize_run_logger,
+    )
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="first", task_id="task", run_id="run")
+    second = home.context(application_id="second", task_id="task", run_id="run")
+    first.prepare_run()
+    second.prepare_run()
+    second.log_path.write_text("SECOND-ONLY\n", encoding="utf-8")
+    detached_logs = first.run_dir / "logs-detached"
+    config = LoggingConfigBuilder().apply_mapping(
+        {
+            "console_enabled": False,
+            "file_enabled": True,
+            "max_file_bytes": 120,
+            "backup_count": 2,
+        },
+        source="test",
+    )
+    logger = get_logger("tests.secure_rotation")
+
+    with bind_run_context(first):
+        backend = initialize_run_logger(first, logging_builder=config)
+        with bind_logger_backend(backend, context=first):
+            logger.info("FIRST-BEFORE")
+            first.logs_dir.rename(detached_logs)
+            first.logs_dir.symlink_to(second.logs_dir, target_is_directory=True)
+            for _ in range(8):
+                logger.info("FIRST-AFTER-ROTATION-BOUNDARY")
+
+    second_text = second.log_path.read_text(encoding="utf-8")
+    assert second_text == "SECOND-ONLY\n"
+    assert any("FIRST" in path.read_text(encoding="utf-8") for path in detached_logs.iterdir())
+
+
+def test_agent_log_prefix_never_reads_process_global_trace_fallbacks(monkeypatch) -> None:
+    import importlib
+
+    from src.lib.logging.agent_logger import AgentLoomLogLevel, EnhancedAgentLogger
+
+    task_context_module = importlib.import_module("src.trace.task_context")
+
+    monkeypatch.setattr(task_context_module, "_global_task_id_fallback", "wrong-task")
+    monkeypatch.setattr(task_context_module, "_global_sub_task_id_fallback", "wrong-subtask")
+    monkeypatch.setattr(task_context_module, "_global_agent_name_fallback", "wrong-agent")
+
+    logger = EnhancedAgentLogger(show_timestamp=False, show_trace_info=True)
+    prefix = logger._build_prefix(AgentLoomLogLevel.INFO).plain
+
+    assert "wrong-task" not in prefix
+    assert "wrong-subtask" not in prefix
+    assert "wrong-agent" not in prefix

--- a/tests/agent_test/model_request_headers_real_validation.py
+++ b/tests/agent_test/model_request_headers_real_validation.py
@@ -153,10 +153,17 @@ def _install_temp_config(
         "model_request_headers": system_header_config,
         "lsp_servers": {"enabled": False},
         "checkpoint": {"enabled": False},
+        "runtime": {"root_dir": str(runtime_root / ".agentloom")},
         "self_learning": {"enabled": False},
         "skills": [],
         "default_toolsets": [],
-        "logging": {"enabled": True, "level": "ERROR", "dir": str(runtime_root / "logs")},
+        "logging": {
+            "level": "ERROR",
+            "console_enabled": True,
+            "file_enabled": True,
+            "max_file_bytes": 25 * 1024 * 1024,
+            "backup_count": 3,
+        },
     }
     model_config = {
         "model": {

--- a/tests/agent_test/real_checkpoint_validation.py
+++ b/tests/agent_test/real_checkpoint_validation.py
@@ -13,26 +13,35 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import signal
 import subprocess
 import time
+from collections import Counter
 from pathlib import Path
 from textwrap import dedent
-
 
 ROOT = Path(__file__).resolve().parents[2]
 PYTHON = Path("/Users/bytedance/code/data_clear/AgentLoom/.venv/bin/python")
 YAML_PATH = "applications/test_demo/workflows/test_checkpoint_complex_supervisor.yaml"
 APP_NAME = "test_checkpoint_complex_supervisor"
 WORK_DIR = Path("/tmp/agentloom_ckpt_complex")
+RUNTIME_ROOT = Path("/tmp/agentloom_real_checkpoint_runtime/.agentloom")
+PROBE_STEP = 9001
+CONTEXT_NEEDLE = "old context survives the real resume"
+SIDE_EFFECT_LOG = Path("/tmp/agentloom_ckpt_side_effects.log")
+EXPECTED_SIDE_EFFECTS = {
+    "supervisor_setup": 1,
+    "worker_step_1": 1,
+    "worker_step_2": 1,
+    "worker_step_3": 1,
+    "supervisor_finalize": 1,
+}
 
 
 def _checkpoint_root() -> Path:
-    runtime_root = os.environ.get("AGENT_LOOM_RUNTIME_ROOT", "").strip()
-    if runtime_root:
-        return Path(runtime_root)
-    return ROOT / ".logs"
+    return RUNTIME_ROOT / "checkpoints"
 
 
 def _env() -> dict[str, str]:
@@ -46,6 +55,7 @@ def _run_code(resume_task_id: str | None = None) -> str:
     return dedent(
         f"""
         from src.lib.config import C
+        C.raw.setdefault("runtime", {{}})["root_dir"] = {str(RUNTIME_ROOT)!r}
         C.raw.setdefault("checkpoint", {{}})["cleanup_on_success"] = False
         C.raw.setdefault("lsp_servers", {{}})["enabled"] = False
         C.raw["skills"] = []
@@ -57,12 +67,13 @@ def _run_code(resume_task_id: str | None = None) -> str:
 
 
 def _clean_runtime() -> None:
-    shutil.rmtree(_checkpoint_root() / APP_NAME, ignore_errors=True)
+    shutil.rmtree(RUNTIME_ROOT.parent, ignore_errors=True)
     shutil.rmtree(WORK_DIR, ignore_errors=True)
+    SIDE_EFFECT_LOG.unlink(missing_ok=True)
 
 
 def _latest_task_dir() -> Path | None:
-    candidates = sorted((_checkpoint_root() / APP_NAME).glob("*/checkpoints/task_*"))
+    candidates = sorted((_checkpoint_root() / "test_demo").glob("task_*"))
     return candidates[-1] if candidates else None
 
 
@@ -103,6 +114,89 @@ def _worker_ckpt(task_dir: Path, call_index: int = 0) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _seed_resume_probes(task_dir: Path) -> tuple[str, Path]:
+    """Add old ContextRef and file-history state before the real resume."""
+
+    from src.lib.checkpoint import CheckpointManager
+    from src.lib.checkpoint.file_history import FileHistoryManager
+    from src.lib.context_engine.engine import ContextEngine
+
+    manager = CheckpointManager("resume-probe", checkpoint_dir=task_dir)
+    context_engine = ContextEngine(
+        task_dir / "context_store",
+        storage=manager.directory_storage(task_dir.name, task_dir / "context_store"),
+    )
+    preview = context_engine.compress_tool_result(
+        (CONTEXT_NEEDLE + "\n") * 800,
+        tool_name="shell_tool",
+        source="real-resume-probe",
+    )
+    if preview is None:
+        raise AssertionError("failed to create ContextRef resume probe")
+    match = re.search(r"ContextRef (ctx_[0-9a-f]{16})", preview)
+    if match is None:
+        raise AssertionError(f"ContextRef missing from preview: {preview[:200]}")
+    ref = match.group(1)
+    context_engine.close()
+
+    probe_path = WORK_DIR / "resume_rewind_probe.txt"
+    probe_path.parent.mkdir(parents=True, exist_ok=True)
+    probe_path.write_text("before-resume-edit\n", encoding="utf-8")
+    history = FileHistoryManager(
+        task_dir / "file-history",
+        storage=manager.directory_storage(task_dir.name, task_dir / "file-history"),
+    )
+    history.track_edit(str(probe_path), step_number=PROBE_STEP)
+    probe_path.write_text("mutated-before-resume\n", encoding="utf-8")
+    history.close()
+    manager.close()
+    return ref, probe_path
+
+
+def _verify_resume_probes(task_dir: Path, ref: str, probe_path: Path) -> None:
+    from src.lib.checkpoint import CheckpointManager
+    from src.lib.checkpoint.file_history import FileHistoryManager
+    from src.lib.context_engine.store import ContextStore
+
+    manager = CheckpointManager("resume-probe", checkpoint_dir=task_dir)
+    store = ContextStore(
+        task_dir / "context_store",
+        storage=manager.directory_storage(task_dir.name, task_dir / "context_store"),
+    )
+    retrieved = store.retrieve(ref, offset=0, limit=1)
+    if retrieved is None or CONTEXT_NEEDLE not in retrieved:
+        raise AssertionError(f"old ContextRef was not retrievable after resume: {ref}")
+    store.close()
+
+    history = FileHistoryManager(
+        task_dir / "file-history",
+        storage=manager.directory_storage(task_dir.name, task_dir / "file-history"),
+    )
+    if not history.restore_persisted_index():
+        raise AssertionError("file-history index was not restored after resume")
+    if probe_path.read_text(encoding="utf-8") != "mutated-before-resume\n":
+        raise AssertionError("resume unexpectedly rewound the probe before validation")
+    restored = history.rewind_to_step(PROBE_STEP)
+    if os.path.abspath(probe_path) not in restored:
+        raise AssertionError(f"file-history did not rewind probe: {restored}")
+    if probe_path.read_text(encoding="utf-8") != "before-resume-edit\n":
+        raise AssertionError("file-history rewind restored the wrong probe content")
+    history.close()
+    manager.close()
+
+
+def _run_ids_for_task(task_id: str) -> set[str]:
+    run_ids: set[str] = set()
+    for manifest_path in (RUNTIME_ROOT / "runs").glob("**/manifest.json"):
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if manifest.get("task_id") == task_id and isinstance(manifest.get("run_id"), str):
+            run_ids.add(manifest["run_id"])
+    return run_ids
+
+
 def _assert_final_files() -> None:
     expected = {
         "items/a.txt": "alpha=11",
@@ -120,6 +214,57 @@ def _assert_final_files() -> None:
             missing.append(f"{rel_path} missing {needle!r}")
     if missing:
         raise AssertionError("; ".join(missing))
+
+
+def _assert_side_effects_executed_once() -> None:
+    if not SIDE_EFFECT_LOG.is_file():
+        raise AssertionError("append-only side-effect log was not created")
+    counts = Counter(SIDE_EFFECT_LOG.read_text(encoding="utf-8").splitlines())
+    if dict(counts) != EXPECTED_SIDE_EFFECTS:
+        raise AssertionError(f"resume duplicated or skipped side effects: {dict(counts)}")
+
+
+def _assert_interrupted_attempt(
+    task_dir: Path,
+    returncode: int,
+    counts: dict[str, int],
+) -> None:
+    if returncode == 0:
+        raise AssertionError("interrupt attempt unexpectedly exited successfully")
+    if counts.get("run_started") != 1 or counts.get("run_resumed", 0) != 0:
+        raise AssertionError(f"invalid pre-resume run events: {counts}")
+    tree = json.loads((task_dir / "task_tree.json").read_text(encoding="utf-8"))
+    if tree.get("status") == "completed":
+        raise AssertionError("task completed before the requested interruption")
+    completed_before_resume = [
+        event
+        for event in _events(task_dir)
+        if event.get("type") == "task_status_changed"
+        and event.get("status") == "completed"
+    ]
+    if completed_before_resume:
+        raise AssertionError("completed task event exists before resume")
+
+
+def _assert_completed_resume(
+    task_dir: Path,
+    resume_text: str,
+    counts: dict[str, int],
+) -> tuple[dict, list[dict]]:
+    if "CHECKPOINT COMPLEX COMPLETE" not in resume_text:
+        raise AssertionError("resume result did not contain the required final answer")
+    if counts.get("run_started") != 1 or counts.get("run_resumed") != 1:
+        raise AssertionError(f"resume attempt events are not one-to-one: {counts}")
+    if counts.get("worker_call_started") != 1 or counts.get("worker_call_finished") != 1:
+        raise AssertionError(f"worker call was duplicated or left unfinished: {counts}")
+    tree = json.loads((task_dir / "task_tree.json").read_text(encoding="utf-8"))
+    if tree.get("status") != "completed":
+        raise AssertionError(f"task tree did not complete: {tree.get('status')}")
+    calls = _worker_calls(task_dir)
+    if len(calls) != 1 or calls[0].get("status") != "completed":
+        raise AssertionError(f"expected exactly one completed worker call: {calls}")
+    _assert_side_effects_executed_once()
+    return tree, calls
 
 
 def _start_run(log_path: Path) -> subprocess.Popen:
@@ -205,10 +350,21 @@ def run_main_interrupt() -> dict:
     task_id = task_dir.name
     returncode = _interrupt(proc)
     before = _event_counts(task_dir)
+    _assert_interrupted_attempt(task_dir, returncode, before)
+    old_run_ids = _run_ids_for_task(task_id)
+    context_ref, probe_path = _seed_resume_probes(task_dir)
     resume_text = _resume(task_id, log_dir / "main_interrupt_resume.log")
+    if "Restored file history:" not in resume_text:
+        raise AssertionError("runner did not restore persisted file-history during resume")
     after = _event_counts(task_dir)
+    new_run_ids = _run_ids_for_task(task_id)
+    if len(old_run_ids) != 1 or len(new_run_ids) != 2 or not old_run_ids < new_run_ids:
+        raise AssertionError(
+            f"resume must keep task_id and create one new run_id: {old_run_ids} -> {new_run_ids}"
+        )
+    _verify_resume_probes(task_dir, context_ref, probe_path)
     _assert_final_files()
-    tree = json.loads((task_dir / "task_tree.json").read_text(encoding="utf-8"))
+    tree, calls = _assert_completed_resume(task_dir, resume_text, after)
     return {
         "scenario": "main_interrupt",
         "task_id": task_id,
@@ -216,9 +372,12 @@ def run_main_interrupt() -> dict:
         "before_counts": before,
         "after_counts": after,
         "tree_status": tree.get("status"),
-        "worker_calls": len(_worker_calls(task_dir)),
+        "worker_calls": len(calls),
         "final_files_ok": True,
         "resume_result_seen": "CHECKPOINT COMPLEX COMPLETE" in resume_text,
+        "new_run_on_same_task": True,
+        "old_context_ref_retrieved": True,
+        "file_history_rewound": True,
     }
 
 
@@ -231,16 +390,26 @@ def run_worker_interrupt() -> dict:
     before_worker = _worker_ckpt(task_dir)
     returncode = _interrupt(proc)
     before = _event_counts(task_dir)
+    _assert_interrupted_attempt(task_dir, returncode, before)
+    old_run_ids = _run_ids_for_task(task_id)
+    context_ref, probe_path = _seed_resume_probes(task_dir)
     resume_text = _resume(task_id, log_dir / "worker_interrupt_resume.log")
+    if "Restored file history:" not in resume_text:
+        raise AssertionError("runner did not restore persisted file-history during resume")
     after = _event_counts(task_dir)
+    new_run_ids = _run_ids_for_task(task_id)
+    if len(old_run_ids) != 1 or len(new_run_ids) != 2 or not old_run_ids < new_run_ids:
+        raise AssertionError(
+            f"resume must keep task_id and create one new run_id: {old_run_ids} -> {new_run_ids}"
+        )
+    _verify_resume_probes(task_dir, context_ref, probe_path)
     _assert_final_files()
-    tree = json.loads((task_dir / "task_tree.json").read_text(encoding="utf-8"))
-    calls = _worker_calls(task_dir)
+    tree, calls = _assert_completed_resume(task_dir, resume_text, after)
     final_worker = _worker_ckpt(task_dir)
-    if len(calls) != 1:
-        raise AssertionError(f"expected one worker call, got {len(calls)}")
-    if calls[0].get("status") != "completed":
-        raise AssertionError(f"worker call not completed after resume: {calls[0]}")
+    if before_worker.get("step_count", 0) < 1:
+        raise AssertionError(f"worker was not checkpointed before interrupt: {before_worker}")
+    if final_worker.get("step_count", 0) <= before_worker.get("step_count", 0):
+        raise AssertionError("resumed worker did not advance beyond its saved memory")
     if "Restored worker artifact_worker #0" not in resume_text:
         raise AssertionError("worker restore log not found")
     return {
@@ -256,6 +425,9 @@ def run_worker_interrupt() -> dict:
         "worker_step_count_after": final_worker.get("step_count"),
         "worker_memory_restored": "Restored worker artifact_worker #0" in resume_text,
         "final_files_ok": True,
+        "new_run_on_same_task": True,
+        "old_context_ref_retrieved": True,
+        "file_history_rewound": True,
     }
 
 

--- a/tests/agent_test/runtime_builder_test/test_runtime_builder.py
+++ b/tests/agent_test/runtime_builder_test/test_runtime_builder.py
@@ -17,7 +17,7 @@ from src.lib.smolagents.hooks.types import HookEvent, HookResult
 def _isolate_self_learning_state(tmp_path, monkeypatch):
     """Runtime lifecycle tests must never append to the developer's ledger."""
     monkeypatch.setenv(
-        "AGENTLOOM_SELF_LEARNING_ROOT",
+        "AGENTLOOM_RUNTIME_ROOT",
         str(tmp_path / ".agentloom"),
     )
 
@@ -165,16 +165,12 @@ def test_create_agent_uses_global_logger_when_not_provided(monkeypatch):
 
 
 def test_create_agent_requires_global_logger(monkeypatch):
-    """Agent construction requires initialize_global_logger_once to be called first."""
+    """Standalone construction can explicitly initialize a console backend."""
     from src.lib.logging import initialize_global_logger_once
-    import src.lib.logging.logger_manager as logger_manager
 
     _patch_agent_classes(monkeypatch)
     previous_global_logger = get_global_logger(create_if_missing=False)
     set_global_logger(None)
-    monkeypatch.setattr(logger_manager, "_INITIALIZED", False, raising=True)
-    monkeypatch.setattr(logger_manager, "_ACTIVE_LOG_FILE_PATH", None, raising=True)
-    monkeypatch.setattr(logger_manager, "_PROCESS_LOG_FILE_PATH", None, raising=True)
 
     try:
         initialize_global_logger_once("test_runtime_builder")
@@ -370,6 +366,25 @@ def test_base_run_binds_root_before_memory_snapshot_and_only_owner_emits_session
     assert snapshot_roots == ["supervisor-root"]
     assert HookEvent.SESSION_START not in events
     assert HookEvent.SESSION_END not in events
+
+
+def test_base_run_uses_runner_supplied_run_id_for_root_lifecycle(monkeypatch):
+    from src.trace import capture_explicit_execution_context
+
+    agent = _make_agent(logger=DummyLoggerBackend())
+    runtime_agent = DummyRuntimeRunner(result="ok")
+    observed = []
+
+    monkeypatch.setattr(agent, "build_runtime_agent", lambda: runtime_agent)
+    monkeypatch.setattr(
+        agent,
+        "_inject_memory_snapshot",
+        lambda tasks: observed.append(capture_explicit_execution_context()) or tasks,
+    )
+
+    assert agent.run("top-level", task_id="task-1", run_id="run-from-runner") == "ok"
+    assert observed[0].root_run_id == "run-from-runner"
+    assert observed[0].local_run_id == "run-from-runner"
 
 
 def test_base_run_releases_owned_root_after_failure(monkeypatch):
@@ -579,7 +594,11 @@ def test_max_steps_worker_is_failed_before_checkpoint_success(tmp_path, monkeypa
                 timing=None,
             )
 
-    checkpoint_manager = CheckpointManager("supervisor", base_dir=tmp_path)
+    checkpoint_manager = CheckpointManager(
+        "supervisor",
+        checkpoints_root=tmp_path,
+        run_id="run_test",
+    )
     coordinator = CheckpointCoordinator(
         checkpoint_manager,
         "task-max-steps-worker",
@@ -607,13 +626,6 @@ def test_max_steps_worker_is_failed_before_checkpoint_success(tmp_path, monkeypa
         call_index=worker_call["call_index"],
     )
     assert checkpoint["status"] == "failed"
-    assert (
-        coordinator.check_worker_skip(
-            "max_steps_worker",
-            worker_call["input_hash"],
-        )
-        is None
-    )
 
 
 def test_max_steps_managed_worker_fails_before_call_discards_state(
@@ -643,7 +655,11 @@ def test_max_steps_managed_worker_fails_before_call_discards_state(
             timing=None,
         ),
     )
-    checkpoint_manager = CheckpointManager("supervisor", base_dir=tmp_path)
+    checkpoint_manager = CheckpointManager(
+        "supervisor",
+        checkpoints_root=tmp_path,
+        run_id="run_test",
+    )
     coordinator = CheckpointCoordinator(
         checkpoint_manager,
         "task-max-steps-managed-worker",
@@ -671,13 +687,6 @@ def test_max_steps_managed_worker_fails_before_call_discards_state(
         call_index=worker_call["call_index"],
     )
     assert checkpoint["status"] == "failed"
-    assert (
-        coordinator.check_worker_skip(
-            "max_steps_managed_worker",
-            worker_call["input_hash"],
-        )
-        is None
-    )
 
 
 def test_builtin_session_end_has_only_the_recorder_hook():
@@ -1110,7 +1119,7 @@ def test_base_run_executes_transformed_tasks_sequentially_with_reset_false(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv(
-        "AGENTLOOM_SELF_LEARNING_ROOT",
+        "AGENTLOOM_RUNTIME_ROOT",
         str(tmp_path / ".agentloom"),
     )
     agent = _make_agent(logger=DummyLoggerBackend())

--- a/tests/agent_test/sys_config/test_app_override_no_llm_leak.py
+++ b/tests/agent_test/sys_config/test_app_override_no_llm_leak.py
@@ -173,7 +173,7 @@ def test_application_inherits_or_explicitly_disables_global_memory_review(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     monkeypatch.setattr(
         reviewer,
         "_resolve_review_model",

--- a/tests/agent_test/sys_config/test_app_root_discovery.py
+++ b/tests/agent_test/sys_config/test_app_root_discovery.py
@@ -178,3 +178,24 @@ def test_build_effective_merges_app_overlay(tmp_path):
 
     # 全局基础保留
     assert config_module.C.llm.for_type("powerful").model == "openai/test-model"
+
+
+@pytest.mark.parametrize("key", ["runtime", "logging"])
+def test_build_effective_rejects_global_only_app_overlay(tmp_path, key):
+    agent_root = tmp_path / "agent"
+    config_dir = agent_root / "config"
+    app_root = agent_root / "applications" / "my_app"
+    _write_yaml(config_dir / "system.yaml", {"system": {"name": "base"}})
+    _write_yaml(config_dir / "llm.yaml", _minimal_llm_yaml())
+    _write_yaml(app_root / "config" / "system.yaml", {key: {"root_dir": "other"}})
+    yaml_file = app_root / "workflows" / "agent.yaml"
+    _write_yaml(yaml_file, {"name": "test"})
+    config_module._ACTIVE_CONFIG = config_module._load_merged_config(
+        config_dir=config_dir
+    )
+
+    with pytest.raises(ValueError, match=rf"global-only.*{key}"):
+        config_module.build_effective_agent_config(
+            {"_yaml_file_path": str(yaml_file)},
+            source_name="test",
+        )

--- a/tests/agent_test/test_checkpoint_e2e.py
+++ b/tests/agent_test/test_checkpoint_e2e.py
@@ -63,7 +63,11 @@ class TestCheckpointSaveAndResume:
 
     def test_save_then_resume_filters_incomplete_steps(self, tmp_path):
         """Save checkpoint with mixed steps, resume filters bad ones."""
-        cm = CheckpointManager("e2e_agent", base_dir=tmp_path)
+        cm = CheckpointManager(
+            "e2e_agent",
+            checkpoints_root=tmp_path,
+            run_id="run_test",
+        )
         task_id = "task_e2e_001"
 
         # Simulate: agent completed 2 steps, then was interrupted mid-step-3.
@@ -130,7 +134,11 @@ class TestCheckpointSaveAndResume:
 
     def test_worker_skip_on_resume(self, tmp_path):
         """Completed worker is skipped on resume via input_hash match."""
-        cm = CheckpointManager("e2e_sup", base_dir=tmp_path)
+        cm = CheckpointManager(
+            "e2e_sup",
+            checkpoints_root=tmp_path,
+            run_id="run_test",
+        )
         task_id = "task_e2e_worker_skip"
 
         # Save task tree with a completed worker
@@ -158,7 +166,11 @@ class TestCheckpointSaveAndResume:
 
     def test_context_store_metadata_and_resume_retrieval(self, tmp_path):
         """ContextEngine store is task-scoped and survives coordinator resume."""
-        cm = CheckpointManager("ctx_sup", base_dir=tmp_path)
+        cm = CheckpointManager(
+            "ctx_sup",
+            checkpoints_root=tmp_path,
+            run_id="run_test",
+        )
         task_id = "task_context_store"
 
         class RuntimeAgent:
@@ -210,7 +222,11 @@ class TestFileHistoryWithCoordinator:
     def test_step_callback_triggers_file_history_snapshot(self, tmp_path):
         """Coordinator step callback creates file history post-step snapshot."""
         # Setup
-        cm = CheckpointManager("fh_test", base_dir=tmp_path)
+        cm = CheckpointManager(
+            "fh_test",
+            checkpoints_root=tmp_path,
+            run_id="run_test",
+        )
         task_id = "task_fh_001"
         cm.save_task_tree(task_id, {
             "task_id": task_id,
@@ -218,7 +234,7 @@ class TestFileHistoryWithCoordinator:
             "status": "running",
         })
 
-        fh_dir = tmp_path / "fh_test" / "checkpoints" / task_id / "file-history"
+        fh_dir = tmp_path / task_id / "file-history"
         fh = FileHistoryManager(fh_dir)
 
         # Track a file edit

--- a/tests/agent_test/test_checkpoint_interrupt_resume.sh
+++ b/tests/agent_test/test_checkpoint_interrupt_resume.sh
@@ -18,11 +18,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$PROJECT_ROOT"
 
-PYTHON=".venv/bin/python"
-LRUN="$PYTHON -m src"
+LRUN=".venv/bin/loom"
 TEST_DIR="/tmp/agentloom_checkpoint_test"
 MULTI_DIR="/tmp/agentloom_ckpt_multi"
-RUNTIME_DIR=".runtime"
+RUNTIME_DIR=".agentloom"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -34,16 +33,33 @@ fail_count=0
 
 log_pass() {
     echo -e "${GREEN}✓ PASS${NC}: $1"
-    ((pass_count++))
+    pass_count=$((pass_count + 1))
 }
 
 log_fail() {
     echo -e "${RED}✗ FAIL${NC}: $1"
-    ((fail_count++))
+    fail_count=$((fail_count + 1))
 }
 
 log_info() {
     echo -e "${YELLOW}→${NC} $1"
+}
+
+run_with_deadline() {
+    local seconds="$1"
+    shift
+    "$@" &
+    local pid=$!
+    local deadline=$((SECONDS + seconds))
+    while kill -0 "$pid" 2>/dev/null; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            kill -TERM "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            return 124
+        fi
+        sleep 1
+    done
+    wait "$pid"
 }
 
 cleanup() {
@@ -60,7 +76,7 @@ test_single_agent_interrupt() {
 
     # Run the checkpoint test agent in background
     log_info "Starting agent (will interrupt after 30s)..."
-    $LRUN run applications/test_demo/workflows/test_checkpoint_agent.yaml --log-to-file &
+    $LRUN run applications/test_demo/workflows/test_checkpoint_agent.yaml &
     AGENT_PID=$!
 
     # Wait up to 30 seconds, then send SIGINT (Ctrl-C)
@@ -74,11 +90,11 @@ test_single_agent_interrupt() {
     fi
 
     # Check checkpoint was saved
-    CKPT_DIR=$(find "$RUNTIME_DIR/test_checkpoint/checkpoints" -maxdepth 1 -type d -name "task_*" 2>/dev/null | head -1)
+    CKPT_DIR=$(ls -dt "$RUNTIME_DIR/checkpoints/test_demo"/task_* 2>/dev/null | head -1 || true)
     if [ -n "$CKPT_DIR" ]; then
         log_pass "Checkpoint directory created: $CKPT_DIR"
     else
-        log_fail "No checkpoint directory found under $RUNTIME_DIR/test_checkpoint/"
+        log_fail "No checkpoint directory found under $RUNTIME_DIR/checkpoints/test_demo/"
         return
     fi
 
@@ -129,8 +145,13 @@ test_single_agent_resume() {
     fi
 
     log_info "Resuming task $TASK_ID..."
-    # Run with timeout — should complete faster since some steps are already done
-    timeout 120 $LRUN run applications/test_demo/workflows/test_checkpoint_agent.yaml --resume "$TASK_ID" --log-to-file || true
+    # Resume must actually exit successfully; a timeout or CLI error is a test failure.
+    if run_with_deadline 120 "$LRUN" run applications/test_demo/workflows/test_checkpoint_agent.yaml --resume "$TASK_ID"; then
+        log_pass "Resume command completed successfully"
+    else
+        log_fail "Resume command failed or timed out"
+        return
+    fi
 
     # Check that the agent produced output files
     if [ -f "$TEST_DIR/step1.txt" ]; then
@@ -168,7 +189,7 @@ test_multi_agent_interrupt_resume() {
 
     # Run supervisor in background
     log_info "Starting supervisor agent (will interrupt after 45s)..."
-    $LRUN run applications/test_demo/workflows/test_checkpoint_supervisor.yaml --log-to-file &
+    $LRUN run applications/test_demo/workflows/test_checkpoint_supervisor.yaml &
     AGENT_PID=$!
 
     # Wait longer for multi-agent (worker needs time too)
@@ -182,7 +203,7 @@ test_multi_agent_interrupt_resume() {
     fi
 
     # Check checkpoint
-    SUP_CKPT_DIR=$(find "$RUNTIME_DIR/test_checkpoint_supervisor/checkpoints" -maxdepth 1 -type d -name "task_*" 2>/dev/null | head -1)
+    SUP_CKPT_DIR=$(ls -dt "$RUNTIME_DIR/checkpoints/test_demo"/task_* 2>/dev/null | head -1 || true)
     if [ -n "$SUP_CKPT_DIR" ]; then
         log_pass "Supervisor checkpoint directory created: $SUP_CKPT_DIR"
         SUP_TASK_ID=$(basename "$SUP_CKPT_DIR")
@@ -202,7 +223,12 @@ test_multi_agent_interrupt_resume() {
 
     # Resume
     log_info "Resuming supervisor task $SUP_TASK_ID..."
-    timeout 120 $LRUN run applications/test_demo/workflows/test_checkpoint_supervisor.yaml --resume "$SUP_TASK_ID" --log-to-file || true
+    if run_with_deadline 120 "$LRUN" run applications/test_demo/workflows/test_checkpoint_supervisor.yaml --resume "$SUP_TASK_ID"; then
+        log_pass "Supervisor resume completed successfully"
+    else
+        log_fail "Supervisor resume failed or timed out"
+        return
+    fi
 
     # Check final output
     if [ -f "$MULTI_DIR/output.txt" ]; then

--- a/tests/agent_test/test_config_validation_new_fields.py
+++ b/tests/agent_test/test_config_validation_new_fields.py
@@ -2,12 +2,17 @@
 
 import pytest
 
+from src.lib.config.config import (
+    _reject_application_global_only_keys,
+    extract_workflow_overlay,
+)
 from src.lib.config.config_validation import (
+    LoggingSettings,
     RootSettings,
+    RuntimeSettings,
     ToolAccessControlSettings,
     validate_system_snapshot,
 )
-
 
 # ===========================================================================
 # tool_metadata field
@@ -113,6 +118,37 @@ class TestMissingFieldsDefault:
         assert settings.context_engine == {}
         assert settings.tools == []
 
+    def test_runtime_storage_defaults_are_bounded(self):
+        settings = RootSettings()
+        assert settings.runtime == RuntimeSettings(root_dir=".agentloom")
+        assert settings.logging == LoggingSettings()
+        assert settings.logging.max_file_bytes == 25 * 1024 * 1024
+        assert settings.logging.backup_count == 3
+
+    def test_runtime_and_logging_accept_only_canonical_keys(self):
+        settings = RootSettings(
+            runtime={"root_dir": "/var/lib/agentloom"},
+            logging={
+                "level": "DEBUG",
+                "console_enabled": False,
+                "file_enabled": False,
+                "max_file_bytes": 1024,
+                "backup_count": 1,
+            },
+        )
+        assert settings.runtime.root_dir == "/var/lib/agentloom"
+        assert settings.logging.level == "DEBUG"
+        assert settings.logging.file_enabled is False
+
+    @pytest.mark.parametrize("legacy_key", ["enabled", "dir", "file_path"])
+    def test_legacy_logging_keys_are_rejected(self, legacy_key: str):
+        with pytest.raises(ValueError, match=legacy_key):
+            RootSettings(logging={legacy_key: True})
+
+    def test_automatic_runtime_cleanup_cannot_run_more_often_than_daily(self):
+        with pytest.raises(ValueError, match="greater than or equal to 24"):
+            RootSettings(runtime={"cleanup_interval_hours": 23})
+
     def test_smart_summary_defaults_true(self):
         settings = RootSettings()
         assert settings.smart_summary is True
@@ -201,3 +237,31 @@ class TestValidateSystemSnapshot:
     def test_snapshot_empty_passes(self):
         """An empty snapshot should be valid."""
         validate_system_snapshot({}, "test")
+
+    def test_snapshot_rejects_legacy_self_learning_root(self):
+        with pytest.raises(ValueError, match="self_learning.root_dir"):
+            validate_system_snapshot(
+                {"self_learning": {"root_dir": "/tmp/split-runtime"}},
+                "test",
+            )
+
+
+@pytest.mark.parametrize("key", ["runtime", "logging"])
+def test_application_config_rejects_global_only_runtime_and_logging(key: str) -> None:
+    with pytest.raises(ValueError, match=rf"global-only.*{key}"):
+        _reject_application_global_only_keys(
+            {
+                key: {"root_dir": "other"},
+                "checkpoint": {"enabled": False},
+            },
+            source_name="app/config/system.yaml",
+        )
+
+
+@pytest.mark.parametrize("key", ["runtime", "logging"])
+def test_agent_yaml_rejects_global_only_runtime_and_logging(key: str) -> None:
+    with pytest.raises(ValueError, match=rf"global-only.*{key}"):
+        extract_workflow_overlay(
+            {key: {"file_enabled": False}},
+            source_name="agent.yaml",
+        )

--- a/tests/lib_test/checkpoint/test_checkpoint_manager.py
+++ b/tests/lib_test/checkpoint/test_checkpoint_manager.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 import json
-import time
+import os
 import threading
+import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
-from src.lib.checkpoint.checkpoint_manager import CheckpointManager, list_all_tasks
-
+from src.lib.checkpoint.checkpoint_manager import (
+    CheckpointManager,
+    cleanup_expired_tasks,
+    list_all_tasks,
+)
 
 # ── fixtures ─────────────────────────────────────────────────────────────
 
@@ -18,7 +23,11 @@ from src.lib.checkpoint.checkpoint_manager import CheckpointManager, list_all_ta
 @pytest.fixture()
 def cm(tmp_path: Path) -> CheckpointManager:
     """A CheckpointManager rooted in a temp directory."""
-    return CheckpointManager("test_supervisor", base_dir=tmp_path)
+    return CheckpointManager(
+        "test_supervisor",
+        checkpoints_root=tmp_path,
+        run_id="run_test",
+    )
 
 
 @pytest.fixture()
@@ -166,6 +175,43 @@ class TestTaskEvents:
         assert loaded["task_id"] == task_id
         assert loaded["agent_name"] == "test_supervisor"
 
+    def test_invalid_utf8_event_tail_preserves_complete_events(self, cm: CheckpointManager):
+        task_id = "task_invalid_utf8_tail"
+        cm.record_task_created(
+            task_id,
+            yaml_path="app.yaml",
+            agent_name="test_supervisor",
+            task_text="中文任务",
+            created_at="2026-06-15T12:00:00+08:00",
+        )
+        event_path = cm._task_events_path(task_id)
+        with event_path.open("ab") as stream:
+            stream.write(b'{"type":"task_status_changed","result":"\xe4')
+
+        loaded = cm.load_task_tree(task_id)
+
+        assert loaded is not None
+        assert loaded["task_id"] == task_id
+        assert loaded["task_text"] == "中文任务"
+
+    def test_valid_event_after_invalid_utf8_tail_is_recovered(self, cm: CheckpointManager):
+        task_id = "task_invalid_utf8_then_append"
+        event_path = cm._task_events_path(task_id)
+        event_path.parent.mkdir(parents=True, exist_ok=True)
+        event_path.write_bytes(b'{"type":"task_created","task_id":"broken\xe4')
+
+        cm.record_task_created(
+            task_id,
+            yaml_path="app.yaml",
+            agent_name="test_supervisor",
+            task_text="recovered",
+            created_at="2026-06-15T12:00:00+08:00",
+        )
+
+        loaded = cm.load_task_tree(task_id)
+        assert loaded is not None
+        assert loaded["task_text"] == "recovered"
+
 
 # ── supervisor checkpoint ────────────────────────────────────────────────
 
@@ -173,7 +219,7 @@ class TestTaskEvents:
 class TestSupervisorCheckpoint:
 
     def test_save_load(self, cm: CheckpointManager, task_id: str):
-        from smolagents.memory import TaskStep, ActionStep
+        from smolagents.memory import ActionStep, TaskStep
         from smolagents.monitoring import Timing
         steps = [
             TaskStep(task="test task"),
@@ -194,17 +240,16 @@ class TestSupervisorCheckpoint:
     def test_load_nonexistent(self, cm: CheckpointManager, task_id: str):
         assert cm.load_supervisor_checkpoint(task_id) is None
 
-    def test_env_runtime_root_rebases_external_run_log_dir(self, monkeypatch, tmp_path):
-        runtime_root = tmp_path / "runtime"
-        external_log_dir = tmp_path / "project" / ".logs" / "test_supervisor" / "20260621_120000"
-        monkeypatch.setenv("AGENT_LOOM_RUNTIME_ROOT", str(runtime_root))
+    def test_bound_manager_rejects_a_different_task(self, tmp_path):
+        task_dir = tmp_path / "checkpoints" / "app" / "task_bound"
+        cm = CheckpointManager(
+            "test_supervisor",
+            checkpoint_dir=task_dir,
+            run_id="run_test",
+        )
 
-        cm = CheckpointManager("test_supervisor", run_log_dir=external_log_dir)
-        cm.save_task_tree("task_env_root", {"task_id": "task_env_root", "status": "running"})
-
-        expected = runtime_root / "test_supervisor" / "20260621_120000" / "checkpoints" / "task_env_root" / "task_tree.json"
-        assert expected.exists()
-        assert not (external_log_dir / "checkpoints" / "task_env_root" / "task_tree.json").exists()
+        with pytest.raises(ValueError, match="bound to task"):
+            cm.save_task_tree("task_other", {"status": "running"})
 
 
 # ── worker checkpoint ────────────────────────────────────────────────────
@@ -269,7 +314,12 @@ class TestWorkerCheckpoint:
             input_hash="same",
             task_input="normal retry",
         )
-        reused = cm.record_worker_started(
+        resumed_cm = CheckpointManager(
+            "test_supervisor",
+            checkpoint_dir=cm._task_dir(task_id),
+            run_id="run_resume",
+        )
+        reused = resumed_cm.record_worker_started(
             task_id,
             "resume_worker",
             input_hash="same",
@@ -280,7 +330,7 @@ class TestWorkerCheckpoint:
         assert c0 == 0
         assert c1 == 1
         assert reused == 0
-        calls = cm.load_task_tree(task_id)["workers"]["resume_worker"]
+        calls = resumed_cm.load_task_tree(task_id)["workers"]["resume_worker"]
         assert [c["call_index"] for c in calls] == [0, 1]
 
 
@@ -309,16 +359,29 @@ class TestListAndCleanup:
     def test_cleanup_old(self, cm: CheckpointManager):
         old_tid = "task_old"
         new_tid = "task_new"
-        cm.save_task_tree(old_tid, {"task_id": old_tid, "status": "interrupted"})
-        cm.save_task_tree(new_tid, {"task_id": new_tid, "status": "interrupted"})
+        now = datetime.now(UTC)
+        cm.save_task_tree(
+            old_tid,
+            {
+                "task_id": old_tid,
+                "status": "interrupted",
+                "created_at": (now - timedelta(seconds=100)).isoformat(),
+            },
+        )
+        cm.save_task_tree(
+            new_tid,
+            {
+                "task_id": new_tid,
+                "status": "interrupted",
+                "created_at": now.isoformat(),
+            },
+        )
 
-        # Backdate the old task directory's mtime.
-        import os
-        old_dir = cm._task_dir(old_tid)
-        old_time = time.time() - 100
-        os.utime(old_dir, (old_time, old_time))
-
-        removed = cm.cleanup_old_tasks(max_age_seconds=50)
+        removed = cleanup_expired_tasks(
+            checkpoints_root=cm._checkpoints_root,
+            max_age_seconds=50,
+            now=now,
+        )
         assert removed == 1
         assert cm.load_task_tree(old_tid) is None
         assert cm.load_task_tree(new_tid) is not None
@@ -330,12 +393,14 @@ class TestListAndCleanup:
 class TestListAllTasks:
 
     def test_scans_all_supervisors(self, tmp_path: Path):
-        cm1 = CheckpointManager("sup_a", base_dir=tmp_path)
-        cm2 = CheckpointManager("sup_b", base_dir=tmp_path)
+        app_a = tmp_path / "sup_a"
+        app_b = tmp_path / "sup_b"
+        cm1 = CheckpointManager("sup_a", checkpoints_root=app_a)
+        cm2 = CheckpointManager("sup_b", checkpoints_root=app_b)
         cm1.save_task_tree("t1", {"task_id": "t1", "agent_name": "sup_a", "status": "interrupted"})
         cm2.save_task_tree("t2", {"task_id": "t2", "agent_name": "sup_b", "status": "failed"})
 
-        all_tasks = list_all_tasks(base_dir=tmp_path)
+        all_tasks = list_all_tasks(checkpoints_root=tmp_path)
         assert len(all_tasks) == 2
         names = {t["agent_name"] for t in all_tasks}
         assert names == {"sup_a", "sup_b"}
@@ -345,6 +410,19 @@ class TestListAllTasks:
 
 
 class TestAtomicWrite:
+
+    def test_failed_replace_does_not_leave_temporary_file(self, tmp_path, monkeypatch):
+        target = tmp_path / "task_tree.json"
+
+        def fail_replace(*_args, **_kwargs):
+            raise OSError("replace failed")
+
+        monkeypatch.setattr(os, "replace", fail_replace)
+
+        with pytest.raises(OSError, match="replace failed"):
+            CheckpointManager._atomic_write(target, {"status": "running"})
+
+        assert list(tmp_path.glob("*.tmp")) == []
 
     def test_concurrent_writes(self, cm: CheckpointManager, task_id: str):
         """Multiple threads writing the same tree should not corrupt the file."""

--- a/tests/lib_test/checkpoint/test_checkpoint_resume.py
+++ b/tests/lib_test/checkpoint/test_checkpoint_resume.py
@@ -6,24 +6,28 @@ between ``RoleDrivenAgent``, ``CheckpointManager``, and ``run_app()``.
 
 from __future__ import annotations
 
-import textwrap
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from src.lib.checkpoint import CheckpointManager, CheckpointSerializer
 from src.lib.checkpoint.coordinator import CheckpointCoordinator
 
-
 # ── fixtures ─────────────────────────────────────────────────────────────
 
 
 @pytest.fixture()
 def cm(tmp_path: Path) -> CheckpointManager:
-    return CheckpointManager("test_supervisor", base_dir=tmp_path)
+    return CheckpointManager(
+        "test_supervisor",
+        checkpoints_root=tmp_path,
+        run_id="run_test",
+    )
 
 
 @pytest.fixture()
@@ -31,14 +35,43 @@ def task_id() -> str:
     return "task_resume_test"
 
 
+class _StepCallbacks:
+    def __init__(self) -> None:
+        self.callbacks = []
+
+    def register(self, step_type, callback) -> None:
+        self.callbacks.append((step_type, callback))
+
+
 # ── Supervisor checkpoint save ───────────────────────────────────────────
 
 
 class TestSupervisorCheckpointSave:
 
+    def test_completed_step_identity_not_step_number_controls_deduplication(self):
+        """A resumed run may restart step numbering at one."""
+        from smolagents.memory import ActionStep
+        from smolagents.monitoring import Timing
+
+        from src.lib.checkpoint.coordinator import _steps_including_completed
+
+        previous = ActionStep(
+            step_number=1,
+            timing=Timing(start_time=time.time()),
+            observations="previous attempt",
+        )
+        current = ActionStep(
+            step_number=1,
+            timing=Timing(start_time=time.time()),
+            observations="resumed attempt",
+        )
+
+        assert _steps_including_completed([previous], previous) == [previous]
+        assert _steps_including_completed([previous], current) == [previous, current]
+
     def test_save_on_completed(self, cm: CheckpointManager, task_id: str):
         """After a successful run, checkpoint is saved with status=completed."""
-        from smolagents.memory import TaskStep, ActionStep
+        from smolagents.memory import ActionStep, TaskStep
         from smolagents.monitoring import Timing
 
         steps = [
@@ -53,7 +86,7 @@ class TestSupervisorCheckpointSave:
         assert loaded["result"] == "done"
 
     def test_save_on_interrupted(self, cm: CheckpointManager, task_id: str):
-        from smolagents.memory import TaskStep, ActionStep
+        from smolagents.memory import ActionStep, TaskStep
         from smolagents.monitoring import Timing
 
         steps = [
@@ -69,6 +102,89 @@ class TestSupervisorCheckpointSave:
         tree = cm.load_task_tree(task_id)
         assert tree["status"] == "interrupted"
 
+    def test_step_callback_persists_completed_step_before_memory_append(
+        self,
+        cm: CheckpointManager,
+        task_id: str,
+    ):
+        """smolagents calls callbacks before appending the completed step."""
+        from smolagents.memory import ActionStep, TaskStep
+        from smolagents.monitoring import Timing
+
+        task_step = TaskStep(task="do work")
+        previous_step = ActionStep(
+            step_number=1,
+            timing=Timing(start_time=time.time()),
+            observations="previous attempt",
+        )
+        action_step = ActionStep(
+            # smolagents restarts numbering for a resumed run.
+            step_number=1,
+            timing=Timing(start_time=time.time()),
+            observations="side effect complete",
+        )
+        callbacks = _StepCallbacks()
+        inner = SimpleNamespace(
+            memory=SimpleNamespace(steps=[task_step, previous_step]),
+            step_callbacks=callbacks,
+        )
+        coord = CheckpointCoordinator(cm, task_id, "do work")
+        heartbeat = MagicMock()
+        file_history = MagicMock()
+        coord.set_supervisor_heartbeat(heartbeat)
+        coord._file_history = file_history
+        coord.register_supervisor_step_callback(inner)
+
+        callback = callbacks.callbacks[0][1]
+        callback(action_step, agent=inner)
+
+        loaded = cm.load_supervisor_checkpoint(task_id)
+        restored = CheckpointSerializer.deserialize_memory_steps(loaded["memory_steps"])
+        assert loaded["step_count"] == 3
+        assert restored[-1].observations == "side effect complete"
+        heartbeat.update_step.assert_called_with(3)
+        file_history.make_post_step_snapshot.assert_called_with(3)
+
+        # Also tolerate callback timing where the framework has already
+        # appended the same step; the checkpoint must not duplicate it.
+        inner.memory.steps.append(action_step)
+        callback(action_step, agent=inner)
+        assert cm.load_supervisor_checkpoint(task_id)["step_count"] == 3
+
+    def test_inherited_supervisor_callback_does_not_store_worker_step(
+        self,
+        cm: CheckpointManager,
+        task_id: str,
+    ):
+        from smolagents.memory import ActionStep, TaskStep
+        from smolagents.monitoring import Timing
+
+        supervisor_callbacks = _StepCallbacks()
+        supervisor = SimpleNamespace(
+            memory=SimpleNamespace(steps=[TaskStep(task="supervise")]),
+            step_callbacks=supervisor_callbacks,
+        )
+        worker_callbacks = _StepCallbacks()
+        worker = SimpleNamespace(
+            memory=SimpleNamespace(steps=[TaskStep(task="work")]),
+            step_callbacks=worker_callbacks,
+        )
+        worker_step = ActionStep(
+            step_number=1,
+            timing=Timing(start_time=time.time()),
+            observations="worker-only result",
+        )
+        coord = CheckpointCoordinator(cm, task_id, "supervise")
+        coord.register_supervisor_step_callback(supervisor)
+        coord.register_worker_step_callback(worker)
+
+        inherited_callback = worker_callbacks.callbacks[0][1]
+        inherited_callback(worker_step, agent=worker)
+
+        loaded = cm.load_supervisor_checkpoint(task_id)
+        assert loaded["step_count"] == 1
+        assert "worker-only result" not in str(loaded["memory_steps"])
+
 
 # ── Supervisor checkpoint restore ────────────────────────────────────────
 
@@ -77,7 +193,7 @@ class TestSupervisorRestore:
 
     def test_restore_memory_steps(self, cm: CheckpointManager, task_id: str):
         """Deserialised memory steps should match the originals."""
-        from smolagents.memory import TaskStep, ActionStep, ToolCall
+        from smolagents.memory import ActionStep, TaskStep, ToolCall
         from smolagents.monitoring import Timing
 
         original_steps = [
@@ -105,7 +221,7 @@ class TestSupervisorRestore:
 class TestWorkerRestore:
 
     def test_restore_worker_memory_steps_for_incomplete_resumed_call(self, cm: CheckpointManager, task_id: str):
-        from smolagents.memory import TaskStep, ActionStep
+        from smolagents.memory import ActionStep, TaskStep
         from smolagents.monitoring import Timing
 
         steps = [
@@ -140,7 +256,7 @@ class TestWorkerRestore:
 
     def test_drops_incomplete_last_action(self, cm: CheckpointManager, task_id: str):
         """An interrupted ActionStep (tool_calls but no observations) should be dropped."""
-        from smolagents.memory import TaskStep, ActionStep, ToolCall
+        from smolagents.memory import ActionStep, TaskStep, ToolCall
         from smolagents.monitoring import Timing
 
         steps = [
@@ -179,6 +295,140 @@ class TestWorkerRestore:
 
 class TestWorkerCheckpoint:
 
+    def test_parallel_same_name_workers_bind_trackers_and_share_one_heartbeat(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        """Same-name batch calls keep per-invocation trackers and one writer."""
+
+        start_barrier = threading.Barrier(2)
+
+        class _CheckpointManager:
+            run_id = "run_parallel"
+
+            def __init__(self):
+                self._index = 0
+                self._index_lock = threading.Lock()
+
+            def worker_dir(self, task_id, agent_name):
+                return tmp_path / task_id / "workers" / agent_name
+
+            def prepare_worker_call(self, *args, **kwargs):
+                with self._index_lock:
+                    call_index = self._index
+                    self._index += 1
+                if call_index < 2:
+                    start_barrier.wait(timeout=2)
+                return SimpleNamespace(
+                    call_index=call_index,
+                    should_execute=True,
+                    cached_result=None,
+                )
+
+            def directory_storage(self, *args, **kwargs):
+                return object()
+
+        heartbeat_instances = []
+        heartbeat_instances_lock = threading.Lock()
+
+        class _Heartbeat:
+            def __init__(self, **kwargs):
+                # Let the old unlocked get/create sequence overlap so this
+                # regression deterministically observes duplicate writers.
+                time.sleep(0.05)
+                self._calls = {}
+                self._lock = threading.Lock()
+                self.start_count = 0
+                self.stop_count = 0
+                with heartbeat_instances_lock:
+                    heartbeat_instances.append(self)
+
+            def register_call(self, call_index):
+                with self._lock:
+                    self._calls[call_index] = "running"
+
+            def start(self):
+                self.start_count += 1
+
+            def update_call_status(self, call_index, status):
+                with self._lock:
+                    self._calls[call_index] = status
+
+            def all_calls_terminal(self):
+                with self._lock:
+                    return bool(self._calls) and all(
+                        status in {"completed", "failed"}
+                        for status in self._calls.values()
+                    )
+
+            def stop(self):
+                self.stop_count += 1
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "src.lib.checkpoint.coordinator.WorkerHeartbeat",
+            _Heartbeat,
+        )
+
+        manager = _CheckpointManager()
+        coord = CheckpointCoordinator(manager, "task_parallel", "supervise")
+        coord._step_cb = lambda *args, **kwargs: None
+        workers = [
+            SimpleNamespace(
+                memory=SimpleNamespace(steps=[]),
+                step_callbacks=_StepCallbacks(),
+            )
+            for _ in range(2)
+        ]
+
+        def _start(runtime_agent, input_hash):
+            coord.register_worker_step_callback(runtime_agent, "worker_a")
+            return coord.prepare_worker_call(
+                "worker_a",
+                input_hash,
+                input_hash,
+                runtime_agent=runtime_agent,
+            ).call_index
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(_start, worker, f"hash-{index}")
+                for index, worker in enumerate(workers)
+            ]
+            call_indexes = {future.result(timeout=3) for future in futures}
+
+        assert call_indexes == {0, 1}
+        assert [len(worker.step_callbacks.callbacks) for worker in workers] == [2, 2]
+        assert len(heartbeat_instances) == 1
+        heartbeat = heartbeat_instances[0]
+        assert set(heartbeat._calls) == {0, 1}
+
+        coord._update_worker_heartbeat("worker_a", 0, "completed")
+        assert heartbeat.stop_count == 0
+        coord._update_worker_heartbeat("worker_a", 1, "completed")
+        assert heartbeat.stop_count == 1
+
+        # A later sequential call reuses and restarts the same writer.
+        later_worker = SimpleNamespace(
+            memory=SimpleNamespace(steps=[]),
+            step_callbacks=_StepCallbacks(),
+        )
+        coord.register_worker_step_callback(later_worker, "worker_a")
+        assert coord.prepare_worker_call(
+            "worker_a",
+            "hash-2",
+            "third",
+            runtime_agent=later_worker,
+        ).call_index == 2
+        assert len(heartbeat_instances) == 1
+        assert heartbeat.start_count == 3
+        assert len(later_worker.step_callbacks.callbacks) == 2
+
+        coord.stop_all_worker_heartbeats()
+
     def test_worker_completed_in_tree(self, cm: CheckpointManager, task_id: str):
         cm.save_task_tree(task_id, {"task_id": task_id, "status": "running", "agent_name": "sup", "workers": {}})
         cm.save_worker_checkpoint(task_id, "scan_worker", status="completed", result="42 files")
@@ -195,6 +445,87 @@ class TestWorkerCheckpoint:
         ckpt = cm.load_worker_checkpoint(task_id, "bad_worker")
         assert ckpt["status"] == "failed"
         assert ckpt["error"] == "timeout"
+
+    def test_worker_success_preserves_empty_string_result(
+        self,
+        cm: CheckpointManager,
+        task_id: str,
+    ):
+        call_index = cm.record_worker_started(
+            task_id,
+            "empty_worker",
+            input_hash="hash",
+            task_input="task",
+        )
+        coord = CheckpointCoordinator(cm, task_id, "supervise")
+
+        coord.record_worker_success(
+            "empty_worker",
+            call_index,
+            "hash",
+            "task",
+            "",
+            [],
+        )
+
+        checkpoint = cm.load_worker_checkpoint(
+            task_id,
+            "empty_worker",
+            call_index=call_index,
+        )
+        call = cm.load_task_tree(task_id)["workers"]["empty_worker"][0]
+        assert checkpoint["status"] == "completed"
+        assert checkpoint["result"] == ""
+        assert call["result"] == ""
+
+    def test_step_tracker_persists_completed_step_before_memory_append(
+        self,
+        cm: CheckpointManager,
+        task_id: str,
+    ):
+        from smolagents.memory import ActionStep, TaskStep
+        from smolagents.monitoring import Timing
+
+        task_step = TaskStep(task="worker task")
+        previous_step = ActionStep(
+            step_number=1,
+            timing=Timing(start_time=time.time()),
+            observations="previous worker attempt",
+        )
+        action_step = ActionStep(
+            # A resumed worker also restarts local step numbering.
+            step_number=1,
+            timing=Timing(start_time=time.time()),
+            observations="worker side effect complete",
+        )
+        callbacks = _StepCallbacks()
+        worker = SimpleNamespace(
+            memory=SimpleNamespace(steps=[task_step, previous_step]),
+            step_callbacks=callbacks,
+        )
+        heartbeat = MagicMock()
+        coord = CheckpointCoordinator(cm, task_id, "supervise")
+        coord._worker_heartbeats["worker_a"] = heartbeat
+        coord.register_worker_step_tracker(
+            worker,
+            "worker_a",
+            0,
+            input_hash="hash",
+            task_input="worker task",
+        )
+
+        callback = callbacks.callbacks[0][1]
+        callback(action_step, agent=worker)
+
+        loaded = cm.load_worker_checkpoint(task_id, "worker_a", call_index=0)
+        restored = CheckpointSerializer.deserialize_memory_steps(loaded["memory_steps"])
+        assert loaded["step_count"] == 3
+        assert restored[-1].observations == "worker side effect complete"
+        heartbeat.update_call_step.assert_called_with(0, 3)
+
+        worker.memory.steps.append(action_step)
+        callback(action_step, agent=worker)
+        assert cm.load_worker_checkpoint(task_id, "worker_a", call_index=0)["step_count"] == 3
 
 
 # ── Worker resume (skip completed) ──────────────────────────────────────

--- a/tests/lib_test/checkpoint/test_checkpoint_runtime_paths.py
+++ b/tests/lib_test/checkpoint/test_checkpoint_runtime_paths.py
@@ -1,0 +1,725 @@
+"""Canonical runtime-path contracts for checkpoint persistence."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import time
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.lib.checkpoint.checkpoint_manager import (
+    CheckpointManager,
+    cleanup_expired_tasks,
+    list_all_tasks,
+)
+from src.lib.checkpoint.coordinator import CheckpointCoordinator
+from src.lib.runtime import RuntimeHome
+
+
+def _context(tmp_path, *, task_id: str = "task_123", run_id: str = "run_1"):
+    return RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="tools/search",
+        task_id=task_id,
+        run_id=run_id,
+    )
+
+
+def test_checkpoint_manager_writes_only_to_canonical_task_directory(tmp_path):
+    context = _context(tmp_path)
+    manager = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+
+    manager.save_task_tree(
+        context.task_id,
+        {"task_id": context.task_id, "status": "running", "workers": {}},
+    )
+
+    assert context.task_tree_path.exists()
+    assert context.task_events_path.exists()
+    assert not list((tmp_path / ".agentloom").rglob(".task_index.json"))
+
+
+def test_resume_event_keeps_task_directory_and_records_new_run_id(tmp_path):
+    first = _context(tmp_path, run_id="run_first")
+    first_manager = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=first.checkpoint_dir,
+        run_id=first.run_id,
+    )
+    first_manager.record_task_created(
+        first.task_id,
+        yaml_path="applications/tools/search/workflows/agent.yaml",
+        agent_name="search_supervisor",
+        task_text="search",
+        created_at="2026-07-16T10:00:00+08:00",
+    )
+    first_manager.record_run_started(first.task_id)
+
+    resumed = _context(tmp_path, run_id="run_resumed")
+    resumed_manager = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=resumed.checkpoint_dir,
+        run_id=resumed.run_id,
+    )
+    resumed_manager.record_run_resumed(resumed.task_id)
+
+    events = [json.loads(line) for line in resumed.task_events_path.read_text(encoding="utf-8").splitlines()]
+    assert resumed.checkpoint_dir == first.checkpoint_dir
+    assert [(event["type"], event.get("run_id")) for event in events[-2:]] == [
+        ("run_started", "run_first"),
+        ("run_resumed", "run_resumed"),
+    ]
+    assert resumed_manager.load_task_tree(resumed.task_id)["run_id"] == "run_resumed"
+
+
+def test_checkpoint_payload_records_the_writing_run_id(tmp_path):
+    context = _context(tmp_path, run_id="run_writer")
+    manager = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+
+    manager.save_supervisor_checkpoint(
+        context.task_id,
+        memory_steps=[],
+        task_text="search",
+        status="interrupted",
+    )
+
+    checkpoint = json.loads(context.checkpoint_path.read_text(encoding="utf-8"))
+    assert checkpoint["run_id"] == "run_writer"
+
+
+def test_task_tree_projection_replacement_preserves_run_history(tmp_path):
+    context = _context(tmp_path, run_id="run_writer")
+    manager = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+    manager.record_task_created(
+        context.task_id,
+        yaml_path="agent.yaml",
+        agent_name="search_supervisor",
+        task_text="search",
+        created_at="2026-07-16T10:00:00+08:00",
+    )
+    manager.record_run_started(context.task_id)
+
+    manager.save_task_tree(
+        context.task_id,
+        {"task_id": context.task_id, "status": "interrupted", "workers": {}},
+    )
+
+    tree = manager.load_task_tree(context.task_id)
+    assert tree["run_id"] == "run_writer"
+    assert tree["runs"] == [
+        {
+            "run_id": "run_writer",
+            "event": "run_started",
+            "started_at": tree["runs"][0]["started_at"],
+        }
+    ]
+
+
+def test_list_all_tasks_scans_canonical_tree_without_indexes(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    contexts = [
+        runtime.context(application_id="alpha", task_id="task_a", run_id="run_a"),
+        runtime.context(application_id="nested/beta", task_id="task_b", run_id="run_b"),
+    ]
+    for context in contexts:
+        manager = CheckpointManager(
+            "supervisor",
+            checkpoint_dir=context.checkpoint_dir,
+            run_id=context.run_id,
+        )
+        manager.save_task_tree(
+            context.task_id,
+            {
+                "task_id": context.task_id,
+                "agent_name": context.application_id,
+                "status": "interrupted",
+                "workers": {},
+            },
+        )
+
+    tasks = list_all_tasks(checkpoints_root=runtime.root_dir / "checkpoints")
+
+    assert {task["task_id"] for task in tasks} == {"task_a", "task_b"}
+    assert {task["application_id"] for task in tasks} == {"alpha", "nested/beta"}
+
+
+def test_list_all_tasks_does_not_treat_worker_checkpoints_as_tasks(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    context = runtime.context(application_id="alpha", task_id="task_a", run_id="run_a")
+    manager = CheckpointManager(
+        "supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+    manager.save_task_tree(
+        context.task_id,
+        {
+            "task_id": context.task_id,
+            "agent_name": "supervisor",
+            "status": "interrupted",
+            "workers": {},
+        },
+    )
+    manager.save_worker_checkpoint(
+        context.task_id,
+        "worker_a",
+        call_index=0,
+        status="interrupted",
+    )
+
+    tasks = list_all_tasks(checkpoints_root=runtime.root_dir / "checkpoints")
+
+    assert [(task["application_id"], task["task_id"]) for task in tasks] == [
+        ("alpha", "task_a")
+    ]
+
+
+def test_list_all_tasks_rejects_symlinked_checkpoint_root(tmp_path):
+    external_root = tmp_path / "external"
+    manager = CheckpointManager(
+        "supervisor",
+        checkpoint_dir=external_root / "app" / "task",
+        run_id="run",
+    )
+    manager.save_task_tree(
+        "task",
+        {"task_id": "task", "status": "interrupted", "workers": {}},
+    )
+    runtime_root = tmp_path / ".agentloom"
+    runtime_root.mkdir()
+    (runtime_root / "checkpoints").symlink_to(external_root, target_is_directory=True)
+
+    assert list_all_tasks(checkpoints_root=runtime_root / "checkpoints") == []
+    assert (external_root / "app" / "task" / "task_tree.json").exists()
+
+
+def test_prepare_checkpoint_rejects_symlinked_application_component(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    external = tmp_path / "external"
+    external.mkdir()
+    checkpoints = runtime.root_dir / "checkpoints"
+    checkpoints.mkdir(parents=True)
+    (checkpoints / "app").symlink_to(external, target_is_directory=True)
+    context = runtime.context(application_id="app", task_id="task", run_id="run")
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        context.prepare_checkpoint()
+
+    assert not (external / "task").exists()
+
+
+@pytest.mark.parametrize("worker_name", ["../escaped", "../../../../escaped", "bad\\name"])
+def test_worker_checkpoint_paths_reject_unsafe_worker_names(tmp_path, worker_name):
+    context = _context(tmp_path)
+    manager = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+
+    with pytest.raises(ValueError, match="worker_name"):
+        manager.save_worker_checkpoint(
+            context.task_id,
+            worker_name,
+            call_index=0,
+            status="interrupted",
+        )
+
+
+def test_worker_heartbeat_path_rejects_unsafe_worker_name(tmp_path):
+    context = _context(tmp_path)
+    manager = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+    coordinator = CheckpointCoordinator(
+        manager,
+        context.task_id,
+        "search",
+    )
+
+    try:
+        with pytest.raises(ValueError, match="worker_name"):
+            coordinator.prepare_worker_call(
+                "../../../../escaped",
+                input_hash="hash",
+                task_input="unsafe",
+            )
+    finally:
+        coordinator.stop_all_worker_heartbeats()
+
+
+def test_deactivate_stops_worker_heartbeats_before_clearing_context(tmp_path):
+    context = _context(tmp_path)
+    manager = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+    coordinator = CheckpointCoordinator.activate(
+        manager,
+        context.task_id,
+        "search",
+    )
+
+    class _Heartbeat:
+        stopped = False
+
+        def stop(self):
+            self.stopped = True
+
+    heartbeat = _Heartbeat()
+    coordinator._worker_heartbeats["worker"] = heartbeat
+
+    CheckpointCoordinator.deactivate(coordinator)
+
+    assert heartbeat.stopped is True
+    assert coordinator._worker_heartbeats == {}
+    assert CheckpointCoordinator.current() is None
+
+
+def test_context_engine_uses_effective_application_config(tmp_path):
+    first = _context(tmp_path, task_id="task_first", run_id="run_first")
+    first_manager = CheckpointManager(
+        "supervisor",
+        checkpoint_dir=first.checkpoint_dir,
+        run_id=first.run_id,
+    )
+    first_coord = CheckpointCoordinator.activate(
+        first_manager,
+        first.task_id,
+        "task",
+        effective_config={
+            "context_engine": {
+                "min_chars": 111,
+                "store": {"max_entries": 7},
+            },
+            "checkpoint": {"max_resume_age": 30 * 86400},
+        },
+    )
+    try:
+        assert first_coord._context_engine.config.min_chars == 111
+        assert first_coord._context_engine.config.store.max_entries == 7
+        assert first_coord._context_engine.config.store.ttl_seconds == 30 * 86400
+    finally:
+        CheckpointCoordinator.deactivate(first_coord)
+
+    second = _context(tmp_path, task_id="task_second", run_id="run_second")
+    second_manager = CheckpointManager(
+        "supervisor",
+        checkpoint_dir=second.checkpoint_dir,
+        run_id=second.run_id,
+    )
+    second_coord = CheckpointCoordinator.activate(
+        second_manager,
+        second.task_id,
+        "task",
+        effective_config={
+            "context_engine": {
+                "min_chars": 222,
+                "store": {"ttl_seconds": 45},
+            },
+            "checkpoint": {"max_resume_age": 60 * 86400},
+        },
+    )
+    try:
+        assert second_coord._context_engine.config.min_chars == 222
+        assert second_coord._context_engine.config.store.ttl_seconds == 45
+    finally:
+        CheckpointCoordinator.deactivate(second_coord)
+
+
+def test_task_lease_rejects_concurrent_attempt_for_same_task(tmp_path):
+    context = _context(tmp_path)
+    first = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id="run_first",
+    )
+    second = CheckpointManager(
+        "search_supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id="run_second",
+    )
+
+    with first.task_lease():
+        with pytest.raises(RuntimeError, match="already active"):
+            with second.task_lease():
+                pass
+
+    with second.task_lease():
+        second.record_task_created(
+            context.task_id,
+            yaml_path="applications/tools/search/workflows/agent.yaml",
+            agent_name="search_supervisor",
+            task_text="search",
+            created_at="2026-07-16T10:00:00+08:00",
+        )
+
+
+def test_resume_task_lease_does_not_recreate_a_missing_checkpoint(tmp_path):
+    checkpoint_dir = tmp_path / "checkpoints" / "app" / "missing-task"
+    manager = CheckpointManager("agent", checkpoint_dir=checkpoint_dir)
+
+    with pytest.raises(FileNotFoundError):
+        manager.task_lease(require_exists=True).acquire()
+
+    assert not checkpoint_dir.exists()
+
+
+def test_checkpoint_writes_stay_on_leased_inode_after_task_path_replacement(
+    tmp_path,
+):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    first = runtime.context(
+        application_id="app",
+        task_id="task_first",
+        run_id="run_first",
+    )
+    second = runtime.context(
+        application_id="app",
+        task_id="task_second",
+        run_id="run_second",
+    )
+    first.prepare_checkpoint()
+    second.prepare_checkpoint()
+    first_manager = CheckpointManager("first", checkpoint_dir=first.checkpoint_dir)
+    second_manager = CheckpointManager("second", checkpoint_dir=second.checkpoint_dir)
+    second_manager.save_supervisor_checkpoint(
+        second.task_id,
+        memory_steps=[],
+        task_text="second",
+        status="failed",
+    )
+    detached = first.checkpoint_dir.parent / "task_first_detached"
+
+    with first_manager.task_lease():
+        first.checkpoint_dir.rename(detached)
+        first.checkpoint_dir.symlink_to(second.checkpoint_dir, target_is_directory=True)
+        first_manager.save_supervisor_checkpoint(
+            first.task_id,
+            memory_steps=[],
+            task_text="FIRST-SECRET",
+            status="interrupted",
+        )
+
+    second_payload = json.loads(second.checkpoint_path.read_text(encoding="utf-8"))
+    first_payload = json.loads((detached / "checkpoint.json").read_text(encoding="utf-8"))
+    assert second_payload["task_text"] == "second"
+    assert first_payload["task_text"] == "FIRST-SECRET"
+
+
+def test_expired_cleanup_preserves_task_with_active_attempt_lease(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    context = runtime.context(
+        application_id="alpha",
+        task_id="task_active",
+        run_id="run_active",
+    )
+    manager = CheckpointManager(
+        "supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+    manager.save_task_tree(
+        context.task_id,
+        {
+            "task_id": context.task_id,
+            "status": "failed",
+            "created_at": (datetime.now(UTC) - timedelta(days=30)).isoformat(),
+            "workers": {},
+        },
+    )
+
+    with manager.task_lease():
+        removed = cleanup_expired_tasks(
+            checkpoints_root=runtime.root_dir / "checkpoints",
+            max_age_seconds=7 * 86400,
+        )
+
+    assert removed == 0
+    assert context.checkpoint_dir.exists()
+
+
+def test_cleanup_expired_tasks_uses_logical_age_and_preserves_live_task(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    old = (datetime.now(UTC) - timedelta(days=8)).isoformat()
+    fresh = datetime.now(UTC).isoformat()
+    contexts = {
+        "expired": runtime.context(application_id="app", task_id="expired", run_id="run_old"),
+        "fresh": runtime.context(application_id="app", task_id="fresh", run_id="run_new"),
+        "live": runtime.context(application_id="app", task_id="live", run_id="run_live"),
+    }
+    for name, context in contexts.items():
+        manager = CheckpointManager(
+            "supervisor",
+            checkpoint_dir=context.checkpoint_dir,
+            run_id=context.run_id,
+        )
+        manager.save_task_tree(
+            context.task_id,
+            {
+                "task_id": context.task_id,
+                "status": "running" if name == "live" else "failed",
+                "created_at": fresh if name == "fresh" else old,
+                "workers": {},
+            },
+        )
+    contexts["live"].heartbeat_path.write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "timestamp": time.time(),
+                "status": "running",
+                "run_id": contexts["live"].run_id,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    removed = cleanup_expired_tasks(
+        checkpoints_root=runtime.root_dir / "checkpoints",
+        max_age_seconds=7 * 86400,
+    )
+
+    assert removed == 1
+    assert not contexts["expired"].checkpoint_dir.exists()
+    assert contexts["fresh"].checkpoint_dir.exists()
+    assert contexts["live"].checkpoint_dir.exists()
+
+
+def test_application_cleanup_does_not_recurse_into_nested_application(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    now = datetime.now(UTC)
+    contexts = [
+        runtime.context(application_id="foo", task_id="task_foo", run_id="run_foo"),
+        runtime.context(
+            application_id="foo/bar",
+            task_id="task_bar",
+            run_id="run_bar",
+        ),
+    ]
+    for context in contexts:
+        manager = CheckpointManager(
+            "supervisor",
+            checkpoint_dir=context.checkpoint_dir,
+            run_id=context.run_id,
+        )
+        manager.save_task_tree(
+            context.task_id,
+            {
+                "task_id": context.task_id,
+                "status": "failed",
+                "created_at": (now - timedelta(days=2)).isoformat(),
+                "workers": {},
+            },
+        )
+
+    removed = cleanup_expired_tasks(
+        checkpoints_root=contexts[0].checkpoint_dir.parent,
+        max_age_seconds=86400,
+        now=now,
+        recursive=False,
+    )
+
+    assert removed == 1
+    assert not contexts[0].checkpoint_dir.exists()
+    assert contexts[1].checkpoint_dir.exists()
+
+
+def test_cleanup_expired_tasks_preserves_terminal_task_with_live_heartbeat(tmp_path):
+    """The heartbeat is authoritative even if the task projection lags behind."""
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    context = runtime.context(application_id="app", task_id="active", run_id="run_active")
+    manager = CheckpointManager(
+        "supervisor",
+        checkpoint_dir=context.checkpoint_dir,
+        run_id=context.run_id,
+    )
+    manager.save_task_tree(
+        context.task_id,
+        {
+            "task_id": context.task_id,
+            "status": "failed",
+            "created_at": (datetime.now(UTC) - timedelta(days=30)).isoformat(),
+            "workers": {},
+        },
+    )
+    context.heartbeat_path.write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "timestamp": time.time(),
+                "status": "running",
+                "run_id": context.run_id,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    removed = cleanup_expired_tasks(
+        checkpoints_root=runtime.root_dir / "checkpoints",
+        max_age_seconds=7 * 86400,
+    )
+
+    assert removed == 0
+    assert context.checkpoint_dir.exists()
+
+
+@pytest.mark.parametrize("max_age_seconds", [0, -1])
+def test_cleanup_expired_tasks_non_positive_ttl_disables_cleanup(
+    tmp_path,
+    max_age_seconds,
+):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    context = runtime.context(application_id="app", task_id="keep", run_id="run_keep")
+    manager = CheckpointManager("supervisor", checkpoint_dir=context.checkpoint_dir)
+    manager.save_task_tree(
+        context.task_id,
+        {
+            "task_id": context.task_id,
+            "status": "failed",
+            "created_at": (datetime.now(UTC) - timedelta(days=365)).isoformat(),
+            "workers": {},
+        },
+    )
+
+    removed = cleanup_expired_tasks(
+        checkpoints_root=runtime.root_dir / "checkpoints",
+        max_age_seconds=max_age_seconds,
+    )
+
+    assert removed == 0
+    assert context.checkpoint_dir.exists()
+
+
+def test_cleanup_expired_tasks_accepts_one_crash_truncated_event_tail(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    context = runtime.context(application_id="app", task_id="damaged", run_id="run_damaged")
+    manager = CheckpointManager("supervisor", checkpoint_dir=context.checkpoint_dir)
+    manager.record_task_created(
+        context.task_id,
+        yaml_path="agent.yaml",
+        agent_name="supervisor",
+        task_text="task",
+        created_at=(datetime.now(UTC) - timedelta(days=30)).isoformat(),
+    )
+    manager.record_task_status_changed(context.task_id, "failed")
+    with context.task_events_path.open("a", encoding="utf-8") as stream:
+        stream.write('{"type": "run_resumed"')
+
+    removed = cleanup_expired_tasks(
+        checkpoints_root=runtime.root_dir / "checkpoints",
+        max_age_seconds=7 * 86400,
+    )
+
+    assert removed == 1
+    assert not context.checkpoint_dir.exists()
+
+
+def test_cleanup_expired_tasks_ignores_stale_framework_temp_files(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    context = runtime.context(
+        application_id="app",
+        task_id="stale-temp",
+        run_id="run",
+    )
+    manager = CheckpointManager("agent", checkpoint_dir=context.checkpoint_dir)
+    manager.save_task_tree(
+        context.task_id,
+        {
+            "task_id": context.task_id,
+            "agent_name": "agent",
+            "status": "failed",
+            "created_at": "2020-01-01T00:00:00+00:00",
+        },
+    )
+    (context.checkpoint_dir / "checkpoint.dead.tmp").write_text("partial")
+
+    removed = cleanup_expired_tasks(
+        checkpoints_root=runtime.checkpoints_root,
+        max_age_seconds=7 * 86400,
+        now=datetime(2026, 7, 16, tzinfo=UTC),
+    )
+
+    assert removed == 1
+    assert not context.checkpoint_dir.exists()
+
+
+def test_cleanup_expired_tasks_never_uses_checkpoint_saved_at_as_task_age(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    context = runtime.context(application_id="app", task_id="no_anchor", run_id="run_old")
+    context.checkpoint_dir.mkdir(parents=True)
+    context.checkpoint_path.write_text(
+        json.dumps(
+            {
+                "task_id": context.task_id,
+                "agent_name": "supervisor",
+                "status": "failed",
+                "saved_at": (datetime.now(UTC) - timedelta(days=30)).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    removed = cleanup_expired_tasks(
+        checkpoints_root=runtime.root_dir / "checkpoints",
+        max_age_seconds=7 * 86400,
+    )
+
+    assert removed == 0
+    assert context.checkpoint_dir.exists()
+
+
+@pytest.mark.parametrize("max_age_seconds", [float("nan"), float("inf")])
+def test_cleanup_expired_tasks_rejects_non_finite_ttl(tmp_path, max_age_seconds):
+    with pytest.raises(ValueError, match="finite"):
+        cleanup_expired_tasks(
+            checkpoints_root=tmp_path / "checkpoints",
+            max_age_seconds=max_age_seconds,
+        )
+
+
+def test_cleanup_expired_tasks_skips_when_another_cleaner_holds_root_lock(tmp_path):
+    runtime = RuntimeHome(tmp_path / ".agentloom")
+    context = runtime.context(application_id="app", task_id="expired", run_id="run_old")
+    manager = CheckpointManager("supervisor", checkpoint_dir=context.checkpoint_dir)
+    manager.save_task_tree(
+        context.task_id,
+        {
+            "task_id": context.task_id,
+            "status": "failed",
+            "created_at": (datetime.now(UTC) - timedelta(days=30)).isoformat(),
+            "workers": {},
+        },
+    )
+
+    checkpoints_root = runtime.root_dir / "checkpoints"
+    lock_fd = os.open(checkpoints_root, os.O_RDONLY)
+    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        removed = cleanup_expired_tasks(
+            checkpoints_root=checkpoints_root,
+            max_age_seconds=7 * 86400,
+        )
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+    assert removed == 0
+    assert context.checkpoint_dir.exists()

--- a/tests/lib_test/checkpoint/test_checkpoint_serializer.py
+++ b/tests/lib_test/checkpoint/test_checkpoint_serializer.py
@@ -11,7 +11,6 @@ from smolagents.monitoring import Timing, TokenUsage
 
 from src.lib.checkpoint.serializer import CheckpointSerializer
 
-
 # ── helpers ──────────────────────────────────────────────────────────────
 
 def _make_timing(dur: float = 1.0) -> Timing:

--- a/tests/lib_test/checkpoint/test_cli_checkpoint.py
+++ b/tests/lib_test/checkpoint/test_cli_checkpoint.py
@@ -9,21 +9,33 @@ from click.testing import CliRunner
 
 from src.__main__ import main
 from src.lib.checkpoint.checkpoint_manager import CheckpointManager
+from src.lib.runtime import RuntimeHome
 
 
 @pytest.fixture()
 def populated_runtime(tmp_path: Path, monkeypatch):
     """Create a fake checkpoint dir with two checkpoints, then point the manager there."""
-    ckpt_root = tmp_path / "ckpt"
-    ckpt_root.mkdir()
-    monkeypatch.setenv("AGENT_LOOM_RUNTIME_ROOT", str(ckpt_root))
+    runtime_root = tmp_path / ".agentloom"
+    ckpt_root = runtime_root / "checkpoints"
+    monkeypatch.setattr(
+        "src.__main__._configured_runtime_home",
+        lambda: RuntimeHome(runtime_root),
+    )
 
-    cm1 = CheckpointManager("agent_a", base_dir=ckpt_root)
+    cm1 = CheckpointManager(
+        "agent_a",
+        checkpoint_dir=ckpt_root / "app_a" / "t1",
+        run_id="run_a",
+    )
     cm1.save_task_tree("t1", {"task_id": "t1", "agent_name": "agent_a", "status": "interrupted", "created_at": "2026-03-31T10:00:00Z"})
     c0 = cm1.record_worker_started("t1", "worker_a", input_hash="h", task_input="input")
     cm1.record_worker_finished("t1", "worker_a", call_index=c0, status="completed", result="done")
 
-    cm2 = CheckpointManager("agent_b", base_dir=ckpt_root)
+    cm2 = CheckpointManager(
+        "agent_b",
+        checkpoint_dir=ckpt_root / "app_b" / "t2",
+        run_id="run_b",
+    )
     cm2.save_task_tree("t2", {"task_id": "t2", "agent_name": "agent_b", "status": "failed", "created_at": "2026-03-31T11:00:00Z"})
 
     return tmp_path
@@ -32,13 +44,15 @@ def populated_runtime(tmp_path: Path, monkeypatch):
 class TestListTasks:
 
     def test_empty(self, tmp_path: Path, monkeypatch):
-        empty_dir = tmp_path / "empty_ckpt"
-        empty_dir.mkdir()
-        monkeypatch.setenv("AGENT_LOOM_RUNTIME_ROOT", str(empty_dir))
+        runtime_root = tmp_path / ".agentloom"
+        monkeypatch.setattr(
+            "src.__main__._configured_runtime_home",
+            lambda: RuntimeHome(runtime_root),
+        )
         runner = CliRunner()
         result = runner.invoke(main, ["list-tasks"])
         assert result.exit_code == 0
-        assert "No resumable tasks" in result.output
+        assert "No checkpoint tasks" in result.output
 
     def test_shows_entries(self, populated_runtime):
         runner = CliRunner()
@@ -67,4 +81,53 @@ class TestCleanTasks:
 
         # Verify empty
         result2 = runner.invoke(main, ["list-tasks"])
-        assert "No resumable tasks" in result2.output
+        assert "No checkpoint tasks" in result2.output
+
+    def test_clean_before_preserves_task_with_active_run_lease(self, populated_runtime):
+        task_dir = populated_runtime / ".agentloom" / "checkpoints" / "app_a" / "t1"
+        manager = CheckpointManager(
+            "agent_a",
+            checkpoint_dir=task_dir,
+            run_id="active-run",
+        )
+
+        with manager.task_lease():
+            result = CliRunner().invoke(main, ["clean-tasks", "--before", "1"])
+
+        assert result.exit_code == 0
+        assert task_dir.exists()
+        assert not (
+            populated_runtime / ".agentloom" / "checkpoints" / "app_b" / "t2"
+        ).exists()
+
+
+def test_checkpoint_cli_rejects_symlinked_runtime_root_without_deleting_external_data(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    external = tmp_path / "application-outputs"
+    task_dir = external / "checkpoints" / "app" / "task"
+    manager = CheckpointManager("agent", checkpoint_dir=task_dir)
+    manager.save_task_tree(
+        "task",
+        {
+            "task_id": "task",
+            "agent_name": "agent",
+            "status": "failed",
+            "created_at": "2020-01-01T00:00:00+00:00",
+        },
+    )
+    runtime_link = tmp_path / ".agentloom"
+    runtime_link.symlink_to(external, target_is_directory=True)
+    monkeypatch.setattr(
+        "src.__main__._configured_runtime_home",
+        lambda: RuntimeHome(runtime_link),
+    )
+
+    listed = CliRunner().invoke(main, ["list-tasks"])
+    cleaned = CliRunner().invoke(main, ["clean-tasks", "--all"])
+
+    assert listed.exit_code != 0
+    assert cleaned.exit_code != 0
+    assert "symlink" in (listed.output + cleaned.output)
+    assert task_dir.exists()

--- a/tests/lib_test/checkpoint/test_conversation_recovery.py
+++ b/tests/lib_test/checkpoint/test_conversation_recovery.py
@@ -24,7 +24,6 @@ from src.lib.checkpoint.conversation_recovery import (
     prepare_steps_for_resume,
 )
 
-
 # ---------------------------------------------------------------------------
 # Lightweight step stubs — avoid heavy smolagents import for unit tests.
 # Duck-typed to match ActionStep / TaskStep / PlanningStep attributes.

--- a/tests/lib_test/checkpoint/test_file_history.py
+++ b/tests/lib_test/checkpoint/test_file_history.py
@@ -17,10 +17,11 @@ import time
 import pytest
 
 from src.lib.checkpoint.file_history import (
+    MAX_SNAPSHOTS,
     FileHistoryManager,
     FileHistorySnapshot,
-    MAX_SNAPSHOTS,
 )
+from src.lib.runtime import RuntimeHome
 
 
 @pytest.fixture
@@ -119,6 +120,28 @@ class TestTrackEdit:
         backups = [f for f in os.listdir(backup_dir) if "@v1" in f]
         assert len(backups) == 1
         assert (backup_dir / backups[0]).read_bytes() == original_bytes
+
+    def test_backup_stays_on_original_task_inode_after_path_replacement(
+        self,
+        tmp_path,
+    ) -> None:
+        home = RuntimeHome(tmp_path / ".agentloom")
+        first = home.context(application_id="app", task_id="first", run_id="run-a")
+        second = home.context(application_id="app", task_id="second", run_id="run-b")
+        first.prepare_checkpoint()
+        second.prepare_checkpoint()
+        history = FileHistoryManager(first.file_history_dir)
+        (second.file_history_dir).mkdir()
+        source = tmp_path / "source.txt"
+        source.write_text("FIRST secret", encoding="utf-8")
+        detached = first.checkpoint_dir.parent / "first-detached"
+        first.checkpoint_dir.rename(detached)
+        first.checkpoint_dir.symlink_to(second.checkpoint_dir, target_is_directory=True)
+
+        history.track_edit(str(source), step_number=1)
+
+        assert list(second.file_history_dir.iterdir()) == []
+        assert any("@v1" in path.name for path in (detached / "file-history").iterdir())
 
     def test_different_steps_create_separate_entries(self, fh, sample_file):
         """Normal: Same file in different steps gets separate snapshot entries."""
@@ -299,6 +322,21 @@ class TestRewindToStep:
         assert os.path.exists(sample_file)
         assert open(sample_file, "rb").read() == original
 
+    def test_deleted_executable_restores_mode_and_mtime(self, fh, tmp_path):
+        executable = tmp_path / "tool.sh"
+        executable.write_text("#!/bin/sh\nprintf restored\n", encoding="utf-8")
+        executable.chmod(0o755)
+        expected_mtime_ns = 1_700_000_000_987_654_321
+        os.utime(executable, ns=(expected_mtime_ns, expected_mtime_ns))
+        fh.track_edit(str(executable), step_number=1)
+
+        executable.unlink()
+        fh.rewind_to_step(step_number=1)
+
+        restored = executable.stat()
+        assert restored.st_mode & 0o777 == 0o755
+        assert restored.st_mtime_ns == expected_mtime_ns
+
     def test_rewind_to_earlier_step_deletes_file_created_later(self, fh, sample_file, tmp_path):
         """Files first tracked as non-existent after target step are deleted on rewind."""
         fh.track_edit(sample_file, step_number=1)
@@ -399,6 +437,34 @@ class TestRestoreFromIndex:
 
         assert fh2.snapshot_count == fh.snapshot_count
         assert fh2.tracked_file_count == fh.tracked_file_count
+
+    def test_persisted_restore_stays_on_original_task_inode_after_replacement(
+        self,
+        tmp_path,
+    ) -> None:
+        home = RuntimeHome(tmp_path / ".agentloom")
+        first = home.context(application_id="app", task_id="first", run_id="run-a")
+        second = home.context(application_id="app", task_id="second", run_id="run-b")
+        first.prepare_checkpoint()
+        second.prepare_checkpoint()
+        source = tmp_path / "source.txt"
+        source.write_text("FIRST", encoding="utf-8")
+        original = FileHistoryManager(first.file_history_dir)
+        original.track_edit(str(source), step_number=1)
+        restored = FileHistoryManager(first.file_history_dir)
+        detached = first.checkpoint_dir.parent / "first-detached"
+        first.checkpoint_dir.rename(detached)
+        first.checkpoint_dir.symlink_to(second.checkpoint_dir, target_is_directory=True)
+        (second.file_history_dir).mkdir()
+        (second.file_history_dir / "snapshots.json").write_text(
+            '{"snapshots": [{"step_number": 99}], "first_tracked_backups": {}}',
+            encoding="utf-8",
+        )
+
+        assert restored.restore_persisted_index() is True
+        assert restored.snapshot_count == 1
+        with pytest.raises(ValueError, match="step_number=99"):
+            restored.rewind_to_step(99)
 
     def test_restore_empty_index(self, backup_dir):
         """Boundary: Restore from empty data."""

--- a/tests/lib_test/checkpoint/test_tree_lock.py
+++ b/tests/lib_test/checkpoint/test_tree_lock.py
@@ -6,6 +6,8 @@ from multiple worker threads do not cause data loss or corruption.
 """
 from __future__ import annotations
 
+import contextvars
+import json
 import threading
 
 import pytest
@@ -20,14 +22,22 @@ from src.lib.smolagents.hooks.types import HookEvent
 @pytest.fixture
 def cm(tmp_path):
     """Create a CheckpointManager with a temp base dir."""
-    return CheckpointManager("test_supervisor", base_dir=tmp_path)
+    return CheckpointManager(
+        "test_supervisor",
+        checkpoints_root=tmp_path,
+        run_id="run_test",
+    )
 
 
-class TestCoordinatorFallback:
-    """Tests for tool-executor contexts that do not inherit ContextVar state."""
+class TestCoordinatorContext:
+    """The coordinator is visible only through explicit ContextVar propagation."""
 
-    def test_current_visible_without_context_copy_until_deactivated(self, tmp_path):
-        cm = CheckpointManager("test_supervisor", base_dir=tmp_path)
+    def test_current_requires_context_copy_and_clears_on_deactivate(self, tmp_path):
+        cm = CheckpointManager(
+            "test_supervisor",
+            checkpoints_root=tmp_path,
+            run_id="run_test",
+        )
         coord = CheckpointCoordinator.activate(cm, "task_ctx", "task text")
 
         try:
@@ -40,7 +50,18 @@ class TestCoordinatorFallback:
             thread.start()
             thread.join(timeout=5)
 
-            assert seen == [coord]
+            assert seen == [None]
+
+            propagated_context = contextvars.copy_context()
+            seen_with_context = []
+            thread = threading.Thread(
+                target=propagated_context.run,
+                args=(lambda: seen_with_context.append(CheckpointCoordinator.current()),),
+            )
+            thread.start()
+            thread.join(timeout=5)
+
+            assert seen_with_context == [coord]
 
             CheckpointCoordinator.deactivate(coord)
             seen_after = []
@@ -55,7 +76,11 @@ class TestCoordinatorFallback:
             CheckpointCoordinator.deactivate(coord)
 
     def test_register_file_history_hook_uses_agent_hook_manager(self, tmp_path):
-        cm = CheckpointManager("test_supervisor", base_dir=tmp_path)
+        cm = CheckpointManager(
+            "test_supervisor",
+            checkpoints_root=tmp_path,
+            run_id="run_test",
+        )
         coord = CheckpointCoordinator.activate(cm, "task_ctx", "task text")
         fh = FileHistoryManager(tmp_path / "fh")
         hook_manager = HookManager()
@@ -171,6 +196,277 @@ class TestTreeLock:
         assert sorted(indexes) == list(range(worker_count))
         calls = cm.load_task_tree(task_id)["workers"]["same_worker"]
         assert [c["call_index"] for c in calls] == list(range(worker_count))
+
+    def test_concurrent_resume_claims_are_unique_across_managers(self, tmp_path):
+        """One run attempt claims each matching unfinished call at most once."""
+        task_id = "task_worker_resume_claim_race"
+        initial = CheckpointManager(
+            "test_supervisor",
+            checkpoints_root=tmp_path,
+            run_id="run_initial",
+        )
+        assert initial.record_worker_started(
+            task_id,
+            "same_worker",
+            input_hash="same-hash",
+            task_input="first",
+        ) == 0
+        assert initial.record_worker_started(
+            task_id,
+            "same_worker",
+            input_hash="same-hash",
+            task_input="second",
+        ) == 1
+
+        task_dir = tmp_path / task_id
+        managers = [
+            CheckpointManager(
+                "test_supervisor",
+                checkpoint_dir=task_dir,
+                run_id="run_resume",
+            )
+            for _ in range(2)
+        ]
+        barrier = threading.Barrier(2)
+        indexes: list[int] = []
+        errors: list[Exception] = []
+        result_lock = threading.Lock()
+
+        def claim(manager: CheckpointManager) -> None:
+            try:
+                barrier.wait(timeout=5)
+                index = manager.record_worker_started(
+                    task_id,
+                    "same_worker",
+                    input_hash="same-hash",
+                    task_input="resumed",
+                    reuse_incomplete=True,
+                )
+                with result_lock:
+                    indexes.append(index)
+            except Exception as exc:
+                with result_lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=claim, args=(manager,)) for manager in managers]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert not errors
+        assert sorted(indexes) == [0, 1]
+        tree = managers[0].load_task_tree(task_id)
+        assert [
+            call["attempt_run_id"] for call in tree["workers"]["same_worker"]
+        ] == ["run_resume", "run_resume"]
+        events = [
+            json.loads(line)
+            for line in (task_dir / "task_events.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+        claim_events = [
+            event for event in events if event.get("type") == "worker_call_resume_claimed"
+        ]
+        assert [event["call_index"] for event in claim_events] == [0, 1]
+        assert {event["run_id"] for event in claim_events} == {"run_resume"}
+
+        # Claims belong to one attempt only.  A later resume can reclaim both
+        # calls in the original call_index order after the previous run dies.
+        later = CheckpointManager(
+            "test_supervisor",
+            checkpoint_dir=task_dir,
+            run_id="run_later",
+        )
+        assert [
+            later.record_worker_started(
+                task_id,
+                "same_worker",
+                input_hash="same-hash",
+                task_input="resumed again",
+                reuse_incomplete=True,
+            )
+            for _ in range(2)
+        ] == [0, 1]
+
+    def test_fresh_prepare_never_reuses_completed_result(self, tmp_path):
+        task_id = "task_fresh_does_not_cache"
+        initial = CheckpointManager(
+            "test_supervisor",
+            checkpoints_root=tmp_path,
+            run_id="run_initial",
+        )
+        call_index = initial.record_worker_started(
+            task_id,
+            "worker",
+            input_hash="same",
+            task_input="first",
+        )
+        initial.record_worker_finished(
+            task_id,
+            "worker",
+            call_index=call_index,
+            status="completed",
+            result="old-result",
+        )
+        fresh = CheckpointManager(
+            "test_supervisor",
+            checkpoint_dir=tmp_path / task_id,
+            run_id="run_fresh",
+        )
+
+        preparation = fresh.prepare_worker_call(
+            task_id,
+            "worker",
+            input_hash="same",
+            task_input="second",
+            resume=False,
+        )
+
+        assert preparation.should_execute is True
+        assert preparation.call_index == 1
+
+    @pytest.mark.parametrize("cached_result", ["", None])
+    def test_resume_prioritizes_incomplete_then_claims_falsey_cache(
+        self,
+        tmp_path,
+        cached_result,
+    ):
+        task_id = f"task_mixed_{'none' if cached_result is None else 'empty'}"
+        initial = CheckpointManager(
+            "test_supervisor",
+            checkpoints_root=tmp_path,
+            run_id="run_initial",
+        )
+        completed = initial.record_worker_started(
+            task_id,
+            "worker",
+            input_hash="same",
+            task_input="completed",
+        )
+        initial.record_worker_finished(
+            task_id,
+            "worker",
+            call_index=completed,
+            status="completed",
+            result=cached_result,
+        )
+        interrupted = initial.record_worker_started(
+            task_id,
+            "worker",
+            input_hash="same",
+            task_input="interrupted",
+        )
+        initial.record_worker_finished(
+            task_id,
+            "worker",
+            call_index=interrupted,
+            status="interrupted",
+        )
+        resumed = CheckpointManager(
+            "test_supervisor",
+            checkpoint_dir=tmp_path / task_id,
+            run_id="run_resume",
+        )
+
+        execute = resumed.prepare_worker_call(
+            task_id,
+            "worker",
+            input_hash="same",
+            task_input="retry",
+            resume=True,
+        )
+        cached = resumed.prepare_worker_call(
+            task_id,
+            "worker",
+            input_hash="same",
+            task_input="replay",
+            resume=True,
+        )
+
+        assert (execute.call_index, execute.should_execute) == (1, True)
+        assert (cached.call_index, cached.should_execute) == (0, False)
+        assert cached.cached_result == cached_result
+        calls = resumed.load_task_tree(task_id)["workers"]["worker"]
+        assert calls[0]["status"] == "completed"
+        assert calls[0]["cached_claim_run_id"] == "run_resume"
+        assert calls[1]["attempt_run_id"] == "run_resume"
+
+    def test_concurrent_mixed_same_hash_prepare_is_one_to_one(self, tmp_path):
+        task_id = "task_atomic_mixed_prepare"
+        initial = CheckpointManager(
+            "test_supervisor",
+            checkpoints_root=tmp_path,
+            run_id="run_initial",
+        )
+        completed = initial.record_worker_started(
+            task_id,
+            "worker",
+            input_hash="same",
+            task_input="completed",
+        )
+        initial.record_worker_finished(
+            task_id,
+            "worker",
+            call_index=completed,
+            status="completed",
+            result="cached",
+        )
+        interrupted = initial.record_worker_started(
+            task_id,
+            "worker",
+            input_hash="same",
+            task_input="interrupted",
+        )
+        initial.record_worker_finished(
+            task_id,
+            "worker",
+            call_index=interrupted,
+            status="interrupted",
+        )
+        managers = [
+            CheckpointManager(
+                "test_supervisor",
+                checkpoint_dir=tmp_path / task_id,
+                run_id="run_resume",
+            )
+            for _ in range(2)
+        ]
+        barrier = threading.Barrier(2)
+        preparations = []
+        errors = []
+        result_lock = threading.Lock()
+
+        def prepare(manager):
+            try:
+                barrier.wait(timeout=5)
+                result = manager.prepare_worker_call(
+                    task_id,
+                    "worker",
+                    input_hash="same",
+                    task_input="resume",
+                    resume=True,
+                )
+                with result_lock:
+                    preparations.append(result)
+            except Exception as exc:
+                with result_lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=prepare, args=(manager,)) for manager in managers]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert not errors
+        assert sorted(
+            (item.call_index, item.should_execute, item.cached_result)
+            for item in preparations
+        ) == [(0, False, "cached"), (1, True, None)]
+        calls = managers[0].load_task_tree(task_id)["workers"]["worker"]
+        assert len(calls) == 2
 
     def test_worker_finish_updates_only_matching_call(self, cm):
         """Finishing one worker call does not overwrite sibling calls."""

--- a/tests/lib_test/context_engine/test_context_engine.py
+++ b/tests/lib_test/context_engine/test_context_engine.py
@@ -1,10 +1,46 @@
 from __future__ import annotations
 
+import contextvars
+import threading
+
 from src.lib.context_engine import ContextEngine, ContextEngineConfig
 from src.lib.context_engine.compressors import compress_content
 from src.lib.context_engine.config import ContextStoreConfig
 from src.lib.context_engine.models import ContentKind
 from src.lib.context_engine.router import route_content
+from src.lib.runtime import RuntimeHome
+
+
+def test_context_engine_requires_explicit_thread_context_propagation(tmp_path):
+    from src.lib.context_engine.runtime import (
+        clear_current_context_engine,
+        get_current_context_engine,
+        set_current_context_engine,
+    )
+
+    engine = ContextEngine(tmp_path / "context_store")
+    set_current_context_engine(engine)
+    try:
+        unpropagated = []
+        thread = threading.Thread(
+            target=lambda: unpropagated.append(get_current_context_engine())
+        )
+        thread.start()
+        thread.join(timeout=5)
+
+        propagated_context = contextvars.copy_context()
+        propagated = []
+        thread = threading.Thread(
+            target=propagated_context.run,
+            args=(lambda: propagated.append(get_current_context_engine()),),
+        )
+        thread.start()
+        thread.join(timeout=5)
+
+        assert unpropagated == [None]
+        assert propagated == [engine]
+    finally:
+        clear_current_context_engine(engine)
 
 
 def test_context_engine_stores_preview_and_retrieves_original(tmp_path):
@@ -25,6 +61,30 @@ def test_context_engine_stores_preview_and_retrieves_original(tmp_path):
     ref = preview.split()[1]
     assert engine.retrieve(ref, offset=2, limit=3).splitlines()[0].startswith("line 2 ")
     assert engine.retrieve(ref, query="line 11").startswith("12: line 11 ")
+
+
+def test_context_store_stays_on_original_task_inode_after_path_replacement(
+    tmp_path,
+) -> None:
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="app", task_id="first", run_id="run-a")
+    second = home.context(application_id="app", task_id="second", run_id="run-b")
+    first.prepare_checkpoint()
+    second.prepare_checkpoint()
+    engine = ContextEngine(
+        first.context_store_dir,
+        config=ContextEngineConfig(min_chars=10, preview_max_chars=120),
+    )
+    detached = first.checkpoint_dir.parent / "first-detached"
+    first.checkpoint_dir.rename(detached)
+    first.checkpoint_dir.symlink_to(second.checkpoint_dir, target_is_directory=True)
+    original = "\n".join(f"FIRST secret line {index}" for index in range(100))
+
+    preview = engine.compress_tool_result(original, tool_name="shell_tool")
+
+    assert preview is not None
+    assert list((second.checkpoint_dir / "context_store").glob("**/ctx_*.json")) == []
+    assert len(list((detached / "context_store" / "entries").glob("ctx_*.json"))) == 1
 
 
 def test_context_router_detects_core_content_kinds():

--- a/tests/lib_test/heartbeat/test_heartbeat.py
+++ b/tests/lib_test/heartbeat/test_heartbeat.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from src.lib.heartbeat import HeartbeatWriter
+from src.lib.runtime import RuntimeHome
 
 
 @pytest.fixture()
@@ -18,8 +19,21 @@ def hb_path(tmp_path: Path) -> Path:
 
 class TestHeartbeatWriter:
 
+    def test_records_current_run_id(self, hb_path: Path):
+        hb = HeartbeatWriter(
+            path=hb_path,
+            agent_name="test_agent",
+            run_id="run_current",
+            interval=0.2,
+        )
+        hb.start()
+        time.sleep(0.3)
+        hb.stop()
+
+        assert json.loads(hb_path.read_text())["run_id"] == "run_current"
+
     def test_writes_file(self, hb_path: Path):
-        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", interval=0.2)
+        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", run_id="run_test", interval=0.2)
         hb.start()
         time.sleep(0.5)
         hb.stop()
@@ -30,7 +44,7 @@ class TestHeartbeatWriter:
         assert "timestamp" in data
 
     def test_updates_periodically(self, hb_path: Path):
-        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", interval=0.2)
+        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", run_id="run_test", interval=0.2)
         hb.start()
         time.sleep(0.3)
         ts1 = json.loads(hb_path.read_text())["timestamp"]
@@ -40,7 +54,7 @@ class TestHeartbeatWriter:
         assert ts2 > ts1
 
     def test_stop_writes_stopped(self, hb_path: Path):
-        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", interval=0.2)
+        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", run_id="run_test", interval=0.2)
         hb.start()
         time.sleep(0.3)
         hb.stop()
@@ -48,7 +62,7 @@ class TestHeartbeatWriter:
         assert data["status"] == "stopped"
 
     def test_update_step(self, hb_path: Path):
-        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", interval=0.2)
+        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", run_id="run_test", interval=0.2)
         hb.start()
         hb.update_step(5)
         time.sleep(0.4)
@@ -57,8 +71,32 @@ class TestHeartbeatWriter:
         assert data["step"] == 5
 
     def test_daemon_thread(self, hb_path: Path):
-        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", interval=0.2)
+        hb = HeartbeatWriter(path=hb_path, agent_name="test_agent", run_id="run_test", interval=0.2)
         hb.start()
         assert hb._thread is not None
         assert hb._thread.daemon is True
         hb.stop()
+
+    def test_writer_stays_on_original_task_inode_after_path_replacement(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        home = RuntimeHome(tmp_path / ".agentloom")
+        first = home.context(application_id="app", task_id="first", run_id="run-a")
+        second = home.context(application_id="app", task_id="second", run_id="run-b")
+        first.prepare_checkpoint()
+        second.prepare_checkpoint()
+        second.heartbeat_path.write_text('{"agent_name":"SECOND"}', encoding="utf-8")
+        heartbeat = HeartbeatWriter(
+            path=first.heartbeat_path,
+            agent_name="FIRST",
+            run_id="run-a",
+        )
+        detached = first.checkpoint_dir.parent / "first-detached"
+        first.checkpoint_dir.rename(detached)
+        first.checkpoint_dir.symlink_to(second.checkpoint_dir, target_is_directory=True)
+
+        heartbeat._write_once()
+
+        assert json.loads(second.heartbeat_path.read_text())["agent_name"] == "SECOND"
+        assert json.loads((detached / "heartbeat.json").read_text())["agent_name"] == "FIRST"

--- a/tests/lib_test/heartbeat/test_worker_heartbeat.py
+++ b/tests/lib_test/heartbeat/test_worker_heartbeat.py
@@ -19,8 +19,22 @@ def hb_path(tmp_path: Path) -> Path:
 
 class TestWorkerHeartbeat:
 
+    def test_records_current_run_id(self, hb_path: Path):
+        heartbeat = WorkerHeartbeat(
+            path=hb_path,
+            agent_name="scan_code",
+            run_id="run_current",
+            interval=0.2,
+        )
+        heartbeat.register_call(0)
+        heartbeat.start()
+        time.sleep(0.3)
+        heartbeat.stop()
+
+        assert json.loads(hb_path.read_text())["run_id"] == "run_current"
+
     def test_register_and_write(self, hb_path: Path):
-        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", interval=0.2)
+        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", run_id="run_test", interval=0.2)
         whb.register_call(0)
         whb.start()
         time.sleep(0.5)
@@ -32,7 +46,7 @@ class TestWorkerHeartbeat:
         assert data["calls"]["0"]["status"] in ("running", "stopped")
 
     def test_multiple_calls(self, hb_path: Path):
-        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", interval=0.2)
+        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", run_id="run_test", interval=0.2)
         whb.register_call(0)
         whb.register_call(1)
         whb.start()
@@ -47,7 +61,7 @@ class TestWorkerHeartbeat:
         assert "finished_at" in calls["0"]
 
     def test_update_step(self, hb_path: Path):
-        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", interval=0.2)
+        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", run_id="run_test", interval=0.2)
         whb.register_call(0)
         whb.update_call_step(0, 5)
         whb.start()
@@ -57,7 +71,7 @@ class TestWorkerHeartbeat:
         assert data["calls"]["0"]["step"] == 5
 
     def test_all_calls_terminal(self, hb_path: Path):
-        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", interval=0.2)
+        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", run_id="run_test", interval=0.2)
         whb.register_call(0)
         whb.register_call(1)
         assert not whb.all_calls_terminal()
@@ -68,7 +82,7 @@ class TestWorkerHeartbeat:
 
     def test_thread_safety(self, hb_path: Path):
         """Multiple threads register and update calls concurrently."""
-        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", interval=0.1)
+        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", run_id="run_test", interval=0.1)
         whb.start()
 
         errors: list[Exception] = []
@@ -97,14 +111,14 @@ class TestWorkerHeartbeat:
             assert data["calls"][str(ci)]["status"] == "completed"
 
     def test_daemon_thread(self, hb_path: Path):
-        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", interval=0.2)
+        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", run_id="run_test", interval=0.2)
         whb.start()
         assert whb._thread is not None
         assert whb._thread.daemon is True
         whb.stop()
 
     def test_on_stopping_marks_running_as_stopped(self, hb_path: Path):
-        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", interval=0.2)
+        whb = WorkerHeartbeat(path=hb_path, agent_name="scan_code", run_id="run_test", interval=0.2)
         whb.register_call(0)
         whb.register_call(1)
         whb.update_call_status(0, "completed")

--- a/tests/lib_test/runtime/test_runtime_cli.py
+++ b/tests/lib_test/runtime/test_runtime_cli.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from src.__main__ import main
+from src.lib.checkpoint import CheckpointManager
+from src.lib.runtime import RuntimeHome
+
+
+def test_clean_runtime_command_applies_configured_retention(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = RuntimeHome(tmp_path / ".agentloom")
+    context = home.context(application_id="app", task_id="task", run_id="run")
+    context.prepare_run()
+    old = (datetime.now(UTC) - timedelta(days=8)).isoformat()
+    context.manifest_path.write_text(
+        json.dumps(
+            {
+                "application_id": "app",
+                "task_id": "task",
+                "run_id": "run",
+                "status": "completed",
+                "ended_at": old,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("src.__main__._configured_runtime_home", lambda: home)
+
+    result = CliRunner().invoke(main, ["clean-runtime"])
+
+    assert result.exit_code == 0, result.output
+    assert "runs=1" in result.output
+    assert not context.run_dir.exists()
+
+
+def test_clean_runtime_command_never_removes_checkpoint(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = RuntimeHome(tmp_path / ".agentloom")
+    context = home.context(application_id="app", task_id="expired", run_id="run_old")
+    manager = CheckpointManager("supervisor", checkpoint_dir=context.checkpoint_dir)
+    manager.save_task_tree(
+        context.task_id,
+        {
+            "task_id": context.task_id,
+            "status": "interrupted",
+            "created_at": (datetime.now(UTC) - timedelta(days=8)).isoformat(),
+            "workers": {},
+        },
+    )
+    monkeypatch.setattr("src.__main__._configured_runtime_home", lambda: home)
+
+    result = CliRunner().invoke(main, ["clean-runtime"])
+
+    assert result.exit_code == 0, result.output
+    assert "checkpoints=" not in result.output
+    assert context.checkpoint_dir.exists()
+
+
+def test_clean_runtime_command_reports_lock_contention_as_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = RuntimeHome(tmp_path / ".agentloom")
+    home.root_dir.mkdir(parents=True)
+    monkeypatch.setattr("src.__main__._configured_runtime_home", lambda: home)
+    lock_fd = os.open(home.root_dir, os.O_RDONLY)
+    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        result = CliRunner().invoke(main, ["clean-runtime"])
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+    assert result.exit_code != 0
+    assert "cleanup skipped" in result.output
+    assert "already in progress" in result.output
+    assert "Cleaned runtime" not in result.output
+
+
+def test_migrate_runtime_command_defaults_to_dry_run(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = RuntimeHome(tmp_path / ".agentloom")
+    observed = {}
+
+    def _migrate(legacy_logs_dir, runtime_root, **kwargs):
+        observed.update(
+            legacy_logs_dir=Path(legacy_logs_dir),
+            runtime_root=Path(runtime_root),
+            **kwargs,
+        )
+        return SimpleNamespace(
+            dry_run=kwargs["dry_run"],
+            plan=SimpleNamespace(candidate_count=0, skipped_count=0, candidates=[], skipped=[]),
+            migrated_count=0,
+            already_migrated_count=0,
+            archive_dir=None,
+        )
+
+    monkeypatch.setattr("src.__main__._configured_runtime_home", lambda: home)
+    monkeypatch.setattr("src.lib.runtime.migration.migrate_runtime", _migrate)
+
+    result = CliRunner().invoke(main, ["migrate-runtime", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert observed["dry_run"] is True
+    assert observed["archive_legacy"] is False
+    assert "candidates=0" in result.output
+
+
+def test_migrate_runtime_apply_requests_atomic_legacy_archive(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = RuntimeHome(tmp_path / ".agentloom")
+    observed = {}
+
+    def _migrate(_legacy_logs_dir, _runtime_root, **kwargs):
+        observed.update(kwargs)
+        return SimpleNamespace(
+            dry_run=False,
+            plan=SimpleNamespace(candidate_count=1, skipped_count=0, candidates=[], skipped=[]),
+            migrated_count=1,
+            already_migrated_count=0,
+            archive_dir=home.root_dir / "legacy" / "logs-v1-now",
+        )
+
+    monkeypatch.setattr("src.__main__._configured_runtime_home", lambda: home)
+    monkeypatch.setattr("src.lib.runtime.migration.migrate_runtime", _migrate)
+
+    result = CliRunner().invoke(main, ["migrate-runtime", "--apply"])
+
+    assert result.exit_code == 0, result.output
+    assert observed["dry_run"] is False
+    assert observed["archive_legacy"] is True
+    assert "migrated=1" in result.output

--- a/tests/lib_test/runtime/test_runtime_context.py
+++ b/tests/lib_test/runtime/test_runtime_context.py
@@ -1,0 +1,216 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+
+def test_runtime_home_builds_run_and_checkpoint_paths(tmp_path: Path) -> None:
+    from src.lib.runtime import RuntimeHome
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+
+    context = home.context(
+        application_id="web/search",
+        task_id="task_123",
+        run_id="run_abc",
+    )
+
+    assert context.run_dir == tmp_path / ".agentloom" / "runs" / "web" / "search" / "run_abc"
+    assert context.log_path == context.run_dir / "logs" / "runtime.log"
+    assert context.shell_audit_path == context.run_dir / "audit" / "shell.jsonl"
+    assert context.artifacts_dir == context.run_dir / "artifacts"
+    assert context.checkpoint_dir == tmp_path / ".agentloom" / "checkpoints" / "web" / "search" / "task_123"
+    assert not context.run_dir.exists()
+    assert not context.checkpoint_dir.exists()
+
+
+def test_runtime_home_resolves_relative_root_against_agent_root(tmp_path: Path) -> None:
+    from src.lib.runtime import resolve_runtime_home
+
+    home = resolve_runtime_home(
+        {"runtime": {"root_dir": "state/runtime"}},
+        agent_root=tmp_path,
+    )
+
+    assert home.root_dir == (tmp_path / "state" / "runtime").resolve()
+
+
+def test_runtime_context_rejects_path_traversal(tmp_path: Path) -> None:
+    from src.lib.runtime import RuntimeContext, RuntimeHome
+
+    home = RuntimeHome(tmp_path)
+    with pytest.raises(ValueError):
+        home.context(application_id="../other", task_id="task", run_id="run")
+    with pytest.raises(ValueError):
+        home.context(application_id="app", task_id="../task", run_id="run")
+    with pytest.raises(ValueError):
+        RuntimeContext(tmp_path, "../outside", "task", "run")
+
+
+def test_runtime_ids_reject_lossy_sanitization_and_cannot_collide(tmp_path: Path) -> None:
+    from src.lib.runtime import RuntimeHome
+
+    home = RuntimeHome(tmp_path)
+    canonical = home.context(application_id="app", task_id="task_x", run_id="run_x")
+
+    for task_id in ("task@x", "task#x", "中文任务"):
+        with pytest.raises(ValueError):
+            home.context(application_id="app", task_id=task_id, run_id="run_x")
+    for run_id in ("run@x", "run#x", "中文执行"):
+        with pytest.raises(ValueError):
+            home.context(application_id="app", task_id="task_x", run_id=run_id)
+
+    assert canonical.checkpoint_dir.name == "task_x"
+
+
+def test_external_workflow_application_id_is_stable_and_collision_safe(tmp_path: Path) -> None:
+    from src.lib.runtime import resolve_application_id
+
+    first = tmp_path / "one" / "agent.yaml"
+    second = tmp_path / "two" / "agent.yaml"
+
+    assert resolve_application_id({}, first) == resolve_application_id({}, first)
+    assert resolve_application_id({}, first) != resolve_application_id({}, second)
+
+
+def test_unicode_application_ids_use_stable_portable_components() -> None:
+    from src.lib.runtime import safe_application_id
+
+    first = safe_application_id("中文应用")
+    second = safe_application_id("另一个应用")
+
+    assert first.startswith("app-")
+    assert first == safe_application_id("中文应用")
+    assert first != second
+    assert first.isascii()
+
+
+def test_unicode_external_workflow_name_falls_back_to_safe_name_and_hash(tmp_path: Path) -> None:
+    from src.lib.runtime import fallback_application_id
+
+    workflow = tmp_path / "测试.yaml"
+    application_id = fallback_application_id(workflow, name_hint="中文名字")
+
+    assert application_id.startswith("external-")
+    assert application_id == fallback_application_id(workflow, name_hint="中文名字")
+    assert application_id.isascii()
+
+
+def test_generated_attempt_ids_do_not_collide_within_the_same_clock_tick() -> None:
+    from src.lib.runtime import generate_runtime_id
+
+    generated = {generate_runtime_id("run") for _ in range(100)}
+
+    assert len(generated) == 100
+
+
+def test_runtime_context_allocates_safe_unique_skill_execution_dirs(tmp_path: Path) -> None:
+    from src.lib.runtime import RuntimeHome
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="app",
+        task_id="task",
+        run_id="run",
+    )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        directories = list(
+            executor.map(
+                lambda _: context.new_skill_execution_dir("中文/skill name"),
+                range(40),
+            )
+        )
+
+    assert len(set(directories)) == 40
+    assert all(path.is_dir() for path in directories)
+    assert all(path.is_relative_to(context.skill_artifacts_dir) for path in directories)
+    assert all("中文" not in str(path.relative_to(context.skill_artifacts_dir)) for path in directories)
+
+
+def test_artifact_allocator_rejects_cross_run_symlink(tmp_path: Path) -> None:
+    from src.lib.runtime import RuntimeHome
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="first", task_id="task", run_id="run")
+    second = home.context(application_id="second", task_id="task", run_id="run")
+    first.prepare_run()
+    second.prepare_run()
+    first.shell_artifacts_dir.rmdir()
+    first.shell_artifacts_dir.symlink_to(
+        second.shell_artifacts_dir,
+        target_is_directory=True,
+    )
+
+    with pytest.raises(RuntimeError, match="safe directory"):
+        first.allocate_artifact("shell", prefix="cmd-", suffix=".txt")
+
+    assert list(second.shell_artifacts_dir.iterdir()) == []
+
+
+def test_atomic_run_write_rejects_replaced_skill_audit_directory(tmp_path: Path) -> None:
+    from src.lib.runtime import RuntimeHome
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="first", task_id="task", run_id="run")
+    second = home.context(application_id="second", task_id="task", run_id="run")
+    first.prepare_run()
+    second.prepare_run()
+    audit_dir = first.new_skill_execution_dir("skill")
+    audit_dir.rmdir()
+    audit_dir.symlink_to(second.skill_artifacts_dir, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="safe directory"):
+        first.atomic_write_run_file(audit_dir / "stdout.txt", "secret")
+
+    assert not (second.skill_artifacts_dir / "stdout.txt").exists()
+
+
+def test_bound_run_home_owns_self_learning_state(tmp_path: Path, monkeypatch) -> None:
+    from src.extensions.self_learning.paths import self_learning_root
+    from src.lib.runtime import RuntimeHome, bind_run_context
+
+    context = RuntimeHome(tmp_path / "canonical").context(
+        application_id="app",
+        task_id="task",
+        run_id="run",
+    )
+    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(tmp_path / "legacy-override"))
+
+    with bind_run_context(context):
+        assert self_learning_root() == context.root_dir
+
+
+def test_legacy_self_learning_env_cannot_split_unbound_runtime_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from src.extensions.self_learning import paths
+
+    configured_root = tmp_path / "canonical"
+    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(tmp_path / "legacy"))
+    monkeypatch.setattr(
+        paths,
+        "_runtime_config_section",
+        lambda: {"root_dir": str(configured_root)},
+    )
+
+    assert paths.self_learning_root() == configured_root
+
+
+def test_canonical_runtime_env_moves_every_runtime_consumer_together(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from src.extensions.self_learning.paths import self_learning_root
+    from src.lib.runtime import resolve_runtime_home
+
+    override = tmp_path / "isolated-runtime"
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(override))
+
+    home = resolve_runtime_home(
+        {"runtime": {"root_dir": str(tmp_path / "configured")}},
+        agent_root=tmp_path,
+    )
+
+    assert home.root_dir == override
+    assert self_learning_root() == override

--- a/tests/lib_test/runtime/test_runtime_migration.py
+++ b/tests/lib_test/runtime/test_runtime_migration.py
@@ -1,0 +1,989 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+NOW = datetime(2026, 7, 16, 12, 0, tzinfo=UTC)
+CONTEXT_REF = "ctx_0123456789abcdef"
+CONTEXT_PAYLOAD = "original payload survives runtime migration"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _make_workflow(repo_root: Path, application_id: str) -> Path:
+    workflow = repo_root / "applications" / application_id / "workflows" / "agent.yaml"
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text(
+        "name: supervisor\ndescription: migration test\nworkflow: resume safely\n",
+        encoding="utf-8",
+    )
+    return workflow
+
+
+def _make_legacy_task(
+    legacy_root: Path,
+    *,
+    task_id: str,
+    workflow: Path,
+    age: timedelta,
+    progress: str = "context_store",
+    supervisor: str = "supervisor",
+    corrupt_event_tail: bool = False,
+) -> Path:
+    task_dir = legacy_root / supervisor / "20260716_120000" / "checkpoints" / task_id
+    task_dir.mkdir(parents=True)
+    timestamp = (NOW - age).isoformat()
+    events = [
+        {
+            "type": "task_created",
+            "task_id": task_id,
+            "yaml_path": str(workflow),
+            "agent_name": supervisor,
+            "created_at": timestamp,
+            "timestamp": timestamp,
+        },
+        {
+            "type": "task_status_changed",
+            "status": "interrupted",
+            "interrupted_at": timestamp,
+            "timestamp": timestamp,
+        },
+    ]
+    event_text = "".join(json.dumps(event) + "\n" for event in events)
+    if corrupt_event_tail:
+        event_text += '{"type":"worker_call_started"'
+    (task_dir / "task_events.jsonl").write_text(event_text, encoding="utf-8")
+    _write_json(
+        task_dir / "task_tree.json",
+        {
+            "task_id": task_id,
+            "yaml_path": str(workflow),
+            "agent_name": supervisor,
+            "status": "interrupted",
+            "created_at": timestamp,
+            "interrupted_at": timestamp,
+            "workers": {},
+        },
+    )
+    _write_json(
+        task_dir / "checkpoint.json",
+        {
+            "task_id": task_id,
+            "agent_name": supervisor,
+            "status": "interrupted",
+            "saved_at": timestamp,
+            "memory_steps": ([{"_step_type": "TaskStep", "task": "resume me"}] if progress == "memory" else []),
+            "step_count": (1 if progress == "memory" else 0),
+        },
+    )
+
+    if progress == "context_store":
+        _write_json(
+            task_dir / "context_store" / "entries" / f"{CONTEXT_REF}.json",
+            {
+                "ref": CONTEXT_REF,
+                "kind": "text",
+                "tool_name": "shell_tool",
+                "original": CONTEXT_PAYLOAD,
+                "preview": "preview",
+                "original_chars": len(CONTEXT_PAYLOAD),
+                "preview_chars": 7,
+                "original_tokens_est": 10,
+                "preview_tokens_est": 2,
+                "strategy": "test",
+                "created_at": NOW.timestamp(),
+                "ttl_seconds": None,
+                "source": "migration-test",
+            },
+        )
+        (task_dir / "context_store" / "events.jsonl").write_text(
+            json.dumps({"type": "compressed", "ref": CONTEXT_REF}) + "\n",
+            encoding="utf-8",
+        )
+        _write_json(
+            task_dir / "file-history" / "snapshots.json",
+            {
+                "first_tracked_backups": {
+                    "/workspace/src/app.py": {
+                        "backup_filename": "abc@v1",
+                        "version": 1,
+                        "backup_time": NOW.timestamp(),
+                    }
+                },
+                "snapshots": [
+                    {
+                        "step_number": 1,
+                        "timestamp": NOW.timestamp(),
+                        "tracked_file_backups": {
+                            "/workspace/src/app.py": {
+                                "backup_filename": "abc@v1",
+                                "version": 1,
+                                "backup_time": NOW.timestamp(),
+                            }
+                        },
+                    }
+                ],
+            },
+        )
+        (task_dir / "file-history" / "abc@v1").write_text("before edit", encoding="utf-8")
+
+    return task_dir
+
+
+def test_scan_ignores_index_and_filters_by_metadata_age_test_identity_and_real_progress(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    test_workflow = _make_workflow(repo_root, "test_app")
+
+    valid = _make_legacy_task(
+        legacy_root,
+        task_id="task_valid",
+        workflow=workflow,
+        age=timedelta(days=1),
+        corrupt_event_tail=True,
+    )
+    expired = _make_legacy_task(
+        legacy_root,
+        task_id="task_expired",
+        workflow=workflow,
+        age=timedelta(days=8),
+    )
+    _write_json(
+        expired / "heartbeat.json",
+        {"timestamp": NOW.timestamp(), "pid": 999999},
+    )
+    os.utime(expired, (NOW.timestamp(), NOW.timestamp()))
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_test",
+        workflow=test_workflow,
+        age=timedelta(days=1),
+        supervisor="test_supervisor",
+    )
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_empty",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="none",
+    )
+    _write_json(
+        legacy_root / "supervisor" / ".task_index.json",
+        {"task_ghost": {"run_dir": "does-not-exist", "created_at": NOW.isoformat()}},
+    )
+
+    plan = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=runtime_root,
+        agent_root=repo_root,
+        now=NOW,
+    ).scan()
+
+    assert [candidate.task_id for candidate in plan.candidates] == ["task_valid"]
+    candidate = plan.candidates[0]
+    assert candidate.source_dir == valid
+    assert candidate.destination_dir == runtime_root / "checkpoints" / "demo" / "task_valid"
+    assert candidate.application_id == "demo"
+    assert candidate.progress_kinds == ("context_store", "file_history")
+    assert candidate.malformed_event_lines == 1
+    assert len(candidate.checksum) == 64
+    assert {item.task_id: item.reason for item in plan.skipped} == {
+        "task_empty": "no resumable progress",
+        "task_expired": "outside migration window",
+        "task_test": "test task",
+    }
+    assert "task_ghost" not in {
+        *(item.task_id for item in plan.skipped),
+        *(item.task_id for item in plan.candidates),
+    }
+
+
+def test_scan_skips_legacy_task_ids_that_cannot_be_resumed_exactly(tmp_path: Path) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    workflow = _make_workflow(repo_root, "demo")
+    _make_legacy_task(
+        legacy_root,
+        task_id="task@unsafe",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+
+    plan = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    ).scan()
+
+    assert plan.candidates == []
+    assert [(item.task_id, item.reason) for item in plan.skipped] == [
+        ("task@unsafe", "unsafe task id")
+    ]
+
+
+@pytest.mark.parametrize("symlink_ancestor", ["supervisor", "timestamp", "checkpoints"])
+def test_scan_never_follows_a_symlinked_legacy_ancestor(
+    tmp_path: Path,
+    symlink_ancestor: str,
+) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    external_root = tmp_path / "external-legacy"
+    workflow = _make_workflow(repo_root, "demo")
+    external_task = _make_legacy_task(
+        external_root,
+        task_id="task_external",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    external_supervisor = external_task.parents[2]
+    external_timestamp = external_task.parents[1]
+    external_checkpoints = external_task.parent
+
+    if symlink_ancestor == "supervisor":
+        legacy_root.mkdir(parents=True)
+        (legacy_root / "supervisor").symlink_to(
+            external_supervisor,
+            target_is_directory=True,
+        )
+    elif symlink_ancestor == "timestamp":
+        parent = legacy_root / "supervisor"
+        parent.mkdir(parents=True)
+        (parent / "20260716_120000").symlink_to(
+            external_timestamp,
+            target_is_directory=True,
+        )
+    else:
+        parent = legacy_root / "supervisor" / "20260716_120000"
+        parent.mkdir(parents=True)
+        (parent / "checkpoints").symlink_to(
+            external_checkpoints,
+            target_is_directory=True,
+        )
+
+    plan = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    ).scan()
+
+    assert not plan.candidates
+    assert not plan.skipped
+    assert external_task.is_dir()
+
+
+def test_external_workflow_uses_the_same_application_id_for_migration_and_runner(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime import resolve_application_id
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    workflow = tmp_path / "external_workflow.yaml"
+    workflow.write_text(
+        "name: custom_supervisor\n"
+        "application_id: explicit-app\n"
+        "description: migration test\n"
+        "workflow: resume safely\n",
+        encoding="utf-8",
+    )
+    migration = RuntimeMigration(
+        legacy_logs_dir=repo_root / ".logs",
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    )
+
+    migrated_id = migration._application_id(
+        str(workflow),
+        "custom_supervisor",
+        repo_root / ".logs" / "legacy-task",
+    )
+    runner_id = resolve_application_id(
+        {
+            "name": "custom_supervisor",
+            "application_id": "explicit-app",
+            "description": "migration test",
+            "workflow": "resume safely",
+        },
+        workflow,
+        agent_root=repo_root,
+    )
+
+    assert migrated_id == runner_id == "explicit-app"
+
+
+def test_scan_requires_a_parseable_live_workflow_with_matching_application_id(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+
+    deleted = _make_workflow(repo_root, "deleted")
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_deleted",
+        workflow=deleted,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    deleted.unlink()
+
+    broken = _make_workflow(repo_root, "broken")
+    broken.write_text("name: [unterminated\n", encoding="utf-8")
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_broken",
+        workflow=broken,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+
+    mismatched = _make_workflow(repo_root, "actual")
+    mismatch_task = _make_legacy_task(
+        legacy_root,
+        task_id="task_mismatch",
+        workflow=mismatched,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    tree = json.loads((mismatch_task / "task_tree.json").read_text(encoding="utf-8"))
+    tree["application_id"] = "different"
+    _write_json(mismatch_task / "task_tree.json", tree)
+
+    plan = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    ).scan()
+
+    assert not plan.candidates
+    assert {item.task_id: item.reason for item in plan.skipped} == {
+        "task_broken": "invalid workflow",
+        "task_deleted": "workflow file not found",
+        "task_mismatch": "workflow application mismatch",
+    }
+
+
+def test_scan_only_tolerates_one_malformed_final_crash_tail(tmp_path: Path) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    workflow = _make_workflow(repo_root, "demo")
+    middle = _make_legacy_task(
+        legacy_root,
+        task_id="task_middle_corruption",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    middle_lines = (middle / "task_events.jsonl").read_text(encoding="utf-8").splitlines()
+    (middle / "task_events.jsonl").write_text(
+        middle_lines[0] + "\n" + '{"type":"worker_call_finished"' + "\n" + middle_lines[1] + "\n",
+        encoding="utf-8",
+    )
+
+    multiple = _make_legacy_task(
+        legacy_root,
+        task_id="task_multiple_corruption",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    with (multiple / "task_events.jsonl").open("a", encoding="utf-8") as stream:
+        stream.write('{"type":"first_tail"\n{"type":"second_tail"')
+
+    plan = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    ).scan()
+
+    assert not plan.candidates
+    assert {item.task_id: item.reason for item in plan.skipped} == {
+        "task_middle_corruption": "corrupt task events",
+        "task_multiple_corruption": "corrupt task events",
+    }
+
+
+def test_scan_isolates_invalid_utf8_checkpoint_metadata_and_context(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    workflow = _make_workflow(repo_root, "demo")
+    invalid_tree = _make_legacy_task(
+        legacy_root,
+        task_id="task_invalid_tree",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    (invalid_tree / "task_tree.json").write_bytes(b"\xff\xfe\x80")
+
+    invalid_checkpoint = _make_legacy_task(
+        legacy_root,
+        task_id="task_invalid_checkpoint",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    (invalid_checkpoint / "checkpoint.json").write_bytes(b"\xff\xfe\x80")
+
+    invalid_context = _make_legacy_task(
+        legacy_root,
+        task_id="task_invalid_context",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    bad_entry = invalid_context / "context_store" / "entries" / "ctx_bad.json"
+    bad_entry.parent.mkdir(parents=True)
+    bad_entry.write_bytes(b"\xff\xfe\x80")
+
+    plan = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    ).scan()
+
+    assert not plan.candidates
+    assert {item.task_id: item.reason for item in plan.skipped} == {
+        "task_invalid_checkpoint": "invalid checkpoint",
+        "task_invalid_context": "invalid context store",
+        "task_invalid_tree": "invalid task tree",
+    }
+
+
+def test_invalid_worker_checkpoint_is_skipped_without_blocking_valid_task_apply(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    invalid = _make_legacy_task(
+        legacy_root,
+        task_id="task_invalid_worker",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    invalid_worker = invalid / "workers" / "researcher" / "checkpoint.json"
+    invalid_worker.parent.mkdir(parents=True)
+    invalid_worker.write_bytes(b"\xff\xfe\x80")
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_valid_worker_batch",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+
+    result = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=runtime_root,
+        agent_root=repo_root,
+        now=NOW,
+    ).migrate(dry_run=False, archive_legacy=True)
+
+    assert [item.task_id for item in result.migrated] == ["task_valid_worker_batch"]
+    assert [(item.task_id, item.reason) for item in result.plan.skipped] == [
+        ("task_invalid_worker", "invalid worker checkpoint")
+    ]
+    assert (
+        runtime_root
+        / "checkpoints"
+        / "demo"
+        / "task_valid_worker_batch"
+        / "checkpoint.json"
+    ).is_file()
+    assert not (
+        runtime_root / "checkpoints" / "demo" / "task_invalid_worker"
+    ).exists()
+    assert result.archive_dir is not None
+    assert not legacy_root.exists()
+
+
+def test_live_legacy_heartbeat_blocks_scan_and_apply_archive(tmp_path: Path) -> None:
+    from src.lib.runtime.migration import MigrationError, RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    workflow = _make_workflow(repo_root, "demo")
+    task_dir = _make_legacy_task(
+        legacy_root,
+        task_id="task_live",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    _write_json(
+        task_dir / "heartbeat.json",
+        {
+            "pid": os.getpid(),
+            "timestamp": NOW.timestamp(),
+            "status": "running",
+        },
+    )
+    migration = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    )
+
+    plan = migration.scan()
+    assert not plan.candidates
+    assert [(item.task_id, item.reason) for item in plan.skipped] == [
+        ("task_live", "live legacy heartbeat")
+    ]
+
+    with pytest.raises(MigrationError, match="writer is live"):
+        migration.migrate(dry_run=False, archive_legacy=True)
+    assert legacy_root.is_dir()
+    assert not (repo_root / ".agentloom" / "legacy").exists()
+
+
+def test_scan_requires_original_created_at_instead_of_fresh_saved_metadata(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    workflow = _make_workflow(repo_root, "demo")
+    task_dir = _make_legacy_task(
+        legacy_root,
+        task_id="task_missing_created_at",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    events = [
+        json.loads(line)
+        for line in (task_dir / "task_events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    events[0].pop("created_at", None)
+    (task_dir / "task_events.jsonl").write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+    tree = json.loads((task_dir / "task_tree.json").read_text(encoding="utf-8"))
+    tree.pop("created_at", None)
+    _write_json(task_dir / "task_tree.json", tree)
+
+    plan = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    ).scan()
+
+    assert not plan.candidates
+    assert [(item.task_id, item.reason) for item in plan.skipped] == [
+        ("task_missing_created_at", "missing original created_at")
+    ]
+
+
+def test_scan_does_not_treat_step_count_without_memory_steps_as_progress(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    workflow = _make_workflow(repo_root, "demo")
+    task_dir = _make_legacy_task(
+        legacy_root,
+        task_id="task_count_only",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="none",
+    )
+    checkpoint = json.loads((task_dir / "checkpoint.json").read_text(encoding="utf-8"))
+    checkpoint["step_count"] = 3
+    checkpoint["memory_steps"] = []
+    _write_json(task_dir / "checkpoint.json", checkpoint)
+
+    plan = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=repo_root / ".agentloom",
+        agent_root=repo_root,
+        now=NOW,
+    ).scan()
+
+    assert not plan.candidates
+    assert [(item.task_id, item.reason) for item in plan.skipped] == [
+        ("task_count_only", "no resumable progress")
+    ]
+
+
+def test_apply_uses_staging_verifies_context_ref_and_archives_whole_legacy_tree(
+    tmp_path: Path,
+) -> None:
+    from src.lib.context_engine.store import ContextStore
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    task_dir = _make_legacy_task(
+        legacy_root,
+        task_id="task_valid",
+        workflow=workflow,
+        age=timedelta(days=1),
+    )
+    checkpoint = json.loads((task_dir / "checkpoint.json").read_text(encoding="utf-8"))
+    checkpoint.update(
+        {
+            "memory_steps": [{"_step_type": "TaskStep", "task": "resume supervisor"}],
+            "step_count": 1,
+        }
+    )
+    _write_json(task_dir / "checkpoint.json", checkpoint)
+    tree = json.loads((task_dir / "task_tree.json").read_text(encoding="utf-8"))
+    tree["workers"] = {
+        "researcher": [
+            {
+                "call_index": 2,
+                "status": "interrupted",
+                "input_hash": "hash-2",
+            }
+        ]
+    }
+    _write_json(task_dir / "task_tree.json", tree)
+    _write_json(
+        task_dir / "workers" / "researcher" / "checkpoint.json",
+        {
+            "task_id": "task_valid",
+            "agent_name": "researcher",
+            "agent_type": "worker",
+            "call_index": 2,
+            "status": "interrupted",
+            "saved_at": (NOW - timedelta(days=1)).isoformat(),
+            "memory_steps": [{"_step_type": "TaskStep", "task": "resume worker"}],
+            "step_count": 1,
+        },
+    )
+    (legacy_root / "unrelated-runtime.log").write_text("archive me", encoding="utf-8")
+    stale_stage = runtime_root / ".migration-staging" / "abandoned" / "partial"
+    stale_stage.mkdir(parents=True)
+    (stale_stage / "checkpoint.json.tmp").write_text("partial", encoding="utf-8")
+    migration = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=runtime_root,
+        agent_root=repo_root,
+        now=NOW,
+    )
+
+    dry_run = migration.migrate(dry_run=True, archive_legacy=True)
+    assert dry_run.dry_run is True
+    assert not (runtime_root / "checkpoints").exists()
+    assert legacy_root.exists()
+
+    validated: list[str] = []
+
+    def validate(candidate, destination: Path) -> None:
+        assert ".migration-staging" in destination.parts
+        assert not candidate.destination_dir.exists()
+        store = ContextStore(destination / "context_store")
+        assert store.retrieve(CONTEXT_REF) == CONTEXT_PAYLOAD
+        assert (destination / "file-history" / "abc@v1").read_text(encoding="utf-8") == "before edit"
+        validated.append(candidate.task_id)
+
+    result = migration.migrate(
+        dry_run=False,
+        archive_legacy=True,
+        validator=validate,
+    )
+
+    destination = runtime_root / "checkpoints" / "demo" / "task_valid"
+    assert result.migrated_count == 1
+    assert validated == ["task_valid"]
+    assert destination.is_dir()
+    assert not (destination / "workers" / "researcher" / "checkpoint.json").exists()
+    worker_checkpoint = destination / "workers" / "researcher" / "calls" / "2" / "checkpoint.json"
+    assert worker_checkpoint.is_file()
+    from src.lib.checkpoint import CheckpointManager
+
+    manager = CheckpointManager("supervisor", checkpoint_dir=destination)
+    assert manager.load_worker_checkpoint("task_valid", "researcher", 2)["step_count"] == 1
+    assert ContextStore(destination / "context_store").retrieve(CONTEXT_REF) == CONTEXT_PAYLOAD
+    assert not legacy_root.exists()
+    assert result.archive_dir is not None
+    assert result.archive_dir.parent == runtime_root / "legacy"
+    assert result.archive_dir.name.startswith("logs-v1-20260716T120000")
+    assert (result.archive_dir / "unrelated-runtime.log").read_text(encoding="utf-8") == "archive me"
+    assert not (runtime_root / ".migration-staging").exists()
+    assert not (runtime_root / ".migration.lock").exists()
+    assert not (runtime_root / "runs").exists()
+
+
+def test_archive_failure_keeps_published_task_leased_until_safe_rollback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.lib.runtime.migration as migration_module
+    from src.lib.checkpoint.checkpoint_manager import CheckpointTaskLease
+    from src.lib.runtime.migration import MigrationError, RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_valid",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    migration = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=runtime_root,
+        agent_root=repo_root,
+        now=NOW,
+    )
+    archive_entered = threading.Event()
+    allow_archive_failure = threading.Event()
+
+    def fail_archive(*_args, **_kwargs):
+        archive_entered.set()
+        assert allow_archive_failure.wait(timeout=5)
+        raise OSError("archive failed")
+
+    monkeypatch.setattr(migration_module, "archive_legacy_logs", fail_archive)
+    errors: list[BaseException] = []
+
+    def apply_migration() -> None:
+        try:
+            migration.migrate(dry_run=False, archive_legacy=True)
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=apply_migration)
+    thread.start()
+    assert archive_entered.wait(timeout=5)
+
+    destination = runtime_root / "checkpoints" / "demo" / "task_valid"
+    assert destination.is_dir()
+    with pytest.raises(RuntimeError, match="already active"):
+        CheckpointTaskLease(destination, require_exists=True).acquire()
+
+    allow_archive_failure.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], MigrationError)
+    assert "archive failed" in str(errors[0])
+    assert legacy_root.is_dir()
+    assert not destination.exists()
+
+
+def test_source_change_during_staging_aborts_before_publish_or_archive(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import MigrationError, RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    source = _make_legacy_task(
+        legacy_root,
+        task_id="task_changes",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    migration = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=runtime_root,
+        agent_root=repo_root,
+        now=NOW,
+    )
+
+    def append_legacy_progress(_candidate, _staged: Path) -> None:
+        checkpoint_path = source / "checkpoint.json"
+        checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        checkpoint["memory_steps"].append(
+            {"_step_type": "TaskStep", "task": "new legacy progress"}
+        )
+        checkpoint["step_count"] = 2
+        _write_json(checkpoint_path, checkpoint)
+
+    with pytest.raises(MigrationError, match="changed during migration"):
+        migration.migrate(
+            dry_run=False,
+            archive_legacy=True,
+            validator=append_legacy_progress,
+        )
+
+    assert legacy_root.is_dir()
+    assert not (runtime_root / "checkpoints" / "demo" / "task_changes").exists()
+    assert not (runtime_root / "legacy").exists()
+
+
+def test_apply_is_idempotent_when_destination_already_matches(tmp_path: Path) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_valid",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    migration = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=runtime_root,
+        agent_root=repo_root,
+        now=NOW,
+    )
+
+    first = migration.migrate(dry_run=False, archive_legacy=False)
+    second = migration.migrate(dry_run=False, archive_legacy=False)
+
+    assert first.migrated_count == 1
+    assert second.migrated_count == 0
+    assert second.already_migrated_count == 1
+
+
+def test_validator_failure_rolls_back_destination_and_keeps_legacy_tree(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import MigrationError, RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_valid",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    migration = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=runtime_root,
+        agent_root=repo_root,
+        now=NOW,
+    )
+
+    def reject(_candidate, _destination: Path) -> None:
+        raise RuntimeError("resume validation failed")
+
+    with pytest.raises(MigrationError, match="resume validation failed"):
+        migration.migrate(
+            dry_run=False,
+            archive_legacy=True,
+            validator=reject,
+        )
+
+    assert legacy_root.exists()
+    assert not (runtime_root / "checkpoints" / "demo" / "task_valid").exists()
+    assert not (runtime_root / ".migration-staging").exists()
+    assert not (runtime_root / ".migration.lock").exists()
+
+
+def test_apply_rejects_symlinked_destination_component_and_keeps_legacy(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.migration import MigrationError, RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    _make_legacy_task(
+        legacy_root,
+        task_id="task_valid",
+        workflow=workflow,
+        age=timedelta(days=1),
+        progress="memory",
+    )
+    external = tmp_path / "external"
+    external.mkdir()
+    checkpoints = runtime_root / "checkpoints"
+    checkpoints.mkdir(parents=True)
+    (checkpoints / "demo").symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(MigrationError, match="symlink"):
+        RuntimeMigration(
+            legacy_logs_dir=legacy_root,
+            runtime_root=runtime_root,
+            agent_root=repo_root,
+            now=NOW,
+        ).migrate(dry_run=False, archive_legacy=True)
+
+    assert legacy_root.exists()
+    assert list(external.iterdir()) == []
+
+
+def test_scan_skips_checkpoint_with_missing_file_history_backup(tmp_path: Path) -> None:
+    from src.lib.runtime.migration import RuntimeMigration
+
+    repo_root = tmp_path / "repo"
+    legacy_root = repo_root / ".logs"
+    runtime_root = repo_root / ".agentloom"
+    workflow = _make_workflow(repo_root, "demo")
+    task_dir = _make_legacy_task(
+        legacy_root,
+        task_id="task_invalid_history",
+        workflow=workflow,
+        age=timedelta(days=1),
+    )
+    (task_dir / "file-history" / "abc@v1").unlink()
+
+    result = RuntimeMigration(
+        legacy_logs_dir=legacy_root,
+        runtime_root=runtime_root,
+        agent_root=repo_root,
+        now=NOW,
+    ).migrate(dry_run=False, archive_legacy=True)
+
+    assert result.migrated_count == 0
+    assert {item.task_id: item.reason for item in result.plan.skipped} == {
+        "task_invalid_history": "invalid file history"
+    }
+    assert not (runtime_root / "checkpoints" / "demo" / "task_invalid_history").exists()

--- a/tests/lib_test/runtime/test_runtime_retention.py
+++ b/tests/lib_test/runtime/test_runtime_retention.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+NOW = datetime(2026, 7, 16, 12, 0, tzinfo=UTC)
+
+
+def _make_run(
+    runtime_root: Path,
+    *,
+    run_id: str,
+    status: str,
+    age: timedelta,
+) -> Path:
+    run_dir = runtime_root / "runs" / "demo" / run_id
+    (run_dir / "artifacts" / "shell").mkdir(parents=True)
+    (run_dir / "artifacts" / "shell" / "stdout.txt").write_text("raw output", encoding="utf-8")
+    (run_dir / "logs").mkdir()
+    (run_dir / "logs" / "runtime.log").write_text("keep", encoding="utf-8")
+    timestamp = (NOW - age).isoformat()
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "application_id": "demo",
+                "run_id": run_id,
+                "task_id": f"task_{run_id}",
+                "status": status,
+                "started_at": timestamp,
+                "finished_at": timestamp,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def test_clean_runtime_applies_status_and_artifact_retention_without_touching_legacy_or_outputs(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.retention import clean_runtime
+
+    runtime_root = tmp_path / ".agentloom"
+    completed_old = _make_run(runtime_root, run_id="completed-old", status="completed", age=timedelta(days=8))
+    failed_recent = _make_run(runtime_root, run_id="failed-recent", status="failed", age=timedelta(days=8))
+    failed_old = _make_run(runtime_root, run_id="failed-old", status="interrupted", age=timedelta(days=31))
+    completed_recent = _make_run(runtime_root, run_id="completed-recent", status="success", age=timedelta(days=4))
+    fresh = _make_run(runtime_root, run_id="fresh", status="failed", age=timedelta(days=2))
+
+    legacy_file = runtime_root / "legacy" / "logs-v1-old" / "runtime.log"
+    legacy_file.parent.mkdir(parents=True)
+    legacy_file.write_text("legacy", encoding="utf-8")
+    output_file = tmp_path / "applications" / "demo" / "outputs" / "report.md"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("deliverable", encoding="utf-8")
+
+    result = clean_runtime(runtime_root, now=NOW)
+
+    assert not completed_old.exists()
+    assert failed_recent.exists()
+    assert not failed_old.exists()
+    assert completed_recent.exists()
+    assert not (completed_recent / "artifacts").exists()
+    assert fresh.exists()
+    assert (fresh / "artifacts" / "shell" / "stdout.txt").exists()
+    assert legacy_file.read_text(encoding="utf-8") == "legacy"
+    assert output_file.read_text(encoding="utf-8") == "deliverable"
+    assert result.removed_run_count == 2
+    assert result.removed_artifact_count == 2
+    assert result.reclaimed_bytes > 0
+
+
+def test_clean_runtime_ignores_manifest_named_raw_artifact(tmp_path: Path) -> None:
+    from src.lib.runtime.retention import clean_runtime
+
+    runtime_root = tmp_path / ".agentloom"
+    run_dir = _make_run(
+        runtime_root,
+        run_id="current-run",
+        status="completed",
+        age=timedelta(days=1),
+    )
+    nested = run_dir / "artifacts" / "shell" / "captured"
+    nested.mkdir()
+    stale = (NOW - timedelta(days=90)).isoformat()
+    (nested / "manifest.json").write_text(
+        json.dumps(
+            {
+                "application_id": "demo",
+                "task_id": "task_fake",
+                "run_id": "fake-run",
+                "status": "completed",
+                "finished_at": stale,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = clean_runtime(runtime_root, now=NOW)
+
+    assert nested.is_dir()
+    assert result.removed_run_count == 0
+    assert result.removed_artifact_count == 0
+
+
+def test_invalid_utf8_manifest_does_not_block_other_run_cleanup(tmp_path: Path) -> None:
+    from src.lib.runtime.retention import clean_runtime
+
+    runtime_root = tmp_path / ".agentloom"
+    removable = _make_run(
+        runtime_root,
+        run_id="removable",
+        status="completed",
+        age=timedelta(days=8),
+    )
+    retained = _make_run(
+        runtime_root,
+        run_id="retained",
+        status="completed",
+        age=timedelta(days=1),
+    )
+    nested = retained / "artifacts" / "shell" / "captured"
+    nested.mkdir()
+    (nested / "manifest.json").write_bytes(b"\xff\xfe")
+
+    corrupt = _make_run(
+        runtime_root,
+        run_id="corrupt",
+        status="completed",
+        age=timedelta(days=90),
+    )
+    (corrupt / "manifest.json").write_bytes(b"\xff\xfe")
+
+    result = clean_runtime(runtime_root, now=NOW)
+
+    assert not removable.exists()
+    assert retained.exists()
+    assert nested.is_dir()
+    assert corrupt.exists()
+    assert result.removed_run_count == 1
+
+
+def test_orphan_cleanup_requires_canonical_run_start_marker(tmp_path: Path) -> None:
+    from src.lib.runtime.retention import RetentionPolicy, clean_runtime
+
+    runtime_root = tmp_path / ".agentloom"
+    fake_run = runtime_root / "runs" / "demo" / "real-run"
+    nested = fake_run / "artifacts" / "shell" / "captured"
+    for child in (nested / "logs", nested / "audit", nested / "artifacts" / "shell"):
+        child.mkdir(parents=True, exist_ok=True)
+    for child in (nested / "artifacts" / "background", nested / "artifacts" / "skills"):
+        child.mkdir(parents=True)
+    old = (NOW - timedelta(days=90)).timestamp()
+    for path in [*nested.rglob("*"), nested]:
+        os.utime(path, (old, old), follow_symlinks=False)
+
+    result = clean_runtime(
+        runtime_root,
+        policy=RetentionPolicy(
+            successful_runs=timedelta(0),
+            failed_runs=timedelta(0),
+            raw_artifacts=timedelta(0),
+        ),
+        now=NOW,
+    )
+
+    assert nested.is_dir()
+    assert result.removed_run_count == 0
+
+
+def test_clean_runtime_rejects_symlinked_runs_root(tmp_path: Path) -> None:
+    from src.lib.runtime.retention import clean_runtime
+
+    runtime_root = tmp_path / ".agentloom"
+    runtime_root.mkdir()
+    output_root = tmp_path / "applications" / "demo" / "outputs"
+    output_root.mkdir(parents=True)
+    (runtime_root / "runs").symlink_to(output_root, target_is_directory=True)
+    external_run = _make_run(
+        runtime_root,
+        run_id="must-survive",
+        status="completed",
+        age=timedelta(days=8),
+    )
+    deliverable = external_run / "report.md"
+    deliverable.write_text("user output", encoding="utf-8")
+
+    result = clean_runtime(runtime_root, now=NOW)
+
+    assert external_run.exists()
+    assert deliverable.read_text(encoding="utf-8") == "user output"
+    assert result.removed_run_count == 0
+
+
+def test_resolved_runtime_home_preserves_root_symlink_for_cleanup_rejection(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime import resolve_runtime_home
+    from src.lib.runtime.retention import clean_runtime
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outputs = tmp_path / "applications" / "demo" / "outputs"
+    outputs.mkdir(parents=True)
+    runtime_link = repo_root / ".agentloom"
+    runtime_link.symlink_to(outputs, target_is_directory=True)
+    external_run = _make_run(
+        outputs,
+        run_id="external-output",
+        status="completed",
+        age=timedelta(days=365),
+    )
+
+    home = resolve_runtime_home(
+        {"runtime": {"root_dir": ".agentloom"}},
+        agent_root=repo_root,
+    )
+    result = clean_runtime(home.root_dir, now=NOW)
+
+    assert home.root_dir == runtime_link.absolute()
+    assert home.root_dir.is_symlink()
+    assert external_run.exists()
+    assert result.removed_run_count == 0
+
+
+def test_orphaned_running_run_uses_failed_retention_but_live_lease_is_preserved(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime.retention import clean_runtime
+
+    runtime_root = tmp_path / ".agentloom"
+    orphan = _make_run(
+        runtime_root,
+        run_id="orphan",
+        status="running",
+        age=timedelta(days=31),
+    )
+    live = _make_run(
+        runtime_root,
+        run_id="live",
+        status="running",
+        age=timedelta(days=365),
+    )
+    live_fd = os.open(live, os.O_RDONLY)
+    fcntl.flock(live_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        result = clean_runtime(runtime_root, now=NOW)
+    finally:
+        fcntl.flock(live_fd, fcntl.LOCK_UN)
+        os.close(live_fd)
+
+    assert not orphan.exists()
+    assert live.exists()
+    assert result.removed_runs == [orphan]
+
+    second = clean_runtime(runtime_root, now=NOW)
+    assert not live.exists()
+    assert second.removed_runs == [live]
+
+
+def test_cleaner_does_not_remove_a_run_before_its_manifest_and_lease_exist(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime import RuntimeHome
+    from src.lib.runtime.retention import clean_runtime
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="demo",
+        task_id="task",
+        run_id="run-being-created",
+    )
+    context.prepare_run()
+
+    clean_runtime(context.root_dir, now=NOW)
+
+    assert context.run_dir.is_dir()
+    with context.run_lease():
+        context.write_manifest()
+
+
+def test_cleaner_removes_old_crash_before_manifest_temp_but_not_unknown_data(
+    tmp_path: Path,
+) -> None:
+    from src.lib.runtime import RuntimeHome
+    from src.lib.runtime.retention import RetentionPolicy, clean_runtime
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    orphan = home.context(application_id="demo", task_id="task", run_id="orphan")
+    orphan.prepare_run()
+    temp = orphan.run_dir / ".manifest.json.dead.tmp"
+    temp.write_text("partial", encoding="utf-8")
+    unknown = home.context(application_id="demo", task_id="task", run_id="unknown")
+    unknown.prepare_run()
+    (unknown.run_dir / "user-data.txt").write_text("preserve", encoding="utf-8")
+    old = (NOW - timedelta(days=31)).timestamp()
+    for path in [*orphan.run_dir.rglob("*"), orphan.run_dir, *unknown.run_dir.rglob("*"), unknown.run_dir]:
+        os.utime(path, (old, old), follow_symlinks=False)
+
+    result = clean_runtime(
+        home.root_dir,
+        policy=RetentionPolicy(
+            successful_runs=timedelta(0),
+            failed_runs=timedelta(0),
+            raw_artifacts=timedelta(0),
+        ),
+        now=NOW,
+    )
+
+    assert orphan.run_dir in result.removed_runs
+    assert not orphan.run_dir.exists()
+    assert (unknown.run_dir / "user-data.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_maybe_clean_runtime_runs_at_most_once_per_24_hours(tmp_path: Path) -> None:
+    from src.lib.runtime.retention import prune_runtime_if_due
+
+    runtime_root = tmp_path / ".agentloom"
+    first = _make_run(runtime_root, run_id="first", status="completed", age=timedelta(days=8))
+    # A process killed after creating the lock must not throttle maintenance
+    # forever on the next process start.
+    (runtime_root / ".cleanup.lock").write_text("stale", encoding="utf-8")
+
+    runtime_config = {
+        "successful_run_retention_days": 7,
+        "failed_run_retention_days": 30,
+        "artifact_retention_days": 3,
+        "cleanup_interval_hours": 24,
+    }
+    initial = prune_runtime_if_due(runtime_root, runtime_config, now=NOW)
+    assert initial.skipped is False
+    assert not first.exists()
+    assert not (runtime_root / ".cleanup.lock").exists()
+
+    second = _make_run(runtime_root, run_id="second", status="completed", age=timedelta(days=8))
+    throttled = prune_runtime_if_due(runtime_root, runtime_config, now=NOW + timedelta(hours=23))
+    assert throttled.skipped is True
+    assert second.exists()
+
+    resumed = prune_runtime_if_due(runtime_root, runtime_config, now=NOW + timedelta(hours=24))
+    assert resumed.skipped is False
+    assert not second.exists()
+
+
+def test_automatic_cleanup_interval_cannot_be_configured_below_24_hours() -> None:
+    from src.lib.runtime.retention import retention_policy_from_config
+
+    with pytest.raises(ValueError, match="at least 24"):
+        retention_policy_from_config({"cleanup_interval_hours": 23})
+
+
+def test_future_cleanup_state_does_not_throttle_maintenance_forever(tmp_path: Path) -> None:
+    from src.lib.runtime.retention import prune_runtime_if_due
+
+    runtime_root = tmp_path / ".agentloom"
+    expired = _make_run(
+        runtime_root,
+        run_id="expired",
+        status="completed",
+        age=timedelta(days=8),
+    )
+    (runtime_root / ".cleanup-state.json").write_text(
+        json.dumps({"last_completed_at": (NOW + timedelta(days=365)).isoformat()}),
+        encoding="utf-8",
+    )
+
+    result = prune_runtime_if_due(runtime_root, now=NOW)
+
+    assert result.skipped is False
+    assert not expired.exists()
+
+
+def test_runtime_cleanup_respects_concurrent_maintenance_lock(tmp_path: Path) -> None:
+    from src.lib.runtime.retention import maybe_clean_runtime
+
+    runtime_root = tmp_path / ".agentloom"
+    expired = _make_run(
+        runtime_root,
+        run_id="expired",
+        status="completed",
+        age=timedelta(days=8),
+    )
+    lock_fd = os.open(runtime_root, os.O_RDONLY)
+    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        result = maybe_clean_runtime(runtime_root, now=NOW)
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+    assert result.skipped is True
+    assert result.skip_reason == "cleanup already in progress"
+    assert expired.exists()

--- a/tests/lib_test/runtime/test_secure_storage.py
+++ b/tests/lib_test/runtime/test_secure_storage.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.lib.runtime import SecureDirectory
+
+
+def test_append_text_retries_regular_file_short_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = SecureDirectory(tmp_path / "state")
+    real_write = os.write
+
+    def short_write(fd: int, payload) -> int:
+        limit = max(1, len(payload) // 2)
+        return real_write(fd, payload[:limit])
+
+    monkeypatch.setattr(os, "write", short_write)
+    try:
+        storage.append_text("events.jsonl", "0123456789\n")
+    finally:
+        storage.close()
+
+    assert (tmp_path / "state" / "events.jsonl").read_text(encoding="utf-8") == "0123456789\n"
+
+
+def test_append_text_rejects_zero_byte_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = SecureDirectory(tmp_path / "state")
+    monkeypatch.setattr(os, "write", lambda _fd, _payload: 0)
+    try:
+        with pytest.raises(OSError, match="short write"):
+            storage.append_text("events.jsonl", "event\n")
+    finally:
+        storage.close()
+
+
+def test_copy_streams_large_files_and_retries_short_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.bin"
+    payload = (b"0123456789abcdef" * (200 * 1024)) + b"tail"
+    source.write_bytes(payload)
+    source.chmod(0o751)
+    expected_mtime_ns = 1_700_000_000_123_456_789
+    os.utime(source, ns=(expected_mtime_ns, expected_mtime_ns))
+    storage = SecureDirectory(tmp_path / "state")
+    real_write = os.write
+
+    def short_write(fd: int, data) -> int:
+        return real_write(fd, data[: max(1, len(data) // 3)])
+
+    monkeypatch.setattr(os, "write", short_write)
+    try:
+        storage.copy_from(source, "history/backup.bin")
+        restored = tmp_path / "restored.bin"
+        storage.copy_to("history/backup.bin", restored)
+        assert storage.same_content_as("history/backup.bin", source)
+    finally:
+        storage.close()
+
+    assert restored.read_bytes() == payload
+    assert restored.stat().st_mode & 0o777 == 0o751
+    assert restored.stat().st_mtime_ns == expected_mtime_ns
+
+
+def test_copy_rejects_zero_byte_write_without_publishing_partial_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"new payload")
+    storage = SecureDirectory(tmp_path / "state")
+    monkeypatch.setattr(os, "write", lambda _fd, _payload: 0)
+    try:
+        with pytest.raises(OSError, match="short write"):
+            storage.copy_from(source, "backup.bin")
+        assert not (tmp_path / "state" / "backup.bin").exists()
+        assert not list((tmp_path / "state").glob(".*.tmp"))
+    finally:
+        storage.close()

--- a/tests/self_learning_test/test_curated_memory_store.py
+++ b/tests/self_learning_test/test_curated_memory_store.py
@@ -385,7 +385,11 @@ def test_model_memory_never_uses_another_threads_global_application_fallback(
     from src.tools.self_learning.memory_tool import memory
     from src.trace import bind_root_run, clear_current_agent_config, set_current_agent_config
 
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(tmp_path / ".agentloom"))
+    runtime_root = tmp_path / ".agentloom"
+    monkeypatch.setattr(
+        "src.extensions.self_learning.paths._runtime_config_section",
+        lambda: {"root_dir": str(runtime_root)},
+    )
     set_current_agent_config(
         {
             "application_id": "app_from_other_thread",
@@ -410,7 +414,7 @@ def test_model_memory_never_uses_another_threads_global_application_fallback(
         clear_current_agent_config()
 
     assert result == {"ok": False, "error": "missing_agent_context"}
-    assert MemoryStore().list() == []
+    assert MemoryStore(runtime_root / "self_learning.db").list() == []
 
 
 def test_removed_legacy_memory_arguments_fail_loudly(tmp_path: Path) -> None:

--- a/tests/self_learning_test/test_memory_export.py
+++ b/tests/self_learning_test/test_memory_export.py
@@ -13,7 +13,11 @@ from src.extensions.self_learning.memory_store import MemoryStore
 
 @pytest.fixture()
 def seeded_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MemoryStore:
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(tmp_path / ".agentloom"))
+    runtime_root = tmp_path / ".agentloom"
+    monkeypatch.setattr(
+        "src.extensions.self_learning.paths._runtime_config_section",
+        lambda: {"root_dir": str(runtime_root)},
+    )
     config = {
         "application_id": "export_app",
         "self_learning": {"memory": {"write_approval": True}},

--- a/tests/self_learning_test/test_optional_memory_review_runtime.py
+++ b/tests/self_learning_test/test_optional_memory_review_runtime.py
@@ -436,7 +436,7 @@ def test_completed_run_review_skips_without_a_configured_model(
     from src.extensions.self_learning import reviewer
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
 
     def model_must_not_be_resolved(*_args, **_kwargs):
         raise AssertionError("an empty review_model must not resolve or call a model")
@@ -490,7 +490,7 @@ def test_unconfigured_review_is_inert_before_other_memory_config_validation(
     from src.extensions.self_learning import reviewer
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
 
     def model_must_not_be_resolved(*_args, **_kwargs):
         raise AssertionError("an unconfigured review must not resolve a model")
@@ -515,7 +515,7 @@ def test_disabled_self_learning_never_resolves_a_configured_review_model(
     from src.extensions.self_learning import reviewer
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
 
     def model_must_not_be_resolved(*_args, **_kwargs):
         raise AssertionError("disabled self-learning must not resolve a model")
@@ -548,7 +548,7 @@ def test_failed_run_history_is_never_reviewed_into_memory(
     from src.extensions.self_learning.ledger import SelfLearningLedger
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     SelfLearningLedger(state_root / "self_learning.db").append_event(
         CanonicalSessionEvent(
             event_id="event-failed-review",
@@ -590,7 +590,7 @@ def test_task_completion_alone_cannot_start_completed_run_review(
     from src.extensions.self_learning.ledger import SelfLearningLedger
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     ledger = SelfLearningLedger(state_root / "self_learning.db")
     ledger.append_event(
         CanonicalSessionEvent(
@@ -632,7 +632,7 @@ def test_worker_completion_cannot_authorize_root_review(
     from src.extensions.self_learning.ledger import SelfLearningLedger
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     ledger = SelfLearningLedger(state_root / "self_learning.db")
     ledger.append_event(
         CanonicalSessionEvent(
@@ -678,7 +678,7 @@ def test_terminal_audit_rechecks_root_completion_in_its_write_transaction(
     from src.extensions.self_learning.ledger import SelfLearningLedger
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     root_run_id = "root-deleted-after-review-preflight"
     _record_completed_run(state_root, root_run_id)
     ledger = SelfLearningLedger(state_root / "self_learning.db")
@@ -720,7 +720,7 @@ def test_final_summary_without_observed_evidence_is_reviewed_but_cannot_write(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     SelfLearningLedger(state_root / "self_learning.db").append_event(
         CanonicalSessionEvent(
             event_id="event-final-only",
@@ -756,7 +756,7 @@ def test_configured_review_uses_only_memory_and_persists_its_action(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "The verified page size is 100 rows."
     _record_completed_run(
         state_root,
@@ -825,7 +825,7 @@ def test_duplicate_review_add_records_zero_committed_actions(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "The verified page size is 100 rows."
     store = MemoryStore()
     assert store.add("project", durable_fact)["duplicate"] is False
@@ -878,7 +878,7 @@ def test_reviewer_cannot_change_the_scope_authorized_by_tool_code(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "Only this evidence scope may authorize the memory write."
     _record_completed_run(
         state_root,
@@ -916,7 +916,7 @@ def test_application_evidence_uses_the_persisted_event_application_id(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "Only the memory_validation Application uses this format."
     _record_completed_run(
         state_root,
@@ -960,7 +960,7 @@ def test_cross_application_worker_evidence_cannot_authorize_root_review(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "Only worker Application B uses port 9443."
     root_run_id = "root-app-a-with-worker-app-b"
     _record_completed_root_with_worker_evidence(
@@ -1019,7 +1019,7 @@ def test_root_review_accepts_authorized_worker_evidence_without_scope_regression
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = f"Worker evidence remains valid for {trusted_scope} scope."
     root_run_id = f"root-worker-valid-{trusted_scope}"
     _record_completed_root_with_worker_evidence(
@@ -1064,7 +1064,7 @@ def test_completed_review_transaction_rejects_cross_application_worker_evidence(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "Only worker Application B uses this serializer."
     root_run_id = "root-app-a-transaction-guard"
     _record_completed_root_with_worker_evidence(
@@ -1117,7 +1117,7 @@ def test_completed_audit_failure_rolls_back_active_memory_effect(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "The verified page size is 100 rows."
     _record_completed_run(
         state_root,
@@ -1172,7 +1172,7 @@ def test_evidence_deleted_after_digest_cannot_commit_memory(
 
     state_root = tmp_path / ".agentloom"
     db_path = state_root / "self_learning.db"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "The verified page size is 100 rows."
     _record_completed_run(
         state_root,
@@ -1226,7 +1226,7 @@ def test_completed_audit_failure_rolls_back_pending_memory_effect(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "The verified page size is 100 rows."
     _record_completed_run(
         state_root,
@@ -1280,7 +1280,7 @@ def test_configured_review_preserves_the_complete_evidence_bytes(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "  The checksum format is SHA-256.  "
     _record_completed_run(
         state_root,
@@ -1314,7 +1314,7 @@ def test_completed_run_review_cannot_write_a_fact_absent_from_its_evidence(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(
         state_root,
         "root-mismatched-evidence",
@@ -1354,7 +1354,7 @@ def test_completed_run_review_requires_a_literal_evidence_quote(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(
         state_root,
         "root-transformed-evidence",
@@ -1384,7 +1384,7 @@ def test_completed_run_review_is_at_most_once_per_root(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(
         state_root,
         "root-reviewed-once",
@@ -1427,7 +1427,7 @@ def test_completed_run_review_never_persists_a_running_claim(
     from src.extensions.self_learning import reviewer
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     durable_fact = "The verified page size is 100 rows."
     _record_completed_run(
         state_root,
@@ -1472,7 +1472,7 @@ def test_concurrent_completed_run_review_claims_only_one_model(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(
         state_root,
         "root-concurrent-review",
@@ -1515,7 +1515,7 @@ def test_valid_staged_add_terminates_before_another_provider_call(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(
         state_root,
         "root-failed-after-memory",
@@ -1545,7 +1545,7 @@ def test_multi_tool_turn_cannot_commit_a_staged_add(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(
         state_root,
         "root-multi-tool-review",
@@ -1573,7 +1573,7 @@ def test_provider_failure_before_a_memory_call_has_no_effect(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(state_root, "root-provider-failure")
     model = _ImmediateProviderFailureModel("unused")
     monkeypatch.setattr(reviewer, "_resolve_review_model", lambda _model_type: model)
@@ -1596,7 +1596,7 @@ def test_review_budget_counts_and_fences_internal_provider_retries(
     from src.extensions.self_learning import reviewer
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(state_root, "root-provider-retry-budget")
     model = _InternallyRetryingProviderModel()
     monkeypatch.setattr(reviewer, "_resolve_review_model", lambda _model_type: model)
@@ -1620,7 +1620,7 @@ def test_max_steps_review_does_not_commit_rejected_memory_calls(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(state_root, "root-max-steps-review")
     model = _NeverFinishingMemoryReviewModel(
         "This sentence is absent from every observed result."
@@ -1663,7 +1663,7 @@ def test_arbitrary_tool_result_fields_cannot_become_review_evidence(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     claim = "An unsourced message says the page limit is 777 records."
     durable = "The verified page size is 100 rows."
     _record_completed_run(
@@ -1703,7 +1703,7 @@ def test_raw_tool_result_cannot_spoof_the_internal_evidence_envelope(
     )
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     claim = "An unsourced message says the page limit is 777 records."
     _record_completed_run(
         state_root,
@@ -1749,7 +1749,7 @@ def test_session_jsonl_import_cannot_mint_trusted_review_evidence(
     )
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     claim = "An imported JSONL file claims the page limit is 999 records."
     imported = tmp_path / "spoofed-events.jsonl"
     records = [
@@ -1829,7 +1829,7 @@ def test_session_recorder_accepts_only_the_live_envelope_marker(
     )
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     fact = "The contract page size is 250 records."
     base = {
         "cwd": str(tmp_path),
@@ -2031,7 +2031,7 @@ def test_raw_only_progress_cannot_be_written_as_durable_memory(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(
         state_root,
         "root-transient-review",
@@ -2063,7 +2063,7 @@ def test_review_digest_contains_only_completed_tool_results_and_final_summary(
     from src.lib.trusted_memory_evidence import TRUSTED_MEMORY_EVIDENCE_KIND
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     ledger = SelfLearningLedger(state_root / "self_learning.db")
     ledger.append_event(
         CanonicalSessionEvent(
@@ -2166,7 +2166,7 @@ def test_review_digest_keeps_trusted_evidence_when_raw_output_is_truncated(
     from src.extensions.self_learning import reviewer
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     fact = "The checksum algorithm is SHA-256."
     _record_completed_run(
         state_root,
@@ -2190,7 +2190,7 @@ def test_review_digest_blocks_an_injection_bearing_tool_result(
     from src.extensions.self_learning.ledger import SelfLearningLedger
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     marker = "review-secret-marker"
     ledger = SelfLearningLedger(state_root / "self_learning.db")
     ledger.append_event(
@@ -2243,7 +2243,7 @@ def test_blocked_tool_result_cannot_authorize_a_review_memory_write(
     from src.extensions.self_learning.memory_store import MemoryStore
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     ledger = SelfLearningLedger(state_root / "self_learning.db")
     ledger.append_event(
         CanonicalSessionEvent(
@@ -2299,7 +2299,7 @@ def test_review_failure_telemetry_never_logs_provider_error_content(
     from src.extensions.self_learning import reviewer
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     _record_completed_run(
         state_root,
         "root-review-error",

--- a/tests/self_learning_test/test_root_run_context.py
+++ b/tests/self_learning_test/test_root_run_context.py
@@ -128,7 +128,7 @@ def test_unbound_builtin_recorder_does_not_create_persistent_state(
     from src.lib.smolagents.hooks import register_builtin_hooks
 
     state_root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(state_root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(state_root))
     manager = register_builtin_hooks(HookManager())
     seen: list[HookContext] = []
     manager.register_hook(
@@ -466,7 +466,7 @@ def test_disabled_session_tools_fail_closed_before_runtime_or_state_access(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(root))
     monkeypatch.setattr(
         "src.extensions.self_learning.paths.config_bool",
         lambda name, default=True: False if name == "enabled" else default,
@@ -504,7 +504,7 @@ def test_memory_tool_fails_before_creating_state_without_root_context(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     root = tmp_path / ".agentloom"
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(root))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(root))
     from src.tools.self_learning.memory_tool import memory
 
     result = json.loads(memory("list", scope="project"))
@@ -517,7 +517,7 @@ def test_tool_wrapper_propagates_and_refreshes_root_across_executor_thread(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv(
-        "AGENTLOOM_SELF_LEARNING_ROOT", str(tmp_path / ".agentloom")
+        "AGENTLOOM_RUNTIME_ROOT", str(tmp_path / ".agentloom")
     )
     from src.extensions.self_learning.memory_store import MemoryStore
     from src.lib.smolagents.hooks.tool_shim import inject_hooks
@@ -601,7 +601,7 @@ def test_tool_wrapper_propagates_and_refreshes_root_across_executor_thread(
 def test_session_tools_exclude_every_leaf_of_current_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    monkeypatch.setenv("AGENTLOOM_SELF_LEARNING_ROOT", str(tmp_path / ".agentloom"))
+    monkeypatch.setenv("AGENTLOOM_RUNTIME_ROOT", str(tmp_path / ".agentloom"))
     from src.extensions.self_learning.event_schema import CanonicalSessionEvent, now_iso
     from src.extensions.self_learning.ledger import SelfLearningLedger
     from src.tools.self_learning.session_tools import session_scroll, session_search

--- a/tests/skills_test/test_hook_context_large_payload.py
+++ b/tests/skills_test/test_hook_context_large_payload.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -21,10 +22,11 @@ AGENT_LOOM_ROOT = SCRIPT_DIR.parents[1]
 if str(AGENT_LOOM_ROOT) not in sys.path:
     sys.path.insert(0, str(AGENT_LOOM_ROOT))
 
-from src.lib.smolagents.hooks.types import HookContext, HookEvent
-from src.lib.smolagents.skills.executors import create_hook_executor
-from src.lib.smolagents.skills.skills import SkillsManager
+from src.lib.runtime import RuntimeHome, bind_run_context
 from src.lib.smolagents.hooks.hook_manager import HookManager
+from src.lib.smolagents.hooks.types import HookContext, HookEvent
+from src.lib.smolagents.skills.executors import HOOK_STDOUT_MAX_BYTES, create_hook_executor
+from src.lib.smolagents.skills.skills import SkillsManager
 
 
 def _reset_singletons():
@@ -158,6 +160,86 @@ class TestShellExecutorTempFile(unittest.TestCase):
             len(leaked), 0,
             f"Temp files leaked after hook execution: {leaked}"
         )
+
+
+class TestHookRunArtifacts(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.runtime_context = RuntimeHome(self.root / ".agentloom").context(
+            application_id="hook-tests",
+            task_id="task",
+            run_id="run",
+        )
+        self.binding = bind_run_context(self.runtime_context)
+        self.binding.__enter__()
+
+    def tearDown(self):
+        self.binding.__exit__(None, None, None)
+        self.temp_dir.cleanup()
+
+    def _run_script(self, source: str, *, timeout: float = 10):
+        script = self.root / "hook.py"
+        script.write_text(source, encoding="utf-8")
+        executor = create_hook_executor(
+            code=f'"{sys.executable}" "{script}"',
+            skill_name="artifact-skill",
+            skill_dir=str(self.root),
+            logger=logging.getLogger(__name__),
+            timeout=timeout,
+        )
+        return executor(_make_context({"file": "test.txt"}))
+
+    def test_stdout_stderr_and_audit_are_written_to_bound_run(self):
+        result = self._run_script(
+            "import json, sys\n"
+            "sys.stderr.write('diagnostic\\n')\n"
+            "print(json.dumps({'decision': 'allow'}))\n"
+        )
+
+        self.assertTrue(result.success)
+        stdout_path = Path(result.telemetry["stdout_path"])
+        stderr_path = Path(result.telemetry["stderr_path"])
+        audit_dir = stdout_path.parent
+        self.assertTrue(stdout_path.is_relative_to(self.runtime_context.skill_artifacts_dir))
+        self.assertEqual(stderr_path.read_text(encoding="utf-8"), "diagnostic\n")
+        self.assertTrue((audit_dir / "audit.json").is_file())
+        audit = json.loads((audit_dir / "audit.json").read_text(encoding="utf-8"))
+        self.assertEqual(audit["stdout_path"], str(stdout_path))
+        self.assertEqual(audit["stderr_path"], str(stderr_path))
+
+    def test_oversized_hook_json_is_not_buffered_or_copied_into_telemetry(self):
+        output_size = HOOK_STDOUT_MAX_BYTES + 1
+        result = self._run_script(
+            f'import sys\nsys.stdout.write("x" * {output_size})\n'
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.decision, "block")
+        self.assertIn("exceeds", result.reason)
+        stdout_path = Path(result.telemetry["stdout_path"])
+        self.assertEqual(stdout_path.stat().st_size, output_size)
+        self.assertEqual(result.telemetry["stdout_bytes"], output_size)
+        self.assertNotIn("stdout", result.telemetry)
+        self.assertNotIn("stdout_preview", result.telemetry)
+
+    def test_timeout_kills_descendants_before_audit_is_finalized(self):
+        child_code = "import time; time.sleep(0.5); print('late-child', flush=True)"
+        result = self._run_script(
+            "import json, subprocess, sys, time\n"
+            f"subprocess.Popen([{sys.executable!r}, '-c', {child_code!r}])\n"
+            "print(json.dumps({'decision': 'allow'}), flush=True)\n"
+            "time.sleep(5)\n",
+            timeout=0.2,
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("timed out", result.reason)
+        stdout_path = Path(result.telemetry["stdout_path"])
+        stable = stdout_path.read_bytes()
+        time.sleep(0.7)
+        self.assertEqual(stdout_path.read_bytes(), stable)
+        self.assertNotIn(b"late-child", stable)
 
 
 class TestCommonGetHookContext(unittest.TestCase):

--- a/tests/skills_test/test_skill_script_runtime.py
+++ b/tests/skills_test/test_skill_script_runtime.py
@@ -1,10 +1,14 @@
 import json
 import logging
 import os
+import shlex
+import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
+from src.lib.runtime import RuntimeHome, bind_run_context
 from src.lib.smolagents.hooks.hook_manager import HookManager
 from src.lib.smolagents.skills.skills import SkillsManager
 from src.tools.skills import run_skill_script as run_skill_script_tool
@@ -21,6 +25,13 @@ class TestSkillScriptRuntime(unittest.TestCase):
         _reset_singletons()
         self.temp_dir = tempfile.TemporaryDirectory()
         self.root = Path(self.temp_dir.name)
+        self.runtime_context = RuntimeHome(self.root / ".agentloom").context(
+            application_id="skill-tests",
+            task_id="task",
+            run_id="run",
+        )
+        self._runtime_binding = bind_run_context(self.runtime_context)
+        self._runtime_binding.__enter__()
         self.skills_manager = SkillsManager(
             logger=logging.getLogger(__name__),
             hook_manager=HookManager(),
@@ -29,6 +40,7 @@ class TestSkillScriptRuntime(unittest.TestCase):
 
     def tearDown(self):
         clear_current_skills_manager()
+        self._runtime_binding.__exit__(None, None, None)
         self.temp_dir.cleanup()
 
     def _write_skill(self, name: str = "script-skill") -> Path:
@@ -65,6 +77,7 @@ class TestSkillScriptRuntime(unittest.TestCase):
         self.assertEqual(result["returncode"], 0)
         self.assertIn("skill-dir=", result["stdout_preview"])
         audit_dir = Path(result["audit_dir"])
+        self.assertTrue(audit_dir.is_relative_to(self.runtime_context.skill_artifacts_dir))
         self.assertTrue((audit_dir / "audit.json").is_file())
         self.assertTrue((audit_dir / "stdout.txt").is_file())
         self.assertEqual((audit_dir.parent.parent / "result.txt").read_text(encoding="utf-8"), "artifact")
@@ -128,6 +141,56 @@ class TestSkillScriptRuntime(unittest.TestCase):
         self.assertIn("env-ok", result["stdout_preview"])
         self.assertIn("AGENTLOOM_TEST_VISIBLE", result["env_names"])
         self.assertNotIn("AGENTLOOM_TEST_HIDDEN", result["env_names"])
+
+    def test_large_output_is_streamed_to_artifact_with_bounded_preview(self):
+        skill_path = self._write_skill("large-output")
+        script = skill_path.parent / "scripts" / "large.py"
+        output_size = 2 * 1024 * 1024
+        script.write_text(
+            f'import sys\nsys.stdout.write("x" * {output_size})\n',
+            encoding="utf-8",
+        )
+        self.skills_manager.load_skill_metadata(str(skill_path))
+
+        result = self.skills_manager.run_skill_script(
+            "large-output",
+            f"{shlex.quote(sys.executable)} scripts/large.py",
+            timeout=10,
+        )
+
+        stdout_path = Path(result["stdout_path"])
+        self.assertEqual(result["stdout_bytes"], output_size)
+        self.assertTrue(result["stdout_preview_truncated"])
+        self.assertEqual(len(result["stdout_preview"].encode("utf-8")), 4000)
+        self.assertEqual(stdout_path.stat().st_size, output_size)
+
+    def test_timeout_keeps_output_in_current_run_artifact(self):
+        skill_path = self._write_skill("timeout-output")
+        script = skill_path.parent / "scripts" / "timeout.py"
+        child_code = "import time; time.sleep(1.5); print('late-child', flush=True)"
+        script.write_text(
+            "import subprocess, sys, time\n"
+            f"subprocess.Popen([{sys.executable!r}, '-c', {child_code!r}])\n"
+            'sys.stdout.write("before-timeout\\n")\n'
+            "sys.stdout.flush()\n"
+            "time.sleep(5)\n",
+            encoding="utf-8",
+        )
+        self.skills_manager.load_skill_metadata(str(skill_path))
+
+        result = self.skills_manager.run_skill_script(
+            "timeout-output",
+            f"{shlex.quote(sys.executable)} scripts/timeout.py",
+            timeout=1,
+        )
+
+        self.assertTrue(result["timed_out"])
+        self.assertEqual(result["stdout_preview"], "before-timeout\n")
+        stdout_path = Path(result["stdout_path"])
+        self.assertEqual(stdout_path.read_text(encoding="utf-8"), "before-timeout\n")
+        stable_size = stdout_path.stat().st_size
+        time.sleep(0.8)
+        self.assertEqual(stdout_path.stat().st_size, stable_size)
 
 
 if __name__ == "__main__":

--- a/tests/skills_test/test_task_lifecycle_hooks.py
+++ b/tests/skills_test/test_task_lifecycle_hooks.py
@@ -77,11 +77,14 @@ class _RecordingCheckpointCoordinator:
         self.success_memory_steps = None
         self.interrupted_memory_steps = None
 
-    def check_worker_skip(self, agent_name, input_hash):
-        return None
-
-    def record_worker_start(self, agent_name, input_hash, task_input):
-        return 0
+    def prepare_worker_call(
+        self, agent_name, input_hash, task_input, *, runtime_agent=None
+    ):
+        return type(
+            "_Preparation",
+            (),
+            {"call_index": 0, "should_execute": True, "cached_result": None},
+        )()
 
     def restore_worker(self, runtime_agent, agent_name, call_index):
         return False
@@ -514,6 +517,35 @@ class TestTaskLifecycleHooks(unittest.TestCase):
 
         self.assertEqual(result, "ok:do work")
         self.assertEqual(coord.success_memory_steps, ["prompt", "tool", "final"])
+
+    def test_subtask_cached_falsey_result_does_not_execute_runtime(self):
+        class _CachedCoordinator:
+            def __init__(self, result):
+                self.result = result
+
+            def prepare_worker_call(self, *args, **kwargs):
+                return type(
+                    "_Preparation",
+                    (),
+                    {
+                        "call_index": 0,
+                        "should_execute": False,
+                        "cached_result": self.result,
+                    },
+                )()
+
+        class _MustNotRun(_SubtaskRunner):
+            def run(self, task: str, *args, **kwargs):
+                raise AssertionError("cached worker runtime executed")
+
+        for cached_result in ("", None):
+            with self.subTest(cached_result=cached_result):
+                wrapped = SubTaskTrackedAgent(_MustNotRun(), "worker_agent")
+                with patch(
+                    "src.lib.checkpoint.coordinator.CheckpointCoordinator.current",
+                    return_value=_CachedCoordinator(cached_result),
+                ):
+                    self.assertEqual(wrapped.run("do work"), cached_result)
 
     def test_subtask_checkpoint_records_interrupted_runtime_memory(self):
         coord = _RecordingCheckpointCoordinator()

--- a/tests/test_cli_run_transport_exit.py
+++ b/tests/test_cli_run_transport_exit.py
@@ -44,6 +44,35 @@ def _invoke_failure(monkeypatch: pytest.MonkeyPatch, error: BaseException):
     return CliRunner().invoke(main, ["run", "unused.yaml"])
 
 
+def test_run_no_file_log_is_a_real_python_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed = {}
+
+    def succeed(*_args, **kwargs):
+        observed.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("src.runner.run_app", succeed)
+    result = CliRunner().invoke(main, ["run", "unused.yaml", "--no-file-log"])
+
+    assert result.exit_code == 0
+    assert observed["file_logging"] is False
+    assert "log_to_file" not in observed
+
+
+def test_run_uses_configured_file_logging_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed = {}
+
+    def succeed(*_args, **kwargs):
+        observed.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("src.runner.run_app", succeed)
+    result = CliRunner().invoke(main, ["run", "unused.yaml"])
+
+    assert result.exit_code == 0
+    assert observed["file_logging"] is None
+
+
 @pytest.mark.parametrize(
     "error_factory",
     [

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -349,7 +349,11 @@ class TestParallelExecutorContextPropagation:
         from src.lib.checkpoint.checkpoint_manager import CheckpointManager
         from src.lib.checkpoint.coordinator import CheckpointCoordinator, _current_coordinator
 
-        cm = CheckpointManager("parallel_context", base_dir=tmp_path)
+        cm = CheckpointManager(
+            "parallel_context",
+            checkpoints_root=tmp_path,
+            run_id="run_test",
+        )
         coord = CheckpointCoordinator.activate(cm, "task_ctx", "task")
 
         def tool(task_id, **kw):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -6,11 +6,13 @@ instantiating real LLM-backed agents.
 """
 
 import textwrap
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import click
 import pytest
 
 # ---------------------------------------------------------------------------
@@ -173,6 +175,461 @@ class TestRunApp:
         called_task = mock_agent.run.call_args[0][0]
         assert "测试 agent 的描述" in called_task
         assert result == "ok"
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_binds_canonical_run_context_before_agent_execution(self, mock_cls, fake_yaml: Path):
+        from src.lib.runtime import get_current_run_context
+        from src.runner import run_app
+
+        observed = {}
+        mock_agent = MagicMock()
+
+        def _run(_task, **kwargs):
+            context = get_current_run_context(required=True)
+            observed["context"] = context
+            observed["kwargs"] = kwargs
+            observed["manifest_exists"] = context.manifest_path.exists()
+            return "ok"
+
+        mock_agent.run.side_effect = _run
+        mock_cls.return_value = mock_agent
+
+        assert run_app(str(fake_yaml), file_logging=False) == "ok"
+
+        context = observed["context"]
+        assert context.application_id == "test_app"
+        assert observed["manifest_exists"] is True
+        assert observed["kwargs"]["task_id"] == context.task_id
+        assert observed["kwargs"]["run_id"] == context.run_id
+        assert context.manifest_path.parent == context.run_dir
+        assert not context.log_path.exists()
+        assert context.task_tree_path.exists()
+        assert not (fake_yaml.parents[3] / ".logs").exists()
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_run_finally_releases_shell_sessions_and_background_tasks(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ):
+        import os
+        import subprocess
+
+        from src.lib.runtime import bind_run_context, get_current_run_context
+        from src.tools.shell.background_task import BackgroundTaskRegistry
+        from src.tools.shell.process import ShellProcessRegistry
+        from src.trace import clear_current_agent_id, set_current_agent_id
+        from src.runner import run_app
+
+        BackgroundTaskRegistry._reset_instance()
+        observed = {}
+        mock_agent = MagicMock()
+
+        def _run(_task, **_kwargs):
+            context = get_current_run_context(required=True)
+            set_current_agent_id("runner-cleanup-agent")
+            ShellProcessRegistry.get_instance().get_or_create(
+                "runner-cleanup-agent",
+                session_scoped=False,
+            )
+            context.background_artifacts_dir.mkdir(parents=True, exist_ok=True)
+            output_path = context.background_artifacts_dir / "runner-cleanup.txt"
+            output_fd = os.open(output_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND)
+            process = subprocess.Popen(
+                ["sleep", "60"],
+                stdout=output_fd,
+                stderr=output_fd,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            os.close(output_fd)
+            task_id = BackgroundTaskRegistry.get_instance().register(
+                process,
+                "sleep 60",
+                str(output_path),
+            )
+            observed.update(context=context, process=process, task_id=task_id)
+            return "ok"
+
+        mock_agent.run.side_effect = _run
+        mock_cls.return_value = mock_agent
+
+        try:
+            assert run_app(str(fake_yaml), file_logging=False) == "ok"
+            observed["process"].wait(timeout=5)
+
+            with bind_run_context(observed["context"]):
+                set_current_agent_id("runner-cleanup-agent")
+                assert ShellProcessRegistry.get_instance().registered_agent_ids() == []
+                assert BackgroundTaskRegistry.get_instance().list_all() == []
+        finally:
+            clear_current_agent_id()
+            process = observed.get("process")
+            if process is not None and process.poll() is None:
+                process.kill()
+                process.wait(timeout=2)
+            BackgroundTaskRegistry._reset_instance()
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_automatic_run_cleanup_never_traverses_checkpoints(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+        monkeypatch,
+    ) -> None:
+        from src.runner import run_app
+
+        mock_cls.return_value.run.return_value = "ok"
+        monkeypatch.setattr(
+            "src.lib.runtime.retention.prune_runtime_if_due",
+            lambda *_args, **_kwargs: SimpleNamespace(skipped=False),
+        )
+        monkeypatch.setattr(
+            "src.lib.checkpoint.cleanup_expired_tasks",
+            lambda **_kwargs: pytest.fail("run retention touched checkpoints"),
+        )
+
+        assert run_app(str(fake_yaml), file_logging=False) == "ok"
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_run_lease_covers_manifest_and_logging_configuration(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+        monkeypatch,
+    ) -> None:
+        from src.lib.logging import LoggingConfigBuilder
+        from src.lib.runtime.retention import RetentionPolicy, clean_runtime
+        from src.runner import run_app
+
+        mock_cls.return_value.run.return_value = "ok"
+        original_apply = LoggingConfigBuilder.apply_mapping
+        observed = {}
+
+        def apply_while_cleaning(builder, *args, **kwargs):
+            runtime_root = fake_yaml.parents[3] / ".agentloom"
+            result = clean_runtime(
+                runtime_root,
+                policy=RetentionPolicy(
+                    successful_runs=timedelta(0),
+                    failed_runs=timedelta(0),
+                    raw_artifacts=timedelta(0),
+                ),
+                now=datetime.now(UTC) + timedelta(seconds=1),
+            )
+            observed["removed"] = result.removed_run_count
+            return original_apply(builder, *args, **kwargs)
+
+        monkeypatch.setattr(LoggingConfigBuilder, "apply_mapping", apply_while_cleaning)
+
+        assert run_app(str(fake_yaml), file_logging=False) == "ok"
+        assert observed["removed"] == 0
+
+    def test_concurrent_applications_and_same_application_tasks_keep_logs_isolated(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        from src.lib.logging import get_logger
+        from src.lib.runtime import get_current_run_context
+        from src.runner import run_app
+
+        workflows = []
+        for application in ("alpha", "beta"):
+            workflow_dir = tmp_path / "applications" / application / "workflows"
+            workflow_dir.mkdir(parents=True)
+            workflow = workflow_dir / "agent.yaml"
+            workflow.write_text(
+                _SAMPLE_YAML.replace('name: "test_agent"', f'name: "{application}_agent"'),
+                encoding="utf-8",
+            )
+            workflows.extend([workflow, workflow])
+
+        monkeypatch.setattr("src.runner.C", _fake_c(tmp_path))
+        barrier = threading.Barrier(len(workflows))
+        contexts = []
+        contexts_lock = threading.Lock()
+        lazy_logger = get_logger("tests.concurrent_runner")
+
+        class FakeSupervisor:
+            def __init__(self, config, logger):
+                self.config = config
+
+            def run(self, _task, **_kwargs):
+                context = get_current_run_context(required=True)
+                marker = f"only-{context.task_id}"
+                barrier.wait(timeout=10)
+                lazy_logger.info(marker)
+                with contexts_lock:
+                    contexts.append((context, marker))
+                return marker
+
+        monkeypatch.setattr("src.runner.YamlConfiguredSupervisorAgent", FakeSupervisor)
+        with ThreadPoolExecutor(max_workers=len(workflows)) as executor:
+            results = list(executor.map(lambda path: run_app(path), workflows))
+
+        assert len(results) == len(workflows)
+        assert len({context.task_id for context, _marker in contexts}) == len(workflows)
+        assert len({context.run_id for context, _marker in contexts}) == len(workflows)
+        assert {context.application_id for context, _marker in contexts} == {"alpha", "beta"}
+        for context, marker in contexts:
+            log_text = context.log_path.read_text(encoding="utf-8")
+            assert marker in log_text
+            assert all(
+                other_marker not in log_text
+                for _other_context, other_marker in contexts
+                if other_marker != marker
+            )
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_resume_creates_new_run_but_reuses_task_checkpoint(self, mock_cls, fake_yaml: Path):
+        from src.lib.runtime import get_current_run_context
+        from src.runner import run_app
+
+        attempts = []
+        mock_agent = MagicMock()
+
+        def _run(_task, **kwargs):
+            attempts.append((get_current_run_context(required=True), kwargs))
+            return "ok"
+
+        mock_agent.run.side_effect = _run
+        mock_cls.return_value = mock_agent
+
+        run_app(str(fake_yaml), file_logging=False)
+        first_context, first_kwargs = attempts[0]
+        run_app(
+            str(fake_yaml),
+            resume_task_id=first_context.task_id,
+            file_logging=False,
+        )
+        second_context, second_kwargs = attempts[1]
+
+        assert second_context.task_id == first_context.task_id
+        assert second_context.run_id != first_context.run_id
+        assert second_context.run_dir != first_context.run_dir
+        assert second_context.checkpoint_dir == first_context.checkpoint_dir
+        assert first_kwargs["resume"] is False
+        assert second_kwargs["resume"] is True
+
+    @pytest.mark.parametrize(
+        ("created_at", "error"),
+        [
+            ("not-a-timestamp", "invalid created_at"),
+            ("", "invalid created_at"),
+            (
+                (datetime.now(UTC) - timedelta(days=30))
+                .replace(tzinfo=None)
+                .isoformat(),
+                "expired",
+            ),
+        ],
+    )
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_resume_rejects_invalid_or_expired_naive_created_at(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+        created_at: str,
+        error: str,
+    ) -> None:
+        from src.lib.checkpoint import CheckpointManager
+        from src.lib.runtime import RuntimeHome
+        from src.runner import run_app
+
+        context = RuntimeHome(fake_yaml.parents[3] / ".agentloom").context(
+            application_id="test_app",
+            task_id="invalid_created_at",
+            run_id="old_run",
+        )
+        manager = CheckpointManager(
+            "supervisor",
+            checkpoint_dir=context.checkpoint_dir,
+            run_id="old_run",
+        )
+        manager.save_task_tree(
+            context.task_id,
+            {
+                "task_id": context.task_id,
+                "status": "interrupted",
+                "created_at": created_at,
+                "workers": {},
+            },
+        )
+        manager.close()
+
+        with pytest.raises(FileNotFoundError, match=error):
+            run_app(
+                str(fake_yaml),
+                resume_task_id=context.task_id,
+                file_logging=False,
+            )
+
+        mock_cls.assert_not_called()
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_resume_rejects_completed_checkpoint(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        from src.lib.checkpoint import CheckpointManager
+        from src.lib.runtime import RuntimeHome
+        from src.runner import run_app
+
+        context = RuntimeHome(fake_yaml.parents[3] / ".agentloom").context(
+            application_id="test_app",
+            task_id="completed_task",
+            run_id="old_run",
+        )
+        manager = CheckpointManager(
+            "supervisor",
+            checkpoint_dir=context.checkpoint_dir,
+            run_id="old_run",
+        )
+        manager.save_task_tree(
+            context.task_id,
+            {
+                "task_id": context.task_id,
+                "status": "completed",
+                "created_at": datetime.now(UTC).isoformat(),
+                "workers": {},
+            },
+        )
+        manager.close()
+
+        with pytest.raises(ValueError, match="not resumable.*completed"):
+            run_app(
+                str(fake_yaml),
+                resume_task_id=context.task_id,
+                file_logging=False,
+            )
+
+        mock_cls.assert_not_called()
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_concurrent_resume_of_same_task_is_rejected(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        from src.runner import run_app
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = "initial"
+        mock_cls.return_value = mock_agent
+        run_app(str(fake_yaml), file_logging=False)
+        checkpoint_root = fake_yaml.parents[3] / ".agentloom" / "checkpoints" / "test_app"
+        logical_task_id = next(checkpoint_root.iterdir()).name
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocking_resume(_task, **_kwargs):
+            entered.set()
+            assert release.wait(timeout=10)
+            return "resumed"
+
+        mock_agent.run.side_effect = blocking_resume
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            first_resume = executor.submit(
+                run_app,
+                str(fake_yaml),
+                resume_task_id=logical_task_id,
+                file_logging=False,
+            )
+            assert entered.wait(timeout=10)
+            try:
+                with pytest.raises(RuntimeError, match="already active"):
+                    run_app(
+                        str(fake_yaml),
+                        resume_task_id=logical_task_id,
+                        file_logging=False,
+                    )
+            finally:
+                release.set()
+            assert first_resume.result(timeout=10) == "resumed"
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_automatic_run_cleanup_preserves_expired_checkpoints(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        from src.lib.checkpoint import CheckpointManager
+        from src.lib.runtime import RuntimeHome
+        from src.runner import run_app
+
+        home = RuntimeHome(fake_yaml.parents[3] / ".agentloom")
+
+        def make_expired(task_id: str):
+            context = home.context(
+                application_id="test_app",
+                task_id=task_id,
+                run_id=f"run_{task_id}",
+            )
+            manager = CheckpointManager("supervisor", checkpoint_dir=context.checkpoint_dir)
+            manager.save_task_tree(
+                context.task_id,
+                {
+                    "task_id": context.task_id,
+                    "status": "failed",
+                    "created_at": (
+                        datetime.now(UTC) - timedelta(days=8)
+                    ).isoformat(),
+                    "workers": {},
+                },
+            )
+            return context
+
+        mock_cls.return_value.run.return_value = "ok"
+        first_expired = make_expired("expired_first")
+
+        run_app(str(fake_yaml), file_logging=False)
+
+        assert first_expired.checkpoint_dir.exists()
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_resume_rejects_symlinked_application_checkpoint_directory(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        from src.lib.checkpoint import CheckpointManager
+        from src.runner import run_app
+
+        runtime_root = fake_yaml.parents[3] / ".agentloom"
+        external_app = fake_yaml.parents[3] / "external-checkpoints"
+        manager = CheckpointManager(
+            "supervisor",
+            checkpoint_dir=external_app / "outside_task",
+            run_id="old_run",
+        )
+        manager.save_task_tree(
+            "outside_task",
+            {
+                "task_id": "outside_task",
+                "status": "interrupted",
+                "created_at": datetime.now(UTC).isoformat(),
+                "workers": {},
+            },
+        )
+        checkpoints = runtime_root / "checkpoints"
+        checkpoints.mkdir(parents=True, exist_ok=True)
+        (checkpoints / "test_app").symlink_to(
+            external_app,
+            target_is_directory=True,
+        )
+
+        with pytest.raises(RuntimeError, match="symlink"):
+            run_app(
+                str(fake_yaml),
+                resume_task_id="outside_task",
+                file_logging=False,
+            )
+
+        assert (external_app / "outside_task" / "task_tree.json").exists()
+        mock_cls.assert_not_called()
 
     @patch("src.runner.YamlConfiguredSupervisorAgent")
     def test_relative_path(self, mock_cls, fake_yaml: Path):

--- a/tests/tools_test/shell/test_background_task.py
+++ b/tests/tools_test/shell/test_background_task.py
@@ -26,6 +26,7 @@ def _reset_registry():
 # BackgroundTaskState unit tests
 # ---------------------------------------------------------------------------
 
+
 class TestBackgroundTaskState:
     """Unit tests for the BackgroundTaskState dataclass."""
 
@@ -145,6 +146,7 @@ class TestBackgroundTaskState:
 # BackgroundTaskRegistry tests
 # ---------------------------------------------------------------------------
 
+
 class TestBackgroundTaskRegistry:
     """Tests for the registry lifecycle and thread safety."""
 
@@ -206,11 +208,54 @@ class TestBackgroundTaskRegistry:
         proc, out = self._spawn_sleeper()
         try:
             tid = registry.register(proc, "sleep 60", out)
+            output_reader = registry.get(tid)._output_reader
+            assert output_reader is not None
+            assert output_reader.closed is False
             assert registry.remove(tid) is True
+            assert output_reader.closed is True
             assert registry.get(tid) is None
             assert registry.remove(tid) is False
         finally:
             self._cleanup_proc(proc)
+
+    def test_reset_closes_retained_output_reader(self):
+        registry = BackgroundTaskRegistry.get_instance()
+        proc, out = self._spawn_sleeper()
+        tid = registry.register(proc, "sleep 60", out)
+        output_reader = registry.get(tid)._output_reader
+        assert output_reader is not None
+
+        BackgroundTaskRegistry._reset_instance()
+
+        assert output_reader.closed is True
+        proc.wait(timeout=5)
+
+    def test_register_rejects_a_write_fd_whose_path_now_points_to_another_inode(
+        self,
+        tmp_path,
+    ):
+        registry = BackgroundTaskRegistry.get_instance()
+        output_path = tmp_path / "output.txt"
+        output_path.write_text("FIRST", encoding="utf-8")
+        output_fd = os.open(output_path, os.O_WRONLY)
+        output_path.rename(tmp_path / "detached.txt")
+        output_path.write_text("SECOND-SECRET", encoding="utf-8")
+
+        class Process:
+            pid = 12345
+
+        try:
+            with pytest.raises(RuntimeError, match="writer inode"):
+                registry.register(
+                    Process(),
+                    "test",
+                    str(output_path),
+                    output_fd=output_fd,
+                )
+        finally:
+            os.close(output_fd)
+
+        assert registry.list_all() == []
 
     def test_kill_task(self):
         registry = BackgroundTaskRegistry.get_instance()

--- a/tests/tools_test/shell/test_background_task_tools.py
+++ b/tests/tools_test/shell/test_background_task_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.lib.runtime import RuntimeHome, bind_run_context
 from src.tools.shell.background_task import BackgroundTaskRegistry
 from src.tools.shell.background_task_tools import (
     check_background_task,
@@ -24,7 +25,7 @@ def _reset_registry():
     BackgroundTaskRegistry._reset_instance()
 
 
-def _spawn_and_register(cmd_args, command_str="test cmd"):
+def _spawn_and_register(cmd_args, command_str="test cmd", size_watchdog=None):
     """Helper: spawn a process and register as background task."""
     fd, out_path = tempfile.mkstemp(prefix="test_bgt_", suffix=".txt")
     os.close(fd)
@@ -38,7 +39,12 @@ def _spawn_and_register(cmd_args, command_str="test cmd"):
     )
     os.close(out_fd)
     registry = BackgroundTaskRegistry.get_instance()
-    tid = registry.register(proc, command_str, out_path)
+    tid = registry.register(
+        proc,
+        command_str,
+        out_path,
+        size_watchdog=size_watchdog,
+    )
     return proc, tid, out_path
 
 
@@ -102,12 +108,13 @@ class TestCheckBackgroundTask:
 
     def test_check_shows_stall_warning_from_watchdog(self):
         with patch("src.tools.shell.background_task.C") as mock_c:
-            mock_c.get_nested = MagicMock(side_effect=lambda *args, **kwargs: {
-                ("shell_settings", "background_tasks", "max_concurrent"): 10,
-                ("shell_settings", "background_tasks", "stall_detection"): True,
-                ("shell_settings", "background_tasks",
-                 "stall_threshold_seconds"): 0.5,
-            }.get(args, kwargs.get("default", None)))
+            mock_c.get_nested = MagicMock(
+                side_effect=lambda *args, **kwargs: {
+                    ("shell_settings", "background_tasks", "max_concurrent"): 10,
+                    ("shell_settings", "background_tasks", "stall_detection"): True,
+                    ("shell_settings", "background_tasks", "stall_threshold_seconds"): 0.5,
+                }.get(args, kwargs.get("default", None))
+            )
 
             proc, tid, _ = _spawn_and_register(
                 ["sh", "-c", 'printf "Continue? (y/n) "; sleep 300'],
@@ -172,6 +179,128 @@ class TestListBackgroundTasks:
     def test_list_empty(self):
         result = list_background_tasks()
         assert "no background tasks" in result.lower()
+
+    def test_tasks_are_invisible_and_unkillable_from_another_run(self, tmp_path):
+        home = RuntimeHome(tmp_path / ".agentloom")
+        first = home.context(application_id="alpha", task_id="task-a", run_id="run-a")
+        second = home.context(application_id="beta", task_id="task-b", run_id="run-b")
+
+        with bind_run_context(first):
+            proc, task_id, _ = _spawn_and_register(["sleep", "60"], "alpha-only")
+
+        try:
+            with bind_run_context(second):
+                assert task_id not in list_background_tasks()
+                check_result = check_background_task(task_id)
+                assert "no background task found" in check_result.lower()
+                assert "alpha-only" not in check_result
+                assert "no background task found" in kill_background_task(task_id).lower()
+                assert proc.poll() is None
+
+            with bind_run_context(first):
+                assert task_id in list_background_tasks()
+                assert task_id in check_background_task(task_id)
+                assert "killed" in kill_background_task(task_id).lower()
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    def test_terminate_current_run_kills_only_owned_tasks_and_stops_watchdogs(
+        self,
+        tmp_path,
+    ):
+        class RecordingWatchdog:
+            def __init__(self):
+                self.stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        home = RuntimeHome(tmp_path / ".agentloom")
+        first = home.context(application_id="alpha", task_id="task-a", run_id="run-a")
+        second = home.context(application_id="beta", task_id="task-b", run_id="run-b")
+        registry = BackgroundTaskRegistry.get_instance()
+        first_watchdog = RecordingWatchdog()
+        second_watchdog = RecordingWatchdog()
+
+        with bind_run_context(first):
+            first_proc, first_task_id, first_output = _spawn_and_register(
+                ["sleep", "60"],
+                "alpha-task",
+                size_watchdog=first_watchdog,
+            )
+
+        with bind_run_context(second):
+            second_proc, second_task_id, second_output = _spawn_and_register(
+                ["sleep", "60"],
+                "beta-task",
+                size_watchdog=second_watchdog,
+            )
+
+        with bind_run_context(first):
+            first_reader = registry.get(first_task_id)._output_reader
+        with bind_run_context(second):
+            second_reader = registry.get(second_task_id)._output_reader
+        assert first_reader is not None
+        assert second_reader is not None
+
+        try:
+            with bind_run_context(first):
+                assert registry.terminate_current_run() == 1
+                first_proc.wait(timeout=5)
+                assert registry.list_all() == []
+
+            assert first_watchdog.stopped is True
+            assert first_reader.closed is True
+            assert second_watchdog.stopped is False
+            assert second_reader.closed is False
+            assert second_proc.poll() is None
+
+            with bind_run_context(second):
+                assert [task.task_id for task in registry.list_all()] == [second_task_id]
+                assert registry.terminate_current_run() == 1
+                second_proc.wait(timeout=5)
+            assert second_watchdog.stopped is True
+            assert second_reader.closed is True
+        finally:
+            for proc in (first_proc, second_proc):
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=2)
+            for path in (first_output, second_output):
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+
+    def test_terminate_without_runtime_context_is_a_noop(self, tmp_path):
+        home = RuntimeHome(tmp_path / ".agentloom")
+        context = home.context(
+            application_id="alpha",
+            task_id="task-a",
+            run_id="run-a",
+        )
+        registry = BackgroundTaskRegistry.get_instance()
+
+        with bind_run_context(context):
+            proc, task_id, output_path = _spawn_and_register(["sleep", "60"])
+
+        try:
+            assert registry.terminate_current_run() == 0
+            assert proc.poll() is None
+            with bind_run_context(context):
+                assert registry.get(task_id) is not None
+                assert registry.terminate_current_run() == 1
+                proc.wait(timeout=5)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+            try:
+                os.unlink(output_path)
+            except FileNotFoundError:
+                pass
 
     def test_list_with_tasks(self):
         proc1, tid1, _ = _spawn_and_register(["sleep", "60"], "cmd1")

--- a/tests/tools_test/shell/test_context_injection.py
+++ b/tests/tools_test/shell/test_context_injection.py
@@ -231,7 +231,7 @@ def test_valid_config_execution(clean_registry):
         assert any(s in shell_output.lower() for s in ("bash", "zsh", "sh")), \
             f"Expected a valid shell, got {shell_output}"
 
-def test_concurrent_shell_execution_isolation(clean_registry, monkeypatch):
+def test_concurrent_shell_execution_isolation(clean_registry, monkeypatch, tmp_path):
     """
     Test that multiple agents running concurrently in different threads 
     can execute shell commands in their isolated environments (one bash, one zsh)
@@ -248,25 +248,36 @@ def test_concurrent_shell_execution_isolation(clean_registry, monkeypatch):
     monkeypatch.setattr(validator_module, 'load_allowed_commands', lambda: ['mkdir', 'cd', 'pwd', 'echo'])
 
     results = {}
+    from src.lib.runtime import RuntimeHome, bind_run_context
+
+    run_context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="concurrent-shell-test",
+        task_id="task-concurrent",
+        run_id="run-concurrent",
+    )
 
     def worker(agent_id, subdir):
         try:
-            with task_context(f"task_{agent_id}"):
-                set_current_agent_id(agent_id)
-                set_current_agent_config({"execution_env": {}})
+            with bind_run_context(run_context):
+                try:
+                    with task_context(f"task_{agent_id}"):
+                        set_current_agent_id(agent_id)
+                        set_current_agent_config({"execution_env": {}})
 
-                # Each agent cd's to a different workspace-relative directory.
-                shell_tool(f"mkdir -p {subdir}", load_profile=False)
-                shell_tool(f"cd {subdir}", load_profile=False)
+                        # Each agent cd's to a different workspace-relative directory.
+                        shell_tool(f"mkdir -p {subdir}", load_profile=False)
+                        shell_tool(f"cd {subdir}", load_profile=False)
 
-                # Sleep a bit to encourage thread interleaving.
-                time.sleep(0.1)
+                        # Sleep a bit to encourage thread interleaving.
+                        time.sleep(0.1)
 
-                output_pwd = shell_tool("pwd", load_profile=False).strip()
+                        output_pwd = shell_tool("pwd", load_profile=False).strip()
 
-                results[agent_id] = {
-                    "cwd": output_pwd,
-                }
+                        results[agent_id] = {
+                            "cwd": output_pwd,
+                        }
+                finally:
+                    ShellProcessRegistry.get_instance().release(agent_id)
         except Exception as e:
             results[agent_id] = {"error": str(e)}
 

--- a/tests/tools_test/shell/test_env_isolation.py
+++ b/tests/tools_test/shell/test_env_isolation.py
@@ -226,30 +226,41 @@ def test_zsh_load_profile_isolation(clean_registry, monkeypatch):
             assert "/bin" in output_true or "/usr" in output_true, \
                 "load_profile=True should provide a proper PATH"
 
-def test_cross_agent_cwd_isolation(bypass_shell_security):
+def test_cross_agent_cwd_isolation(bypass_shell_security, tmp_path):
     """
     Test that changing the current working directory in Agent A does not
     affect the current working directory in Agent B.
     """
+    from src.lib.runtime import RuntimeHome, bind_run_context
     from src.trace.task_context import task_context, sub_task_context, set_current_agent_id
-    with task_context("test_task_cwd_isolation"):
-        # Agent A changes directory
-        with sub_task_context("agent_A_cwd"):
-            set_current_agent_id("agent_A_cwd_id")
-            original_dir_a = shell_tool("pwd", load_profile=False).strip()
-            shell_tool("cd /tmp", load_profile=False)
-            new_dir_a = shell_tool("pwd", load_profile=False).strip()
-            assert new_dir_a == os.path.normpath("/tmp"), (
-                "Agent A failed to change directory"
-            )
 
-        # Agent B should still be in its original directory
-        with sub_task_context("agent_B_cwd"):
-            set_current_agent_id("agent_B_cwd_id")
-            dir_b = shell_tool("pwd", load_profile=False).strip()
-            assert dir_b != os.path.normpath("/tmp"), (
-                "Agent B's working directory was polluted by Agent A"
-            )
+    run_context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="cwd-isolation-test",
+        task_id="task-cwd",
+        run_id="run-cwd",
+    )
+    with bind_run_context(run_context):
+        try:
+            with task_context("test_task_cwd_isolation"):
+                # Agent A changes directory
+                with sub_task_context("agent_A_cwd"):
+                    set_current_agent_id("agent_A_cwd_id")
+                    original_dir_a = shell_tool("pwd", load_profile=False).strip()
+                    shell_tool("cd /tmp", load_profile=False)
+                    new_dir_a = shell_tool("pwd", load_profile=False).strip()
+                    assert new_dir_a == os.path.normpath("/tmp"), (
+                        "Agent A failed to change directory"
+                    )
+
+                # Agent B should still be in its original directory
+                with sub_task_context("agent_B_cwd"):
+                    set_current_agent_id("agent_B_cwd_id")
+                    dir_b = shell_tool("pwd", load_profile=False).strip()
+                    assert dir_b != os.path.normpath("/tmp"), (
+                        "Agent B's working directory was polluted by Agent A"
+                    )
+        finally:
+            ShellProcessRegistry.get_instance().release_current_run()
 
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/tools_test/shell/test_path_security.py
+++ b/tests/tools_test/shell/test_path_security.py
@@ -437,7 +437,11 @@ class TestShellToolCwdPlumbing:
         """shell_tool should call validate_command with session CWD."""
         from unittest.mock import patch as mp
 
-        with mp("src.tools.shell.shell_tool.get_current_agent_id", return_value="agent-1"), \
+        with mp(
+                 "src.tools.shell.shell_tool.capture_explicit_execution_context",
+                 return_value=MagicMock(agent_id="agent-1"),
+             ), \
+             mp("src.tools.shell.shell_tool.get_current_run_context", return_value=MagicMock()), \
              mp("src.tools.shell.shell_tool.ShellProcessRegistry") as mock_registry_cls:
 
             mock_registry = MagicMock()
@@ -462,7 +466,11 @@ class TestShellToolCwdPlumbing:
         """When no agent context, cwd=None is passed (falls back to os.getcwd)."""
         from unittest.mock import patch as mp
 
-        with mp("src.tools.shell.shell_tool.get_current_agent_id", return_value=None), \
+        with mp(
+                 "src.tools.shell.shell_tool.capture_explicit_execution_context",
+                 return_value=MagicMock(agent_id="fallback-must-not-be-used"),
+             ), \
+             mp("src.tools.shell.shell_tool.get_current_run_context", return_value=None), \
              mp("src.tools.shell.shell_tool.validate_command") as mock_validate:
 
             mock_validate.side_effect = ValueError("blocked for test")

--- a/tests/tools_test/shell/test_run_scoped_artifacts.py
+++ b/tests/tools_test/shell/test_run_scoped_artifacts.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.lib.runtime import RuntimeHome, bind_run_context, copy_runtime_context
+
+
+def test_shell_audit_is_jsonl_in_the_current_run(tmp_path: Path) -> None:
+    from src.tools.shell.shell_audit_log import (
+        get_shell_audit_logger,
+        reset_audit_loggers,
+    )
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="search",
+        task_id="task-1",
+        run_id="run-1",
+    )
+    reset_audit_loggers()
+    with bind_run_context(context):
+        audit = get_shell_audit_logger("worker")
+        audit._enabled = True
+        audit._log_policy_snapshot = False
+        audit.log_security_block("rm -rf /", "destructive", "blocked")
+        assert Path(audit.get_log_path() or "") == context.shell_audit_path
+
+    lines = context.shell_audit_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    event = json.loads(lines[0])
+    assert event["event_type"] == "SECURITY_BLOCK"
+    assert event["agent"] == "worker"
+    assert event["command"] == "rm -rf /"
+    assert event["check_id"] == "destructive"
+
+
+def test_large_shell_output_spills_to_the_current_run(tmp_path: Path) -> None:
+    from src.tools.shell.output_interceptor import OutputInterceptor
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="search",
+        task_id="task-1",
+        run_id="run-1",
+    )
+    with bind_run_context(context):
+        output = OutputInterceptor(preview_bytes=8)
+        output.write("0123456789abcdef")
+        output.finalize()
+
+    assert output.artifact_path is not None
+    artifact = Path(output.artifact_path)
+    assert artifact.parent == context.shell_artifacts_dir
+    assert artifact.read_text(encoding="utf-8") == "0123456789abcdef"
+
+
+def test_background_shell_output_belongs_to_the_current_run(tmp_path: Path) -> None:
+    from src.tools.shell.background_task import BackgroundTaskRegistry
+    from src.tools.shell.shell_tool import shell_tool
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="search",
+        task_id="task-1",
+        run_id="run-1",
+    )
+    registry = BackgroundTaskRegistry.get_instance()
+    try:
+        with bind_run_context(context):
+            result = shell_tool("printf background-output", run_in_background=True)
+            assert "[Background Task:" in result
+            task = registry.list_all()[-1]
+            assert Path(task.output_path).parent == context.background_artifacts_dir
+    finally:
+        BackgroundTaskRegistry._reset_instance()
+
+
+def test_background_check_keeps_the_original_output_inode_when_directory_is_replaced(
+    tmp_path: Path,
+) -> None:
+    import os
+    import subprocess
+
+    from src.tools.shell.background_task import BackgroundTaskRegistry
+    from src.tools.shell.background_task_tools import check_background_task
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="first", task_id="task", run_id="run")
+    second = home.context(application_id="second", task_id="task", run_id="run")
+    first.prepare_run()
+    second.prepare_run()
+    registry = BackgroundTaskRegistry.get_instance()
+    process = None
+    output_fd = -1
+
+    try:
+        with bind_run_context(first):
+            output_fd, output_path = first.allocate_artifact(
+                "background",
+                prefix="background-",
+                suffix=".txt",
+            )
+            os.write(output_fd, b"FIRST-RUN-OUTPUT\n")
+            process = subprocess.Popen(
+                ["sleep", "60"],
+                stdout=output_fd,
+                stderr=output_fd,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            task_id = registry.register(
+                process,
+                "sleep 60",
+                str(output_path),
+                output_fd=output_fd,
+            )
+            os.close(output_fd)
+            output_fd = -1
+
+            detached = first.run_dir / "background-detached"
+            first.background_artifacts_dir.rename(detached)
+            first.background_artifacts_dir.symlink_to(
+                second.background_artifacts_dir,
+                target_is_directory=True,
+            )
+            (second.background_artifacts_dir / output_path.name).write_text(
+                "SECOND-RUN-SECRET\n",
+                encoding="utf-8",
+            )
+
+            rendered = check_background_task(task_id)
+
+        assert "FIRST-RUN-OUTPUT" in rendered
+        assert "SECOND-RUN-SECRET" not in rendered
+    finally:
+        if output_fd >= 0:
+            os.close(output_fd)
+        BackgroundTaskRegistry._reset_instance()
+        if process is not None and process.poll() is None:
+            process.kill()
+            process.wait(timeout=2)
+
+
+def test_explicit_background_shell_requires_a_runtime_context() -> None:
+    from src.tools.shell.shell_tool import shell_tool
+
+    with pytest.raises(RuntimeError, match="RuntimeContext"):
+        shell_tool("printf no-run-context", run_in_background=True)
+
+
+def test_background_spawn_failure_removes_partial_run_artifact(tmp_path: Path) -> None:
+    from src.tools.shell.shell_tool import shell_tool
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="search",
+        task_id="task",
+        run_id="run",
+    )
+    context.prepare_run()
+    with (
+        bind_run_context(context),
+        patch(
+            "subprocess.Popen",
+            side_effect=OSError("spawn failed"),
+        ),
+    ):
+        with pytest.raises(OSError, match="spawn failed"):
+            shell_tool("printf never-started", run_in_background=True)
+
+    assert list(context.background_artifacts_dir.iterdir()) == []
+
+
+def test_shell_audit_rotation_keeps_two_backups(tmp_path: Path) -> None:
+    from src.tools.shell.shell_audit_log import ShellAuditLogger
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="search",
+        task_id="task-1",
+        run_id="run-1",
+    )
+    with bind_run_context(context):
+        audit = ShellAuditLogger(
+            "worker",
+            runtime_context=context,
+            max_file_bytes=220,
+            backup_count=2,
+        )
+        audit._enabled = True
+        audit._log_policy_snapshot = False
+        for index in range(20):
+            audit.log_security_block(
+                f"command-{index}",
+                "check",
+                "x" * 80,
+            )
+        audit.close()
+
+    assert context.shell_audit_path.exists()
+    assert Path(f"{context.shell_audit_path}.1").exists()
+    assert Path(f"{context.shell_audit_path}.2").exists()
+    assert not Path(f"{context.shell_audit_path}.3").exists()
+
+
+def test_shell_audit_keeps_opened_directory_when_path_is_replaced(tmp_path: Path) -> None:
+    from src.tools.shell.shell_audit_log import ShellAuditLogger
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="first", task_id="task", run_id="run")
+    second = home.context(application_id="second", task_id="task", run_id="run")
+    first.prepare_run()
+    second.prepare_run()
+    second.shell_audit_path.write_text("SECOND-ONLY\n", encoding="utf-8")
+    detached_audit = first.run_dir / "audit-detached"
+
+    with bind_run_context(first):
+        audit = ShellAuditLogger("worker", runtime_context=first)
+        audit._enabled = True
+        audit._log_policy_snapshot = False
+        first.audit_dir.rename(detached_audit)
+        first.audit_dir.symlink_to(second.audit_dir, target_is_directory=True)
+        audit.log_security_block("FIRST-ONLY", "check", "message")
+        audit.close()
+
+    assert second.shell_audit_path.read_text(encoding="utf-8") == "SECOND-ONLY\n"
+    assert "FIRST-ONLY" in (detached_audit / "shell.jsonl").read_text(encoding="utf-8")
+
+
+def test_large_output_does_not_follow_replaced_shell_artifact_directory(
+    tmp_path: Path,
+) -> None:
+    from src.tools.shell.output_interceptor import OutputInterceptor
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="first", task_id="task", run_id="run")
+    second = home.context(application_id="second", task_id="task", run_id="run")
+    first.prepare_run()
+    second.prepare_run()
+    first.shell_artifacts_dir.rmdir()
+    first.shell_artifacts_dir.symlink_to(
+        second.shell_artifacts_dir,
+        target_is_directory=True,
+    )
+
+    with bind_run_context(first):
+        interceptor = OutputInterceptor(preview_bytes=8)
+        interceptor.write("FIRST-SECRET-LARGE-OUTPUT")
+        rendered = interceptor.finalize()
+
+    assert "saved to" not in rendered
+    assert list(second.shell_artifacts_dir.iterdir()) == []
+
+
+def test_sequential_runs_do_not_reuse_shell_audit_sinks(tmp_path: Path) -> None:
+    from src.tools.shell.shell_audit_log import (
+        get_shell_audit_logger,
+        reset_audit_loggers,
+    )
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    first = home.context(application_id="alpha", task_id="task-a", run_id="run-a")
+    second = home.context(application_id="beta", task_id="task-b", run_id="run-b")
+    reset_audit_loggers()
+
+    with bind_run_context(first):
+        audit = get_shell_audit_logger("worker")
+        audit._enabled = True
+        audit._log_policy_snapshot = False
+        audit.log_security_block("first-only", "check", "message")
+    with bind_run_context(second):
+        audit = get_shell_audit_logger("worker")
+        audit._enabled = True
+        audit._log_policy_snapshot = False
+        audit.log_security_block("second-only", "check", "message")
+
+    first_text = first.shell_audit_path.read_text(encoding="utf-8")
+    second_text = second.shell_audit_path.read_text(encoding="utf-8")
+    assert "first-only" in first_text and "second-only" not in first_text
+    assert "second-only" in second_text and "first-only" not in second_text
+
+
+def test_concurrent_runs_keep_shell_audit_contexts_isolated(tmp_path: Path) -> None:
+    from src.tools.shell.shell_audit_log import (
+        get_shell_audit_logger,
+        reset_audit_loggers,
+    )
+
+    home = RuntimeHome(tmp_path / ".agentloom")
+    contexts = [
+        home.context(application_id="alpha", task_id="task-a", run_id="run-a"),
+        home.context(application_id="beta", task_id="task-b", run_id="run-b"),
+    ]
+    reset_audit_loggers()
+
+    def write(context, message: str) -> None:
+        with bind_run_context(context):
+            audit = get_shell_audit_logger("worker")
+            audit._enabled = True
+            audit._log_policy_snapshot = False
+            audit.log_security_block(message, "check", "message")
+
+    threads = [
+        threading.Thread(target=write, args=(contexts[0], "alpha-only")),
+        threading.Thread(target=write, args=(contexts[1], "beta-only")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    alpha = contexts[0].shell_audit_path.read_text(encoding="utf-8")
+    beta = contexts[1].shell_audit_path.read_text(encoding="utf-8")
+    assert "alpha-only" in alpha and "beta-only" not in alpha
+    assert "beta-only" in beta and "alpha-only" not in beta
+
+
+def test_run_logger_scope_closes_shell_audit_handler(tmp_path: Path) -> None:
+    from src.lib.logging import (
+        LoggingConfigBuilder,
+        bind_logger_backend,
+        initialize_run_logger,
+    )
+    from src.tools.shell.shell_audit_log import get_shell_audit_logger
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(application_id="search", task_id="task", run_id="run")
+    config = LoggingConfigBuilder().apply_mapping({"console_enabled": False, "file_enabled": False}, source="test")
+    with bind_run_context(context):
+        backend = initialize_run_logger(context, logging_builder=config)
+        with bind_logger_backend(backend, context=context):
+            audit = get_shell_audit_logger("worker")
+            audit._enabled = True
+            audit._log_policy_snapshot = False
+            audit.log_security_block("command", "check", "message")
+            handler = audit._sink._handler
+            assert handler is not None and handler.stream is not None
+            stale_thread_context = copy_runtime_context()
+
+        assert handler.stream is None
+
+    stale_thread_context.run(lambda: audit.log_security_block("after-run", "check", "message"))
+    assert "after-run" not in context.shell_audit_path.read_text(encoding="utf-8")
+
+
+def test_shell_audit_agent_never_reads_process_global_trace_fallback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    import importlib
+    from dataclasses import replace
+
+    from src.tools.shell.shell_audit_log import get_shell_audit_logger, reset_audit_loggers
+    from src.trace import (
+        bind_explicit_execution_context,
+        capture_explicit_execution_context,
+    )
+
+    task_context_module = importlib.import_module("src.trace.task_context")
+
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="search",
+        task_id="task",
+        run_id="run",
+    )
+    monkeypatch.setattr(task_context_module, "_global_agent_name_fallback", "wrong-agent")
+    reset_audit_loggers()
+
+    explicit = replace(
+        capture_explicit_execution_context(),
+        task_id=None,
+        sub_task_id=None,
+        agent_id=None,
+        agent_name=None,
+    )
+    with bind_run_context(context), bind_explicit_execution_context(explicit):
+        audit = get_shell_audit_logger()
+        audit._enabled = True
+        audit._log_policy_snapshot = False
+        audit.log_security_block("command", "check", "message")
+
+    event = json.loads(context.shell_audit_path.read_text(encoding="utf-8"))
+    assert event["agent"] == "_global"

--- a/tests/tools_test/shell/test_shell_audit_log.py
+++ b/tests/tools_test/shell/test_shell_audit_log.py
@@ -7,42 +7,36 @@ Covers:
 - Integration: audit events fired from security/path/validator/process pipelines
 """
 
-import os
+import json
 import re
 import threading
-import tempfile
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.lib.runtime import RuntimeHome, bind_run_context, copy_runtime_context
 from src.tools.shell.shell_audit_log import (
     ShellAuditLogger,
     get_shell_audit_logger,
     reset_audit_loggers,
-    EVENT_SECURITY_BLOCK,
-    EVENT_PATH_VIOLATION,
-    EVENT_WHITELIST_REJECT,
-    EVENT_STALL_DETECTED,
-    EVENT_TIMEOUT,
-    EVENT_BACKGROUND_PROMOTION,
-    EVENT_SANDBOX_WRAP,
-    EVENT_SANDBOX_UNAVAILABLE,
-    EVENT_COMMAND_SUCCESS,
-    EVENT_POLICY_SNAPSHOT,
 )
-
 
 # =========================================================================
 # Fixtures
 # =========================================================================
 
 @pytest.fixture(autouse=True)
-def _reset_loggers():
-    """Clear cached audit logger instances before/after each test."""
+def _reset_loggers(tmp_path):
+    """Bind every test to a canonical run and reset cached audit loggers."""
     reset_audit_loggers()
-    yield
-    reset_audit_loggers()
+    runtime_context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="shell-audit-tests",
+        task_id="task",
+        run_id="run",
+    )
+    with bind_run_context(runtime_context):
+        yield runtime_context
+        reset_audit_loggers()
 
 
 @pytest.fixture
@@ -54,7 +48,7 @@ def tmp_log_dir(tmp_path):
 @pytest.fixture
 def enabled_audit(tmp_log_dir):
     """Create an audit logger with audit enabled."""
-    audit = ShellAuditLogger("test_agent", log_dir=tmp_log_dir)
+    audit = ShellAuditLogger("test_agent")
     audit._enabled = True
     audit._log_success = False
     return audit
@@ -63,7 +57,7 @@ def enabled_audit(tmp_log_dir):
 @pytest.fixture
 def disabled_audit(tmp_log_dir):
     """Create an audit logger with audit disabled."""
-    audit = ShellAuditLogger("test_agent", log_dir=tmp_log_dir)
+    audit = ShellAuditLogger("test_agent")
     audit._enabled = False
     return audit
 
@@ -74,6 +68,14 @@ def _read_audit_file(audit: ShellAuditLogger) -> str:
     if path.exists():
         return path.read_text(encoding="utf-8")
     return ""
+
+
+def _read_audit_events(audit: ShellAuditLogger) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in _read_audit_file(audit).splitlines()
+        if line.strip()
+    ]
 
 
 # =========================================================================
@@ -93,24 +95,20 @@ class TestAuditFileCreation:
         )
         assert enabled_audit.file_path.exists()
 
-    def test_audit_file_in_agent_timestamp_subdirectory(self, tmp_log_dir):
-        """File should be at {log_dir}/{agent_name}/{timestamp}/shell_audit.log."""
-        audit = ShellAuditLogger("my_agent", log_dir=tmp_log_dir)
+    def test_audit_uses_the_canonical_run_path(self, _reset_loggers):
+        audit = ShellAuditLogger("my_agent")
         audit._enabled = True
         path = audit.file_path
-        # Parent is the timestamp directory; grandparent is the agent directory.
-        assert path.parent.parent.name == "my_agent"
-        assert path.name == "shell_audit.log"
-        assert path.suffix == ".log"
+        assert path == _reset_loggers.shell_audit_path
+        assert path.name == "shell.jsonl"
+        assert path.suffix == ".jsonl"
 
-    def test_fallback_global_agent_name(self, tmp_log_dir):
-        """When agent name is _global, files go to a sanitized subdir."""
-        audit = ShellAuditLogger("_global", log_dir=tmp_log_dir)
+    def test_agent_name_is_metadata_not_a_path_component(self, _reset_loggers):
+        audit = ShellAuditLogger("_global")
         audit._enabled = True
-        path = audit.file_path
-        # _sanitize_component strips leading underscores/dots
-        # Grandparent is the agent dir, parent is the timestamp dir.
-        assert "global" in path.parent.parent.name
+        audit.log_security_block("cmd", "check", "message")
+        assert audit.file_path == _reset_loggers.shell_audit_path
+        assert _read_audit_events(audit)[-1]["agent"] == "_global"
 
 
 class TestEntryFormatting:
@@ -123,22 +121,14 @@ class TestEntryFormatting:
             check_id="command_substitution",
             message="Blocked: $() command substitution detected",
         )
-        content = _read_audit_file(enabled_audit)
-
-        # Timestamp format
-        assert re.search(r"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]", content)
-        # Event type
-        assert "[SECURITY_BLOCK]" in content
-        # Agent name
-        assert "agent=test_agent" in content
-        # Command
-        assert "command: $(cat /etc/passwd)" in content
-        # Check ID
-        assert "check: command_substitution" in content
-        # Message
-        assert "message: Blocked: $() command substitution detected" in content
-        # Suggestion with correct check_id
-        assert "command_substitution: false" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert re.match(r"\d{4}-\d{2}-\d{2}T", event["timestamp"])
+        assert event["event_type"] == "SECURITY_BLOCK"
+        assert event["agent"] == "test_agent"
+        assert event["command"] == "$(cat /etc/passwd)"
+        assert event["check_id"] == "command_substitution"
+        assert event["message"] == "Blocked: $() command substitution detected"
+        assert "command_substitution: false" in event["suggestion"]
 
     def test_path_violation_entry_format(self, enabled_audit):
         """Path violation entry should include the offending path."""
@@ -147,13 +137,12 @@ class TestEntryFormatting:
             message="'/etc/passwd' is outside allowed workspace",
             path="/etc/passwd",
         )
-        content = _read_audit_file(enabled_audit)
-
-        assert "[PATH_VIOLATION]" in content
-        assert "command: cat /etc/passwd" in content
-        assert "message: '/etc/passwd' is outside allowed workspace" in content
-        assert "path_validation" in content
-        assert "include_paths" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "PATH_VIOLATION"
+        assert event["command"] == "cat /etc/passwd"
+        assert event["message"] == "'/etc/passwd' is outside allowed workspace"
+        assert "path_validation" in event["suggestion"]
+        assert "include_paths" in event["suggestion"]
 
     def test_whitelist_rejection_entry_format(self, enabled_audit):
         """Whitelist rejection should include the rejected command name."""
@@ -162,11 +151,10 @@ class TestEntryFormatting:
             message="Command not allowed: wget. Allowed commands: ls, cat",
             name="wget",
         )
-        content = _read_audit_file(enabled_audit)
-
-        assert "[WHITELIST_REJECT]" in content
-        assert "command: wget http://evil.com" in content
-        assert "allowed_commands" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "WHITELIST_REJECT"
+        assert event["command"] == "wget http://evil.com"
+        assert "allowed_commands" in event["suggestion"]
 
     def test_stall_detected_entry_format(self, enabled_audit):
         """Stall detection entry should include PID and elapsed time."""
@@ -176,12 +164,11 @@ class TestEntryFormatting:
             elapsed=47.0,
             stall_message='Task "fg-12345" appears to be waiting for input',
         )
-        content = _read_audit_file(enabled_audit)
-
-        assert "[STALL_DETECTED]" in content
-        assert "pid: 12345" in content
-        assert "elapsed_seconds: 47.0" in content
-        assert "non-interactive" in content.lower() or "--yes" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "STALL_DETECTED"
+        assert event["details"]["pid"] == "12345"
+        assert event["details"]["elapsed_seconds"] == "47.0"
+        assert "non-interactive" in event["suggestion"].lower() or "--yes" in event["suggestion"]
 
     def test_timeout_entry_format(self, enabled_audit):
         """Timeout entry should include timeout duration."""
@@ -190,11 +177,10 @@ class TestEntryFormatting:
             timeout=120.0,
             promoted=False,
         )
-        content = _read_audit_file(enabled_audit)
-
-        assert "[TIMEOUT]" in content
-        assert "timeout_seconds: 120.0" in content
-        assert "run_in_background" in content.lower() or "timeout" in content.lower()
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "TIMEOUT"
+        assert event["details"]["timeout_seconds"] == "120.0"
+        assert "run_in_background" in event["suggestion"] or "timeout" in event["suggestion"].lower()
 
     def test_background_promotion_entry_format(self, enabled_audit):
         """Background promotion entry should include task ID."""
@@ -204,10 +190,9 @@ class TestEntryFormatting:
             promoted=True,
             task_id="bg-abc-123",
         )
-        content = _read_audit_file(enabled_audit)
-
-        assert "[BACKGROUND_PROMOTION]" in content
-        assert "task_id: bg-abc-123" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "BACKGROUND_PROMOTION"
+        assert event["details"]["task_id"] == "bg-abc-123"
 
     def test_sandbox_wrap_entry_format(self, enabled_audit):
         """Sandbox wrap entry should include sandbox mode."""
@@ -215,10 +200,9 @@ class TestEntryFormatting:
             command="npm install",
             sandbox_mode="seatbelt",
         )
-        content = _read_audit_file(enabled_audit)
-
-        assert "[SANDBOX_WRAP]" in content
-        assert "seatbelt" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "SANDBOX_WRAP"
+        assert "seatbelt" in event["message"]
 
     def test_sandbox_unavailable_entry_format(self, enabled_audit):
         """Sandbox unavailable entry should include mode and reason."""
@@ -227,11 +211,10 @@ class TestEntryFormatting:
             sandbox_mode="bwrap",
             reason="bubblewrap is not installed",
         )
-        content = _read_audit_file(enabled_audit)
-
-        assert "[SANDBOX_UNAVAILABLE]" in content
-        assert "bwrap" in content
-        assert "bubblewrap is not installed" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "SANDBOX_UNAVAILABLE"
+        assert "bwrap" in event["message"]
+        assert "bubblewrap is not installed" in event["message"]
 
     def test_policy_snapshot_records_all_allow_defaults(self, enabled_audit):
         """Policy snapshot should make wildcard all-allow settings explicit."""
@@ -259,12 +242,12 @@ class TestEntryFormatting:
         ):
             enabled_audit.log_effective_policy()
 
-        content = _read_audit_file(enabled_audit)
-        assert "[POLICY_SNAPSHOT]" in content
-        assert "allowed_commands: * (all command names allowed)" in content
-        assert "allowed_operators: * (all shell operators allowed)" in content
-        assert "command_success_logging: false" in content
-        assert "sandbox_enabled: false (effective_agent_config)" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "POLICY_SNAPSHOT"
+        assert event["details"]["allowed_commands"] == "* (all command names allowed)"
+        assert event["details"]["allowed_operators"] == "* (all shell operators allowed)"
+        assert event["details"]["command_success_logging"] == "false"
+        assert event["details"]["sandbox_enabled"] == "false (effective_agent_config)"
 
     def test_policy_snapshot_logged_only_once(self, enabled_audit):
         """Repeated snapshot calls should not duplicate policy entries."""
@@ -272,9 +255,9 @@ class TestEntryFormatting:
         enabled_audit.log_effective_policy()
         enabled_audit.log_security_block("cmd", "check", "msg")
 
-        content = _read_audit_file(enabled_audit)
-        assert content.count("[POLICY_SNAPSHOT]") == 1
-        assert content.count("[SECURITY_BLOCK]") == 1
+        types = [event["event_type"] for event in _read_audit_events(enabled_audit)]
+        assert types.count("POLICY_SNAPSHOT") == 1
+        assert types.count("SECURITY_BLOCK") == 1
 
     def test_command_success_not_logged_by_default(self, enabled_audit):
         """Success events should NOT be logged when log_success=False."""
@@ -294,9 +277,9 @@ class TestEntryFormatting:
             exit_code=0,
             duration=0.5,
         )
-        content = _read_audit_file(enabled_audit)
-        assert "[COMMAND_SUCCESS]" in content
-        assert "exit_code=0" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "COMMAND_SUCCESS"
+        assert "exit_code=0" in event["message"]
 
 
 class TestMultipleEntries:
@@ -308,18 +291,17 @@ class TestMultipleEntries:
         enabled_audit.log_security_block("cmd2", "check2", "msg2")
         enabled_audit.log_path_violation("cmd3", "msg3", "/etc")
 
-        content = _read_audit_file(enabled_audit)
-        assert content.count("[SECURITY_BLOCK]") == 2
-        assert content.count("[PATH_VIOLATION]") == 1
+        types = [event["event_type"] for event in _read_audit_events(enabled_audit)]
+        assert types.count("SECURITY_BLOCK") == 2
+        assert types.count("PATH_VIOLATION") == 1
 
-    def test_entries_separated_by_blank_lines(self, enabled_audit):
-        """Each entry should be separated by a blank line."""
+    def test_each_entry_is_one_json_line(self, enabled_audit):
         enabled_audit.log_security_block("cmd1", "check1", "msg1")
         enabled_audit.log_security_block("cmd2", "check2", "msg2")
 
-        content = _read_audit_file(enabled_audit)
-        # Two entries means at least one blank-line separator
-        assert "\n\n" in content
+        lines = _read_audit_file(enabled_audit).splitlines()
+        assert len(lines) == 3  # one policy snapshot plus two events
+        assert all(isinstance(json.loads(line), dict) for line in lines)
 
 
 # =========================================================================
@@ -327,27 +309,25 @@ class TestMultipleEntries:
 # =========================================================================
 
 class TestPerAgentIsolation:
-    """Verify that different agents write to separate log files."""
+    """Verify that agent identity does not split one run's audit stream."""
 
-    def test_different_agents_different_files(self, tmp_log_dir):
-        """Two agents should write to different directories."""
-        audit_a = ShellAuditLogger("agent_alpha", log_dir=tmp_log_dir)
+    def test_different_agents_share_the_run_file_with_distinct_metadata(self):
+        audit_a = ShellAuditLogger("agent_alpha")
         audit_a._enabled = True
-        audit_b = ShellAuditLogger("agent_beta", log_dir=tmp_log_dir)
+        audit_a._log_policy_snapshot = False
+        audit_b = ShellAuditLogger("agent_beta")
         audit_b._enabled = True
+        audit_b._log_policy_snapshot = False
 
         audit_a.log_security_block("cmd_a", "check_a", "msg_a")
         audit_b.log_security_block("cmd_b", "check_b", "msg_b")
 
-        content_a = _read_audit_file(audit_a)
-        content_b = _read_audit_file(audit_b)
-
-        assert "agent_alpha" in str(audit_a.file_path)
-        assert "agent_beta" in str(audit_b.file_path)
-        assert "cmd_a" in content_a
-        assert "cmd_b" in content_b
-        assert "cmd_a" not in content_b
-        assert "cmd_b" not in content_a
+        assert audit_a.file_path == audit_b.file_path
+        events = _read_audit_events(audit_a)
+        assert {(event["agent"], event["command"]) for event in events} == {
+            ("agent_alpha", "cmd_a"),
+            ("agent_beta", "cmd_b"),
+        }
 
 
 # =========================================================================
@@ -372,12 +352,12 @@ class TestDisabledAudit:
 class TestErrorResilience:
     """Verify that audit logging errors never crash the shell pipeline."""
 
-    def test_unwritable_directory_does_not_raise(self, tmp_log_dir):
+    def test_unwritable_directory_does_not_raise(self):
         """Writing to an unwritable directory should fail silently."""
-        audit = ShellAuditLogger("test_agent", log_dir="/proc/nonexistent")
+        audit = ShellAuditLogger("test_agent")
         audit._enabled = True
-        # Force resolve to a bad path
-        audit._file_path = Path("/proc/nonexistent/shell_audit.log")
+        audit._sink._handler = MagicMock()
+        audit._sink._handler.emit.side_effect = OSError("unwritable")
 
         # Should not raise
         audit.log_security_block("cmd", "check", "msg")
@@ -397,7 +377,15 @@ class TestErrorResilience:
             except Exception as e:
                 errors.append(e)
 
-        threads = [threading.Thread(target=writer, args=(t,)) for t in range(5)]
+        threads = []
+        for index in range(5):
+            thread_context = copy_runtime_context()
+            threads.append(
+                threading.Thread(
+                    target=thread_context.run,
+                    args=(writer, index),
+                )
+            )
         for t in threads:
             t.start()
         for t in threads:
@@ -405,9 +393,56 @@ class TestErrorResilience:
 
         assert not errors, f"Errors during concurrent writes: {errors}"
 
-        content = _read_audit_file(enabled_audit)
-        # All 100 entries should be present (5 threads * 20 each)
-        assert content.count("[SECURITY_BLOCK]") == 100
+        events = _read_audit_events(enabled_audit)
+        assert sum(event["event_type"] == "SECURITY_BLOCK" for event in events) == 100
+
+    def test_multiple_agents_share_one_rotating_sink(self, _reset_loggers):
+        """Concurrent agents must not race separate handlers during rollover."""
+        audits = [
+            ShellAuditLogger(
+                f"agent_{index}",
+                max_file_bytes=16 * 1024,
+                backup_count=15,
+            )
+            for index in range(4)
+        ]
+        for audit in audits:
+            audit._enabled = True
+            audit._log_policy_snapshot = False
+
+        def writer(agent_index):
+            audit = audits[agent_index]
+            for event_index in range(50):
+                audit.log_security_block(
+                    command=f"cmd_{agent_index}_{event_index}",
+                    check_id="concurrent_rollover",
+                    message="x" * 80,
+                )
+
+        threads = []
+        for index in range(len(audits)):
+            thread_context = copy_runtime_context()
+            threads.append(
+                threading.Thread(
+                    target=thread_context.run,
+                    args=(writer, index),
+                )
+            )
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        commands = set()
+        for path in _reset_loggers.audit_dir.glob("shell.jsonl*"):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                commands.add(json.loads(line)["command"])
+
+        assert commands == {
+            f"cmd_{agent_index}_{event_index}"
+            for agent_index in range(4)
+            for event_index in range(50)
+        }
 
 
 # =========================================================================
@@ -439,18 +474,16 @@ class TestBoundaryConditions:
     def test_empty_command(self, enabled_audit):
         """Empty command string should still produce a valid entry."""
         enabled_audit.log_security_block("", "check", "msg")
-        content = _read_audit_file(enabled_audit)
-        assert "[SECURITY_BLOCK]" in content
-        assert "command: " in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "SECURITY_BLOCK"
+        assert event["command"] == ""
 
-    def test_special_characters_in_agent_name(self, tmp_log_dir):
-        """Agent names with special characters should be sanitized."""
-        audit = ShellAuditLogger("agent/with spaces!@#", log_dir=tmp_log_dir)
+    def test_special_characters_in_agent_name_are_event_metadata(self):
+        audit = ShellAuditLogger("agent/with spaces!@#")
         audit._enabled = True
-        path = audit.file_path
-        # Directory name should be sanitized (no slashes, spaces, etc.)
-        assert "/" not in path.parent.name or str(tmp_log_dir) in str(path)
-        assert " " not in path.parent.name
+        audit._log_policy_snapshot = False
+        audit.log_security_block("cmd", "check", "message")
+        assert _read_audit_events(audit)[-1]["agent"] == "agent/with spaces!@#"
 
     def test_unicode_in_command(self, enabled_audit):
         """Unicode characters in command should be written correctly."""
@@ -466,25 +499,22 @@ class TestBoundaryConditions:
         enabled_audit.log_security_block(
             "cmd", "check", "line1\nline2\nline3"
         )
-        content = _read_audit_file(enabled_audit)
-        assert "[SECURITY_BLOCK]" in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert event["event_type"] == "SECURITY_BLOCK"
+        assert event["message"] == "line1\nline2\nline3"
 
-    def test_duplicate_timestamp_collision(self, tmp_log_dir):
-        """Two loggers created at the same time should get different dirs."""
-        audit1 = ShellAuditLogger("same_agent", log_dir=tmp_log_dir)
+    def test_run_sink_is_stable(self):
+        audit1 = ShellAuditLogger("same_agent")
         audit1._enabled = True
         # Force file creation for audit1
         audit1.log_security_block("cmd1", "c1", "m1")
 
-        audit2 = ShellAuditLogger("same_agent", log_dir=tmp_log_dir)
+        audit2 = ShellAuditLogger("same_agent")
         audit2._enabled = True
-        # Force file creation for audit2 — should detect collision on timestamp dir
+        # Runtime isolation is keyed by RuntimeContext rather than timestamps.
         path2 = audit2.file_path
-        # Both files are named shell_audit.log but in different timestamp dirs
-        assert path2.name == "shell_audit.log"
-        assert audit1.file_path.name == "shell_audit.log"
-        # They should be under the same agent parent directory
-        assert path2.parent.parent == audit1.file_path.parent.parent
+        assert path2.name == "shell.jsonl"
+        assert path2 == audit1.file_path
 
 
 # =========================================================================
@@ -496,30 +526,30 @@ class TestGetShellAuditLogger:
 
     def test_returns_same_instance_for_same_agent(self, tmp_log_dir):
         """Same agent name should return the same cached instance."""
-        a1 = get_shell_audit_logger("agent_x", log_dir=tmp_log_dir)
-        a2 = get_shell_audit_logger("agent_x", log_dir=tmp_log_dir)
+        a1 = get_shell_audit_logger("agent_x")
+        a2 = get_shell_audit_logger("agent_x")
         assert a1 is a2
 
     def test_returns_different_instances_for_different_agents(self, tmp_log_dir):
         """Different agent names should return different instances."""
-        a1 = get_shell_audit_logger("agent_x", log_dir=tmp_log_dir)
-        a2 = get_shell_audit_logger("agent_y", log_dir=tmp_log_dir)
+        a1 = get_shell_audit_logger("agent_x")
+        a2 = get_shell_audit_logger("agent_y")
         assert a1 is not a2
 
     def test_fallback_to_global_when_no_agent_context(self, tmp_log_dir):
         """Should fall back to _global when no agent context."""
         with patch("src.trace.task_context.get_current_agent_name",
                     side_effect=Exception("no context")):
-            audit = get_shell_audit_logger(log_dir=tmp_log_dir)
+            audit = get_shell_audit_logger()
         # We can't check the name directly since the factory may have
         # caught the exception; just verify it returns an instance.
         assert isinstance(audit, ShellAuditLogger)
 
     def test_reset_clears_cache(self, tmp_log_dir):
         """reset_audit_loggers() should clear the cache."""
-        a1 = get_shell_audit_logger("agent_x", log_dir=tmp_log_dir)
+        a1 = get_shell_audit_logger("agent_x")
         reset_audit_loggers()
-        a2 = get_shell_audit_logger("agent_x", log_dir=tmp_log_dir)
+        a2 = get_shell_audit_logger("agent_x")
         assert a1 is not a2
 
 
@@ -532,28 +562,28 @@ class TestConfigIntegration:
 
     def test_enabled_reads_from_config(self, tmp_log_dir):
         """enabled property should read from tools.shell.audit_log.enabled."""
-        audit = ShellAuditLogger("test", log_dir=tmp_log_dir)
+        audit = ShellAuditLogger("test")
         with patch("src.tools.shell.shell_audit_log.C") as mock_c:
             mock_c.get_nested.return_value = False
             assert audit.enabled is False
 
     def test_enabled_coerces_string_true(self, tmp_log_dir):
         """String 'true' should be coerced to boolean True."""
-        audit = ShellAuditLogger("test", log_dir=tmp_log_dir)
+        audit = ShellAuditLogger("test")
         with patch("src.tools.shell.shell_audit_log.C") as mock_c:
             mock_c.get_nested.return_value = "true"
             assert audit.enabled is True
 
     def test_enabled_coerces_string_false(self, tmp_log_dir):
         """String 'false' should be coerced to boolean False."""
-        audit = ShellAuditLogger("test", log_dir=tmp_log_dir)
+        audit = ShellAuditLogger("test")
         with patch("src.tools.shell.shell_audit_log.C") as mock_c:
             mock_c.get_nested.return_value = "false"
             assert audit.enabled is False
 
     def test_log_success_default_false(self, tmp_log_dir):
         """log_success should default to False."""
-        audit = ShellAuditLogger("test", log_dir=tmp_log_dir)
+        audit = ShellAuditLogger("test")
         with patch("src.tools.shell.shell_audit_log.C") as mock_c:
             mock_c.get_nested.return_value = False
             assert audit.log_success is False
@@ -649,12 +679,11 @@ class TestSecurityPipelineIntegration:
                             with pytest.raises(ValueError):
                                 validate_command("echo a ; echo b")
 
-        content = _read_audit_file(enabled_audit)
-        assert "Command not allowed: date. Allowed commands: cat, echo, pwd" in content
-        assert "Operator not allowed: ;. Allowed operators: &&, |" in content
-        assert 'allowed_commands: ["date", ...]' in content
-        assert 'allowed_operators: [";", ...]' in content
-        assert 'allowed_commands: [";", ...]' not in content
+        events = _read_audit_events(enabled_audit)
+        assert any("Command not allowed: date. Allowed commands: cat, echo, pwd" in event.get("message", "") for event in events)
+        operator = next(event for event in events if "Operator not allowed" in event.get("message", ""))
+        assert 'allowed_operators: [";", ...]' in operator["suggestion"]
+        assert 'allowed_commands: [";", ...]' not in operator["suggestion"]
 
 
 # =========================================================================
@@ -699,10 +728,10 @@ class TestSuggestionContent:
             "Operator not allowed: ;. Allowed operators: &&, |",
             ";",
         )
-        content = _read_audit_file(enabled_audit)
-        assert "allowed_operators" in content
-        assert '[";", ...]' in content
-        assert 'allowed_commands: [";", ...]' not in content
+        event = _read_audit_events(enabled_audit)[-1]
+        assert "allowed_operators" in event["suggestion"]
+        assert '[";", ...]' in event["suggestion"]
+        assert 'allowed_commands: [";", ...]' not in event["suggestion"]
 
     def test_stall_suggestion_mentions_non_interactive(self, enabled_audit):
         """Stall suggestion should mention non-interactive flags."""

--- a/tests/tools_test/shell/test_shell_registry.py
+++ b/tests/tools_test/shell/test_shell_registry.py
@@ -5,15 +5,17 @@ ShellProcessRegistry 与 shell_tool per-agent 绑定集成测试。
 
 背景
 ─────
-将 ShellProcess 与 agent 实例通过 agent_id 绑定在注册表中，
+将 ShellProcess 与 run 内的 agent 实例通过 runtime_key + agent_id 绑定在注册表中，
 使同一 Agent 的多次工具调用之间共享同一个 session-scoped shell 会话，从而保留：
   - 工作目录（cd 跨调用生效）
   - shell snapshot（aliases/functions/options/PATH）
 
 环境变量 export 只在单条命令内生效，不跨工具调用持久化。
 
-注册表 key = agent_id（如 "supervisor_001"、"worker_001"）
+注册表 key = RuntimeContext.runtime_key + agent_id
   - supervisor 和 worker 各有独立的 shell session，互不干扰
+  - 同一 agent_id 在不同 run 中也必须完全隔离
+  - 没有显式 RuntimeContext 时不写入进程全局注册表
 
 测试分四组
 ──────────
@@ -42,6 +44,7 @@ import os
 import threading
 from contextvars import copy_context
 
+from src.lib.runtime import RuntimeHome, bind_run_context
 from src.tools.shell.process import ShellProcess, ShellProcessRegistry
 from src.tools.shell import shell_tool
 from src.trace import (
@@ -87,8 +90,20 @@ def _logical(path: str) -> str:
 # Fixtures
 # ---------------------------------------------------------------------------
 
+@pytest.fixture
+def runtime_scope(tmp_path):
+    """Bind the canonical run identity required by persistent shell sessions."""
+    context = RuntimeHome(tmp_path / ".agentloom").context(
+        application_id="shell-registry-tests",
+        task_id="task-default",
+        run_id="run-default",
+    )
+    with bind_run_context(context):
+        yield context
+
+
 @pytest.fixture(autouse=True)
-def clean_registry():
+def clean_registry(runtime_scope):
     """
     在每个测试前后自动清空 ShellProcessRegistry。
 
@@ -131,6 +146,35 @@ def test_same_agent_id_returns_same_process(registry):
     p1 = registry.get_or_create("supervisor_001", session_scoped=False)
     p2 = registry.get_or_create("supervisor_001", session_scoped=False)
     assert p1 is p2, "相同 agent_id 必须返回同一 ShellProcess 对象"
+
+
+def test_same_agent_id_is_partitioned_by_run_and_release_is_run_scoped(
+    registry,
+    runtime_scope,
+):
+    second_run = RuntimeHome(runtime_scope.root_dir).context(
+        application_id=runtime_scope.application_id,
+        task_id=runtime_scope.task_id,
+        run_id="run-second",
+    )
+
+    set_current_agent_id("shared-agent")
+    first_process = registry.get_or_create("shared-agent", session_scoped=False)
+
+    with bind_run_context(second_run):
+        set_current_agent_id("shared-agent")
+        second_process = registry.get_or_create("shared-agent", session_scoped=False)
+        assert second_process is not first_process
+        assert registry.registered_agent_ids() == ["shared-agent"]
+
+    set_current_agent_id("shared-agent")
+    assert registry.release_current_run() == 1
+    assert registry.registered_agent_ids() == []
+
+    with bind_run_context(second_run):
+        set_current_agent_id("shared-agent")
+        assert registry.get_or_create("shared-agent", session_scoped=False) is second_process
+        assert registry.release_current_run() == 1
 
 
 def test_existing_agent_process_refreshes_runtime_options(registry):
@@ -276,24 +320,26 @@ def test_same_agent_reuses_process_across_calls(registry):
         "同一 agent 的两次 shell_tool 调用必须复用相同的 ShellProcess 实例"
 
 
-def test_agent_id_fallback_preserves_cwd_from_executor_thread(bypass_shell_security):
+def test_raw_thread_without_propagated_run_context_never_borrows_session(
+    bypass_shell_security,
+):
     """
     【真实执行】模拟 code executor 在线程中直接调用 shell_tool。
 
-    ContextVar 不会自动传播到新线程；shell_tool 必须能通过 task_context
-    的 agent_id fallback 绑定到同一个 session-scoped ShellProcess。
+    ContextVar 不会自动传播到新线程。即使进程全局 fallback 中还有
+    agent_id，没有显式 RuntimeContext 的线程也不得借用父 run 的 shell 会话。
     """
     results = {}
 
     def _worker_thread():
         try:
-            shell_tool("cd /tmp")
             results["pwd"] = shell_tool("pwd")
         except Exception as exc:
             results["error"] = str(exc)
 
     set_current_agent_id("executor_thread_agent")
     try:
+        shell_tool("cd /tmp")
         thread = threading.Thread(target=_worker_thread)
         thread.start()
         thread.join(timeout=10)
@@ -302,7 +348,7 @@ def test_agent_id_fallback_preserves_cwd_from_executor_thread(bypass_shell_secur
 
     assert not thread.is_alive(), "executor thread should finish"
     assert "error" not in results, results.get("error")
-    assert _path_output(results["pwd"]) == _logical("/tmp")
+    assert _path_output(results["pwd"]) == _logical(os.getcwd())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools_test/shell/test_signal_handling.py
+++ b/tests/tools_test/shell/test_signal_handling.py
@@ -1,8 +1,5 @@
 """Tests for signal handling and partial output preservation."""
 
-import os
-import subprocess
-import tempfile
 import time
 from unittest.mock import patch
 
@@ -113,6 +110,34 @@ class TestAutoBackgroundOnTimeout:
             assert "Timeout" in result
 
         proc.cleanup()
+
+    @patch("src.lib.config.C.get_nested")
+    def test_timeout_without_runtime_context_is_never_promoted(self, mock_get_nested):
+        mock_get_nested.side_effect = lambda *args, default=None: {
+            ("shell_settings", "background_tasks", "enabled"): True,
+            (
+                "shell_settings",
+                "background_tasks",
+                "auto_background_on_timeout",
+            ): True,
+            (
+                "shell_settings",
+                "background_tasks",
+                "stall_threshold_seconds",
+            ): 45,
+        }.get(args, default)
+        proc = ShellProcess(
+            timeout=1,
+            session_scoped=False,
+            return_err_output=True,
+            load_profile=False,
+        )
+
+        result = proc.run("echo no-runtime-promotion; sleep 300")
+
+        assert "Timeout Error" in result
+        assert "Background Task" not in result
+        assert BackgroundTaskRegistry.get_instance().list_all() == []
 
     @patch("src.lib.config.C.get_nested")
     def test_auto_background_disabled(self, mock_get_nested):

--- a/tests/tools_test/shell/test_stall_watchdog.py
+++ b/tests/tools_test/shell/test_stall_watchdog.py
@@ -1,50 +1,51 @@
 """Tests for the stall watchdog — interactive prompt detection."""
 
 import os
-import tempfile
 import time
 
 import pytest
 
-from src.tools.shell.stall_watchdog import StallWatchdog, PROMPT_PATTERNS
+from src.tools.shell.stall_watchdog import PROMPT_PATTERNS, StallWatchdog
 
 
 class TestPromptPatterns:
     """Verify the prompt detection patterns match expected inputs."""
 
-    @pytest.mark.parametrize("line", [
-        "(y/n)",
-        "[y/n]",
-        "(yes/no)",
-        "Do you want to continue? ",
-        "Would you like to proceed?",
-        "Are you sure? ",
-        "Press Enter to continue",
-        "Press any key",
-        "Continue?",
-        "Overwrite?",
-        "Proceed?",
-        "[Y/n]",
-        "[yes/No]",
-    ])
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "(y/n)",
+            "[y/n]",
+            "(yes/no)",
+            "Do you want to continue? ",
+            "Would you like to proceed?",
+            "Are you sure? ",
+            "Press Enter to continue",
+            "Press any key",
+            "Continue?",
+            "Overwrite?",
+            "Proceed?",
+            "[Y/n]",
+            "[yes/No]",
+        ],
+    )
     def test_matches_known_prompts(self, line):
-        assert any(p.search(line) for p in PROMPT_PATTERNS), (
-            f"Pattern should match: {line!r}"
-        )
+        assert any(p.search(line) for p in PROMPT_PATTERNS), f"Pattern should match: {line!r}"
 
-    @pytest.mark.parametrize("line", [
-        "Building module 3/10...",
-        "Compiling source.c",
-        "100% complete",
-        "WARNING: something happened",
-        "ERROR: build failed",
-        "running tests...",
-        "",
-    ])
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "Building module 3/10...",
+            "Compiling source.c",
+            "100% complete",
+            "WARNING: something happened",
+            "ERROR: build failed",
+            "running tests...",
+            "",
+        ],
+    )
     def test_does_not_match_non_prompts(self, line):
-        assert not any(p.search(line) for p in PROMPT_PATTERNS), (
-            f"Pattern should NOT match: {line!r}"
-        )
+        assert not any(p.search(line) for p in PROMPT_PATTERNS), f"Pattern should NOT match: {line!r}"
 
 
 class TestStallWatchdog:
@@ -183,3 +184,36 @@ class TestStallWatchdog:
         assert sw.stall_message is not None
         # The internal _stopped flag should be True.
         assert sw._stopped is True
+
+    def test_does_not_follow_a_replaced_output_directory(self, tmp_path):
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        output_path = first / "output.txt"
+        output_fd = os.open(output_path, os.O_RDWR | os.O_CREAT, 0o600)
+        os.write(output_fd, b"ordinary output\n")
+        sw = StallWatchdog(
+            task_id="first-run",
+            output_path=str(output_path),
+            output_fd=output_fd,
+            poll_interval=0.1,
+            stall_threshold=0.2,
+        )
+
+        try:
+            detached = tmp_path / "first-detached"
+            first.rename(detached)
+            first.symlink_to(second, target_is_directory=True)
+            (second / "output.txt").write_text(
+                "SECOND-RUN-SECRET Continue? (y/n) ",
+                encoding="utf-8",
+            )
+
+            sw.start()
+            time.sleep(0.8)
+
+            assert sw.stall_message is None
+        finally:
+            sw.stop()
+            os.close(output_fd)

--- a/tests/tools_test/shell/test_tree_kill.py
+++ b/tests/tools_test/shell/test_tree_kill.py
@@ -17,12 +17,11 @@ import time
 import pytest
 
 from src.tools.shell.tree_kill import (
-    tree_kill,
-    graceful_kill,
-    _is_alive,
     SizeWatchdog,
+    _is_alive,
+    graceful_kill,
+    tree_kill,
 )
-
 
 pytestmark = pytest.mark.skipif(
     not sys.platform.startswith(("linux", "darwin")),
@@ -33,6 +32,7 @@ pytestmark = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 # Normal path: tree_kill
 # ---------------------------------------------------------------------------
+
 
 class TestTreeKill:
     """Direct process killing."""
@@ -73,6 +73,7 @@ class TestTreeKill:
 # Normal path: graceful_kill
 # ---------------------------------------------------------------------------
 
+
 class TestGracefulKill:
     """SIGTERM → SIGKILL escalation."""
 
@@ -103,6 +104,7 @@ class TestGracefulKill:
 # Normal path: _is_alive
 # ---------------------------------------------------------------------------
 
+
 class TestIsAlive:
     """Process existence checking."""
 
@@ -131,6 +133,7 @@ class TestIsAlive:
 # ---------------------------------------------------------------------------
 # SizeWatchdog
 # ---------------------------------------------------------------------------
+
 
 class TestSizeWatchdog:
     """File size watchdog for background processes."""
@@ -220,3 +223,37 @@ class TestSizeWatchdog:
         time.sleep(0.3)
         watchdog.stop()
         # Should not raise any exceptions
+
+    def test_watchdog_does_not_follow_a_replaced_output_directory(self, tmp_path):
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        output_path = first / "output.txt"
+        output_fd = os.open(output_path, os.O_RDWR | os.O_CREAT, 0o600)
+        os.write(output_fd, b"small\n")
+        proc = subprocess.Popen(["sleep", "60"], start_new_session=True)
+        watchdog = SizeWatchdog(
+            proc.pid,
+            str(output_path),
+            max_bytes=100,
+            poll_interval_s=0.05,
+            output_fd=output_fd,
+        )
+
+        try:
+            detached = tmp_path / "first-detached"
+            first.rename(detached)
+            first.symlink_to(second, target_is_directory=True)
+            (second / "output.txt").write_bytes(b"SECOND-RUN" * 100)
+
+            watchdog.start()
+            time.sleep(0.3)
+
+            assert proc.poll() is None
+        finally:
+            watchdog.stop()
+            os.close(output_fd)
+            if proc.poll() is None:
+                proc.kill()
+            proc.wait(timeout=5)

--- a/tests/tools_test/test_create_agent_loom_application_validator.py
+++ b/tests/tools_test/test_create_agent_loom_application_validator.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[2]
     / "agentloom-framework-skill"
@@ -135,6 +134,61 @@ def test_validator_rejects_invalid_list_workflow_item(tmp_path: Path) -> None:
         err["field"] == "workflow[1]" and err["rule"] == "required_non_empty_string"
         for err in payload["errors"]
     )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("runtime", {"root_dir": "/tmp/split-runtime"}),
+        ("logging", {"file_enabled": False}),
+        ("logging", {"enabled": True, "dir": ".logs"}),
+    ],
+)
+def test_agent_yaml_rejects_global_only_runtime_and_logging(
+    tmp_path: Path,
+    field: str,
+    value: dict,
+) -> None:
+    app_root = _create_min_project(tmp_path)
+    workflow_file = app_root / "workflows" / "demo_agent.yaml"
+    config = yaml.safe_load(workflow_file.read_text(encoding="utf-8"))
+    config[field] = value
+    _write_yaml(workflow_file, config)
+
+    completed, payload = _run_validator(tmp_path)
+
+    assert completed.returncode == 1
+    assert payload["summary"]["valid"] is False
+    matching = [error for error in payload["errors"] if error["field"] == field]
+    assert matching
+    assert all(error["rule"] == "global_only_top_level_key" for error in matching)
+    assert all("enabled: true" not in error["suggestion"] for error in matching)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("runtime", {"root_dir": "/tmp/split-runtime"}),
+        ("logging", {"file_enabled": False}),
+        ("logging", {"enabled": True, "dir": ".logs"}),
+    ],
+)
+def test_application_system_yaml_rejects_global_only_runtime_and_logging(
+    tmp_path: Path,
+    field: str,
+    value: dict,
+) -> None:
+    app_root = _create_min_project(tmp_path)
+    _write_yaml(app_root / "config" / "system.yaml", {field: value})
+
+    completed, payload = _run_validator(tmp_path)
+
+    assert completed.returncode == 1
+    assert payload["summary"]["valid"] is False
+    matching = [error for error in payload["errors"] if error["field"] == field]
+    assert matching
+    assert all(error["rule"] == "global_only_top_level_key" for error in matching)
+    assert all("enabled: true" not in error["suggestion"] for error in matching)
 
 
 def test_worker_path_must_point_to_file(tmp_path: Path) -> None:

--- a/tests/tools_test/test_logger_safety.py
+++ b/tests/tools_test/test_logger_safety.py
@@ -18,19 +18,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Helpers to reset module-level globals between tests
 # ---------------------------------------------------------------------------
 
 def _reset_global_logger():
-    """Reset global logger state to simulate a fresh process."""
+    """Reset the logger binding in this execution context."""
     import src.lib.logging.logger_manager as lm
 
-    lm._GLOBAL_LOGGER = None
-    lm._PROCESS_LOG_FILE_PATH = None
-    lm._INITIALIZED = False
-    lm._ACTIVE_LOG_FILE_PATH = None
+    lm.set_global_logger(None)
 
 
 @pytest.fixture(autouse=True)
@@ -50,33 +46,23 @@ class TestModuleLevelSafety:
 
     def test_get_logger_str_does_not_init_global(self):
         """Calling get_logger with a string must not initialise the global backend."""
-        from src.lib.logging.logger_manager import (
-            LazyLoggerAdapter,
-            _GLOBAL_LOGGER,
-            get_logger,
-        )
+        from src.lib.logging.logger_manager import LazyLoggerAdapter, get_global_logger, get_logger
 
         logger = get_logger("my.module")
         assert isinstance(logger, LazyLoggerAdapter)
-        # Global logger must still be None
-        from src.lib.logging.logger_manager import _GLOBAL_LOGGER as gl
-        assert gl is None, "get_logger(str) must not initialise _GLOBAL_LOGGER"
+        assert get_global_logger() is None
 
     def test_get_logger_none_does_not_init_global(self):
         """Calling get_logger(None) must not initialise the global backend."""
-        from src.lib.logging.logger_manager import (
-            LazyLoggerAdapter,
-            get_logger,
-        )
+        from src.lib.logging.logger_manager import LazyLoggerAdapter, get_global_logger, get_logger
 
         logger = get_logger(None)
         assert isinstance(logger, LazyLoggerAdapter)
-        from src.lib.logging.logger_manager import _GLOBAL_LOGGER as gl
-        assert gl is None
+        assert get_global_logger() is None
 
     def test_lazy_logger_log_call_does_not_init_global(self):
         """Logging through a lazy logger must NOT trigger global init."""
-        from src.lib.logging.logger_manager import get_logger
+        from src.lib.logging.logger_manager import get_global_logger, get_logger
 
         logger = get_logger("test.lazy")
 
@@ -86,9 +72,7 @@ class TestModuleLevelSafety:
             mock_get.return_value = mock_stdlib
             logger.info("hello %s", "world")
 
-        # _GLOBAL_LOGGER must still be None
-        from src.lib.logging.logger_manager import _GLOBAL_LOGGER as gl
-        assert gl is None, "Lazy log call must not initialise _GLOBAL_LOGGER"
+        assert get_global_logger() is None
 
 
 # ---------------------------------------------------------------------------
@@ -119,43 +103,29 @@ class TestRuntimeBinding:
         )
 
     def test_log_dir_follows_app_name(self, tmp_path: Path):
-        """Log directory must be named after the app, not 'AgentLoom'."""
-        from src.lib.logging.logger_manager import (
-            resolve_log_file_path,
-            _get_agent_root,
-        )
+        """The file path comes only from the canonical RuntimeContext."""
+        from src.lib.runtime import RuntimeHome
 
-        log_path = resolve_log_file_path(
-            "my_custom_app",
-            ensure_parent=False,
+        context = RuntimeHome(tmp_path / ".agentloom").context(
+            application_id="my_custom_app", task_id="task", run_id="run"
         )
-        # The path should contain the app name
-        assert "my_custom_app" in str(log_path), (
-            f"Log path should contain app name: {log_path}"
-        )
-        # The log file and its parent directories (relative to agent_root)
-        # must use the app name, not the fallback "AgentLoom".
-        # We only check the relative portion to avoid false positives when
-        # the project itself is located in a directory named "AgentLoom".
-        agent_root = _get_agent_root()
-        try:
-            relative_path = str(log_path.relative_to(agent_root))
-        except ValueError:
-            relative_path = str(log_path)
-        assert "AgentLoom" not in relative_path, (
-            f"Log path (relative to agent_root) must NOT contain fallback name: {relative_path}"
+        assert context.log_path == (
+            tmp_path
+            / ".agentloom"
+            / "runs"
+            / "my_custom_app"
+            / "run"
+            / "logs"
+            / "runtime.log"
         )
 
     def test_global_init_not_called_before_run_app(self):
         """Importing runner must not trigger global logger initialisation."""
         # The import itself was tested above; this test ensures the contract
         # holds for the full import chain.
-        from src.lib.logging.logger_manager import _GLOBAL_LOGGER as gl
+        from src.lib.logging.logger_manager import get_global_logger
 
-        # After _clean_global_state fixture reset, importing runner should
-        # not have re-initialised the global logger (it's a cached import).
-        # We just verify the state is clean.
-        assert gl is None
+        assert get_global_logger() is None
 
 
 # ---------------------------------------------------------------------------
@@ -225,9 +195,8 @@ class TestDispatchFallbackSafety:
             "_dispatch must never call initialize_global_logger_once"
         )
 
-        # Verify _GLOBAL_LOGGER is still None
-        from src.lib.logging.logger_manager import _GLOBAL_LOGGER as gl
-        assert gl is None
+        from src.lib.logging.logger_manager import get_global_logger
+        assert get_global_logger() is None
 
     def test_dispatch_uses_global_when_available(self):
         """When global backend exists, _dispatch falls back to it."""

--- a/tests/tools_test/test_tools_import_boundaries.py
+++ b/tests/tools_test/test_tools_import_boundaries.py
@@ -1,0 +1,21 @@
+"""Package import boundaries that must work in a fresh interpreter."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_shell_audit_module_imports_without_preloading_agent_packages() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from src.tools.shell.shell_audit_log import ShellAuditLogger",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/ui_test/test_dashboard_identity.py
+++ b/tests/ui_test/test_dashboard_identity.py
@@ -1,0 +1,35 @@
+from src.lib.checkpoint.checkpoint_manager import CheckpointManager
+from src.ui.dashboard import _delete_dashboard_task, _find_task, _task_row_key
+
+
+def test_dashboard_row_key_includes_application_identity() -> None:
+    assert _task_row_key("alpha", "task-1") != _task_row_key("beta", "task-1")
+
+
+def test_dashboard_task_lookup_uses_application_and_task_id() -> None:
+    tasks = [
+        {"application_id": "alpha", "task_id": "same", "checkpoint_dir": "/alpha"},
+        {"application_id": "beta", "task_id": "same", "checkpoint_dir": "/beta"},
+    ]
+
+    assert _find_task(tasks, ("beta", "same")) == tasks[1]
+
+
+def test_dashboard_delete_preserves_task_with_active_run_lease(tmp_path) -> None:
+    task_dir = tmp_path / "checkpoints" / "app" / "task"
+    manager = CheckpointManager("agent", checkpoint_dir=task_dir)
+    manager.save_task_tree(
+        "task",
+        {
+            "task_id": "task",
+            "agent_name": "agent",
+            "status": "interrupted",
+            "created_at": "2026-07-16T00:00:00+00:00",
+        },
+    )
+
+    with manager.task_lease():
+        deleted = _delete_dashboard_task({"checkpoint_dir": str(task_dir)})
+
+    assert deleted is False
+    assert task_dir.exists()


### PR DESCRIPTION
## Summary

- introduce a canonical RuntimeHome, RuntimeContext, and RuntimePaths ownership model
- isolate logs and execution artifacts by run while keeping checkpoints scoped by logical task
- replace process-global logging paths with ContextVar-bound run backends
- decouple checkpoint recovery from log retention and remove legacy index/log scanning
- add bounded log rotation, runtime retention, clean-runtime, and one-time migrate-runtime commands
- update CLI, dashboard, documentation, framework skill, and regression coverage

## Why

Runtime storage previously had no single run-scoped path owner. Process-global log paths could leak across applications, checkpoints depended on log directories, and deleting or rotating logs could break task recovery. The refactor gives each artifact one explicit lifecycle and ownership boundary.

## Impact

A resume creates a new run attempt while preserving the original task checkpoint. Runtime logs and raw artifacts can now be rotated or cleaned independently from recoverable task state. Application outputs and the semantic `.runtime` workspace remain outside automatic cleanup.

## Validation

- full test suite: 3261 passed, 2 skipped
- real Supervisor and Worker interrupt/resume validation, including single worker execution
- ContextRef retrieval and file-history restoration validation
- migration dry-run/apply and real migrated-checkpoint resume validation
- Ruff high-signal checks, compileall, and git diff --check
