### PR TITLE
docs: merge README restructure into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ English | <a href="docs/cn/README.md">简体中文</a>
 <h1 align="center">AgentLoom</h1>
 
 <p align="center">
-  <strong>Application-level framework for building multi-agent systems from YAML.</strong>
+  <strong>Create, run, and inspect YAML-defined multi-agent applications.</strong>
 </p>
 
 <p align="center">
-  Build multi-agent apps by writing YAML, route each sub-agent to the right model, load Skills / MCP / tools, run repeated work in parallel, and resume long runs from saved state.
+  Use the terminal Builder to design Agent systems through conversation, then run them with AgentLoom's Python runtime and inspect every Agent, Worker, and Run from one project view.
 </p>
 
 <p align="center">
@@ -22,104 +22,112 @@ English | <a href="docs/cn/README.md">简体中文</a>
   <img alt="AgentLoom application flow" src="docs/assets/agentloom-application-flow.svg">
 </p>
 
----
+## Install
 
-## 3-Minute Quick Start
-
-AgentLoom is for developers who want ready-to-run agent apps: YAML-defined agents, explicit Worker contracts, model routing, runtime logs, checkpoint state, and optional UI monitoring.
+The source installer is the recommended starting point. It prepares the TUI, the Python runtime, and their dependencies together, so you do not need to build environments by hand.
 
 ```bash
-git clone <repo-url> AgentLoom
+git clone https://github.com/linora-u/AgentLoom.git
 cd AgentLoom
-
-uv sync
-# If PyPI is slow or unavailable on your network:
-# UV_DEFAULT_INDEX=https://mirrors.aliyun.com/pypi/simple uv sync
-
-cp config/llm.example.yaml config/llm.yaml
-# Edit config/llm.yaml and add your model credentials.
-
-uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
+./install
 ```
 
-After the first run, you should see:
-
-- structured terminal logs with agent names, task IDs, step duration, and token usage;
-- one execution attempt under `.agentloom/runs/<application_id>/<run_id>/`, with a manifest, bounded runtime log, Shell audit, and raw artifacts;
-- resumable task state under `.agentloom/checkpoints/<application_id>/<task_id>/` when checkpointing is enabled;
-- optional visualization through `uv run loom ui`;
-- optional terminal monitoring through `uv run loom dashboard`.
-- the interactive Agent Builder and project-wide Run directory through the
-  TypeScript TUI in [`agentloom-tui/`](agentloom-tui/README.md).
-
-`run_id` identifies one execution attempt and changes on resume. `task_id` identifies the logical task and remains stable, so a resumed attempt writes a new run directory while continuing the same checkpoint. Agent workspaces live under `.agentloom/workspaces/agents/<application_id>/<agent_path>/`: `insights.md` is shared across tasks, while task state lives under `tasks/<task_id>/`.
-
-### Use the AgentLoom TUI
-
-The TUI is a small Agent Builder and project status browser. It can chat,
-inspect the current project's Agent catalog, and prepare Agent YAML through
-bounded tools. It does not run Shell commands, Git operations, or Agent
-workloads itself.
-
-#### 1. Install it and open a project
+Open a new terminal after installation, then verify the command from the repository root:
 
 ```bash
-./install
-# Open a new shell once, then run from the AgentLoom project to inspect:
+agentloom --version
+agentloom --snapshot
+```
+
+The installer:
+
+- installs missing `uv` and Bun with their official installers;
+- creates a locked Python environment under `~/.agentloom/venv`;
+- builds the current-platform TypeScript/OpenTUI binary;
+- installs `agentloom` and `agentloom-tui` under `~/.agentloom/bin`;
+- adds that directory to your shell `PATH` when a writable shell config exists.
+
+The source installer currently targets macOS and Linux shells. It requires Git and Bash; `curl` is required only when `uv` or Bun must be installed.
+
+Use a custom install location or leave `PATH` unchanged when needed:
+
+```bash
+AGENTLOOM_INSTALL_DIR="$HOME/tools/agentloom" ./install
+./install --no-modify-path
+```
+
+### Configure a model
+
+Copy the model template before using TUI chat or running an Agent:
+
+```bash
+cp config/llm.example.yaml config/llm.yaml
+```
+
+Edit `config/llm.yaml` and replace the placeholders. Do not commit this file; it is ignored because it contains credentials.
+
+```yaml
+model:
+  default_model_type: powerful
+  powerful:
+    model: "openai/<model-id>"
+    api_key: "<api-key>"
+    base_url: "https://<openai-compatible-endpoint>"  # optional for OpenAI
+    tool_choice: "auto"
+```
+
+Agent workloads use AgentLoom's normal model runtime. TUI chat currently requires an OpenAI-compatible Chat Completions endpoint; YAML creation also requires streaming and native tool/function calling.
+
+## Start with the TUI
+
+Run `agentloom` inside the project you want to inspect, or pass the project explicitly:
+
+```bash
+cd /path/to/AgentLoom
 agentloom
 
-# Or point it at a project explicitly:
+# Inspect another AgentLoom project
 agentloom --project /path/to/project
 ```
 
-The source installer follows OpenCode's native-binary installation pattern. It
-builds the current-platform TypeScript/OpenTUI application, installs it under
-`~/.agentloom/bin`, and creates an isolated locked Python environment under
-`~/.agentloom/venv`. It finds or installs `uv` and Bun during setup; running
-`agentloom` needs neither environment activation nor `uv run`. Use
-`./install --no-modify-path` to leave shell configuration untouched, or set
-`AGENTLOOM_INSTALL_DIR` to choose another installation root.
+The TUI is an Agent Builder and project control surface. It can discuss your design, inspect existing definitions, stage and validate Agent YAML, and read canonical runtime status.
 
-#### 2. Select the chat model
+It does not execute Shell commands, Git operations, or Agent workloads. You decide when YAML is written and run the Agent in a separate terminal.
 
-The TUI reads the model catalog and default from `config/llm.yaml`. Before
-chatting, configure at least one OpenAI-compatible profile with a `model`, an
-`api_key`, and either an HTTPS `base_url` (local HTTP is allowed) or an
-`openai/...` model ID that uses the default OpenAI endpoint. The TUI
-conversation calls that provider directly; Agent workloads continue to use the
-normal AgentLoom runtime model path. Creating YAML also requires streaming
-Chat Completions with native tool/function calling; leave `tool_choice` as
-`auto` or `required`, rather than `none`.
+### 1. Describe the Agent system
 
-Inside the TUI, enter `/models` to open the model selector or `/model <type>`
-to switch directly, for example `/model summary`.
-
-#### 3. Create or update Agent YAML through chat
-
-Press `Enter` to send a request. For example:
+Press `Enter` to send a request. A useful first prompt states the application, roles, inputs, outputs, and acceptance criteria:
 
 ```text
-Create an application named release_review. Use one Supervisor and two Workers
-for API review and test review. Choose model types from config/llm.yaml, then
-show me the proposed files without writing them yet.
+Create an application named release_review.
+Use one Supervisor and two Workers for API review and test review.
+Choose model types from config/llm.yaml.
+Show the proposed files and contracts before writing anything.
 ```
 
-The Builder reads existing Agent YAML definitions as needed, stages the
-proposed YAML in memory, and validates it. Ask for revisions until the draft is
-correct, then enter `/apply`. Only the current validated draft is written;
-sending a chat message does not modify files, and `/apply` does not start the
-Agent.
+The Builder reads only the project context it needs, stages a draft in memory, and validates the proposed YAML. Continue chatting until the topology and contracts are correct.
 
-#### 4. Run the Agent yourself
+### 2. Review and write the YAML
 
-Run the YAML directly in another terminal, using the actual path shown in the
-draft:
+Normal chat never changes files. Enter `/apply` to write the current validated draft. The command writes YAML only; it does not start an Agent.
+
+Use `/models` for the model picker or `/model <type>` to switch directly:
+
+```text
+/models
+/model summary
+/apply
+```
+
+### 3. Run the Agent
+
+Open another terminal and run the Supervisor path shown by the Builder:
 
 ```bash
 uv run loom run applications/<app>/workflows/<agent>.yaml
 ```
 
-If you prefer a Python entry file, generate and run one:
+You can also generate a Python entrypoint:
 
 ```bash
 uv run loom create applications/<app>/workflows/<agent>.yaml \
@@ -127,105 +135,166 @@ uv run loom create applications/<app>/workflows/<agent>.yaml \
 uv run python applications/<app>/<app>_app.py
 ```
 
-Keep the TUI open while the process runs. Both `loom run` and Python entry
-files that call `src.runner.run_app` publish canonical status. Calling a
-low-level Agent `.run()` directly bypasses that lifecycle, so the TUI cannot
-show a complete Run for it.
+Keep the TUI open while the Agent runs. `loom run` and generated entrypoints publish the canonical lifecycle that powers project-wide status.
 
-#### 5. Inspect every Agent and Run in the project
+Calling a low-level Agent `.run()` directly bypasses that lifecycle, so no UI can reconstruct a complete Run from it.
 
-- Press `Ctrl+P` or `Tab`, type an Application, Agent, Worker, Run, Skill, or
-  Schedule name, then use `↑` / `↓` and `Enter`; workspace entries are also
-  clickable.
-- Agent details show definitions that have never run, topology, files, and
-  validation. Run details distinguish running, completed, failed, crashed,
-  interrupted, and unknown states, and show Worker status and retained result.
-- A failed Run shows the key error, abnormal Workers, log file paths, and
-  the artifact index plus a bounded result preview instead of dumping the
-  complete raw log. Press `a` in that Run to ask the TUI assistant to analyze
-  a sanitized, bounded failure context.
-- Use `F6` to switch focus between chat and details. A focused detail view
-  supports `PgUp` / `PgDn`, `Home` / `End`, arrow keys, and the mouse wheel;
-  press `Esc` or `b` to return. Runtime state refreshes automatically; press
-  `r` from the detail panel or enter `/refresh` to rebuild the project index.
+### 4. Inspect Agents and Runs
 
-See [`agentloom-tui/README.md`](agentloom-tui/README.md) for additional TUI
-architecture and contributor details.
+Press `Ctrl+P` or `Tab` to search Applications, Agents, Workers, Runs, Skills, Schedules, and commands. Select entries with the keyboard or mouse.
 
-Schedules created in the TUI are durable, but automatic firing requires an
-explicit foreground service in a separate terminal:
+The detail view distinguishes never-run, running, completed, failed, crashed, interrupted, and unknown states. It shows topology, validation, Worker status, results, and artifact locations without dumping entire logs.
+
+For a failed Run, press `a` to ask the TUI assistant to analyze a sanitized and bounded failure context. The full log remains on disk and the detail view shows its path.
+
+Use `F6` to switch focus. A focused detail view supports arrow keys, `PgUp` / `PgDn`, `Home` / `End`, and the mouse wheel. Press `Esc` or `b` to return.
+
+| Action | Command / key |
+|---|---|
+| Send chat | `Enter` |
+| Browse the project | `Ctrl+P` or `Tab` |
+| Select a model | `/models` or `/model <type>` |
+| Write the validated draft | `/apply` |
+| Refresh the full index | `/refresh` or `r` in details |
+| Switch chat/details focus | `F6` |
+| Analyze the selected failed Run | `a` |
+
+See [agentloom-tui/README.md](agentloom-tui/README.md) for TUI architecture and contributor details.
+
+### 5. Run schedules explicitly
+
+The TUI can create and manage durable schedules. Automatic firing is a separate foreground service, so closing the TUI never leaves a hidden daemon behind.
 
 ```bash
 agentloom schedules --project /path/to/project serve
 ```
 
-## Create a Multi-Agent App with Codex
+## Run an existing Agent
 
-The fastest path is to let Codex use the framework skill that ships with this repository. Codex can create the YAML files, run the AgentLoom app, inspect `.agentloom/` run and checkpoint evidence, and revise the app when a Worker gets stuck or a config is wrong.
+To verify the framework without creating a new application, run the included code review example:
 
-Use a prompt like this:
+```bash
+uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
+```
+
+One run creates a receipt under `.agentloom/runs/<application_id>/<run_id>/`. When checkpointing is enabled, resumable task state lives under `.agentloom/checkpoints/<application_id>/<task_id>/`.
+
+`run_id` identifies one attempt and changes after resume. `task_id` identifies the logical task and remains stable.
+
+## How AgentLoom works
+
+AgentLoom treats a multi-agent system as an application, not a loose collection of prompts.
+
+| Concept | Responsibility |
+|---|---|
+| Supervisor | Decomposes the application task and coordinates Workers and tools. |
+| Worker | Owns one specialized role and exposes a typed callable contract. |
+| Agent YAML | Defines role, workflow, model type, tools, Skills, Workers, and runtime policy. |
+| Python runtime | Handles model routing, generated Worker tools, concurrency, logs, checkpoints, and artifacts. |
+
+This keeps orchestration reusable while leaving deterministic preprocessing, validation, caching, and output writing in normal Python code.
+
+### Core capabilities
+
+| Need | AgentLoom provides |
+|---|---|
+| Build an application from configuration | Direct YAML execution with `loom run` and optional Python entrypoint generation. |
+| Route roles to different models | Per-Agent `model_type` with credentials isolated in `config/llm.yaml`. |
+| Call an Agent like a tool | Worker `agent_function_schema` becomes a validated callable function. |
+| Process repeated inputs | Fixed or automatic Worker concurrency with `.batch(tasks)`. |
+| Extend an Agent | Built-in tools, local Python functions, MCP servers, Claude-style Skills, and explicit Hooks. |
+| Recover and inspect work | Run receipts, bounded logs, Shell audit, checkpoint resume, structured events, Web UI, dashboard, and TUI. |
+
+## Create an application manually
+
+An application keeps its Supervisor, Workers, prompts, optional tools, and outputs together:
+
+```text
+applications/release_review/
+├── workflows/
+│   ├── release_review_agent.yaml
+│   └── worker_agents/
+│       ├── api_reviewer.yaml
+│       └── test_reviewer.yaml
+├── config/system.yaml          # optional application overlay
+├── sysprompt/                  # optional prompt templates
+└── README.md
+```
+
+A minimal Supervisor references Worker YAML files:
+
+```yaml
+name: "release_review"
+description: "Review an API release and its test evidence."
+model_type: "powerful"
+tool_call_type: "tool_call"
+
+worker_agents:
+  - path: "applications/release_review/workflows/worker_agents/api_reviewer.yaml"
+  - path: "applications/release_review/workflows/worker_agents/test_reviewer.yaml"
+
+workflow: |
+  Ask both Workers for evidence, reconcile conflicts, and return one release decision.
+
+tools: []
+skills: []
+max_steps: 12
+```
+
+Each Worker defines the contract that the Supervisor sees:
+
+```yaml
+name: "api_reviewer"
+description: "Review API compatibility risks."
+model_type: "fast"
+tool_call_type: "tool_call"
+
+agent_function_schema:
+  description: "Review one release request."
+  inputs:
+    request:
+      description: "Release scope and API diff."
+      required: true
+  output:
+    description: "Evidence-backed compatibility findings."
+
+workflow: |
+  Review the request, cite evidence, and return prioritized findings.
+
+tools: []
+worker_agents: []
+skills: []
+max_steps: 8
+```
+
+Validate the real model types against `config/llm.yaml`, then run the Supervisor:
+
+```bash
+uv run loom run applications/release_review/workflows/release_review_agent.yaml
+```
+
+For the complete schema, use the [Agent Configuration Reference](docs/en/agent_config.md).
+
+## Create an application with a coding assistant
+
+The repository includes `agentloom-framework-skill/` for Codex, Claude Code, and other Skill-aware coding assistants.
+
+Ask the assistant to read the Skill before creating files:
 
 ```text
 Read agentloom-framework-skill/SKILL.md first.
 
 Create an AgentLoom application named <app_name> for this goal:
-<describe the user-facing task, input, output, and acceptance criteria>
+<task, inputs, outputs, and acceptance criteria>
 
-Requirements:
-- Create files under applications/<app_name>/.
-- Use a Supervisor YAML plus at least two Worker YAML files.
-- Each Worker must define agent_function_schema with clear inputs and output.
-- Choose model_type values only from config/llm.yaml.
-- Add Skills or MCP config only if they are useful for this app.
-- Write an application README with run commands, Worker responsibilities, validation records, and known limits.
-- Run the app, watch the logs/checkpoints, and fix any YAML or tool issues you find.
+Create one Supervisor and the necessary Workers under applications/<app_name>/.
+Use only model types from config/llm.yaml.
+Define every Worker input/output with agent_function_schema.
+Validate the YAML, run the application, inspect .agentloom evidence,
+and report what passed, failed, or remains limited.
 ```
 
-You can let Codex run and monitor the app for you, or run it yourself:
-
-```bash
-uv run loom run applications/<app_name>/workflows/<app_name>_agent.yaml
-```
-
-Useful runtime checks while the app is running:
-
-```bash
-uv run loom list-tasks
-uv run loom dashboard
-
-manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
-run_dir=$(dirname "$manifest")
-sed -n '1,160p' "$manifest"
-tail -n 80 "$run_dir/logs/runtime.log"
-tail -n 80 "$run_dir/audit/shell.jsonl"
-```
-
-If you prefer Claude Code, give it the same request: read `agentloom-framework-skill/SKILL.md`, create the app under `applications/<app_name>/`, run it, and summarize what worked or failed.
-
-The main config ideas are simple:
-
-- `model_type`: which configured model category this Agent uses.
-- `worker_agents`: which Worker YAML files the Supervisor can call.
-- `agent_function_schema`: the input and output contract for a Worker.
-- `skills` / `mcp_servers`: optional extra knowledge and external tools.
-
-## Why AgentLoom
-
-Many agent frameworks expose components. AgentLoom gives you a complete app structure.
-
-Complex agent applications often repeat the same setup code: Worker registration, parameter adapters, runtime entrypoints, batch execution, logging, checkpointing, and safety controls. AgentLoom moves those reusable parts into YAML and the runtime. Your application code stays focused on domain work: preprocessing, validation, artifact writing, and the actual Agent roles.
-
-The practical result:
-
-| Need | AgentLoom approach |
-|---|---|
-| Build a full multi-agent app | Define a Supervisor, Workers, tools, Skills, and runtime behavior in YAML. |
-| Route roles to different models | Set `model_type` per Agent and keep credentials isolated in `config/llm.yaml`. |
-| Turn sub-agents into tools | Give Workers `agent_function_schema`; the Supervisor calls them like normal tools. |
-| Reuse coding-assistant knowledge | Load Claude-style `SKILL.md` packages on demand or eagerly. |
-| Connect external tools | Register local Python tools, local `codex exec`, and MCP servers through `mcp_servers`. |
-| Handle repeated work | Use Worker `concurrency` and `tool.batch(tasks)` for independent repeated inputs. |
-| Understand long runs | Read the run manifest, bounded runtime log, Shell audit, task checkpoint, `loom ui`, and `loom dashboard`. |
+The Framework Skill is development guidance for coding assistants. It is not a runtime Skill and is not auto-loaded by Agent applications.
 
 ## Architecture
 
@@ -233,132 +302,83 @@ The practical result:
   <img alt="AgentLoom runtime architecture" src="docs/assets/agentloom-runtime-architecture.svg">
 </p>
 
-The important boundary is:
+Worker Agents become generated tools. The Supervisor calls them together with normal Python, MCP, file, Shell, search, Git, Codex, or Skill tools.
 
-- Worker Agents define their role, tools, inputs, and output contract.
-- AgentLoom turns Workers into callable tools with generated function signatures.
-- The Supervisor coordinates Workers and normal tools to complete the application task.
-- Python remains available for deterministic preprocessing, validation, caching, and artifact writing.
+The runtime owns execution identity and evidence. TUI and other observers read that canonical state instead of guessing status from process output.
 
-## Capabilities
+## Example applications
 
-| Capability | What is already implemented |
+| Application | Demonstrates |
 |---|---|
-| Application-first YAML | `loom run` executes an Agent YAML directly; `loom create` generates a Python entry script; `run_app()` embeds the app in Python. |
-| Per-Agent model routing | Each Agent selects a `model_type`; the actual provider, key, endpoint, retries, and parameters live in `config/llm.yaml`. |
-| Agent-as-Tool coordination | Worker Agents export as callable tools through `agent_function_schema`, including required-input validation and string outputs. |
-| Skills, MCP, and tools | Agents can load `SKILL.md` packages, local Python functions, built-in file/shell/search/git tools, local Codex tools, and MCP client tools through `mcp_servers`. |
-| Concurrent repeated work | Worker `concurrency: auto` or fixed concurrency works with `.batch(tasks)` for many independent inputs. |
-| State and observability | Rich terminal logs, bounded per-run file logs, per-step timing, token usage, run manifests, checkpoint resume, Web UI, and TUI dashboard. |
-
-## Example Applications
-
-The `applications/` directory contains working apps that show the intended usage patterns.
-
-| Application | What it builds | What it demonstrates |
-|---|---|---|
-| `ai_quality_analysis` | Multi-dimensional code review application. | 12 Worker Agents, staged review, direct `loom run`, long-running codebase analysis. |
-| `unit_test_studio` | Python pytest generation workflow. | Strict multi-step pipeline, custom entry script, function intake, scenario planning, test generation, refinement, delivery report. |
-| `repo_map` | Repository architecture map generator. | Deterministic Python preprocessing plus Agent analysis, bottom-up directory processing, `tool.batch(tasks)`, progress persistence. |
-| `codex_exec_demo` | Local Codex Exec tool-call example. | Direct `loom run`, normal function tool registration, `fixed_args` for Codex parameters, structured `tool_call` sequencing. |
-
-Run the default code review example:
+| `ai_quality_analysis` | Twelve specialized Workers coordinated into a staged code review. |
+| `unit_test_studio` | A strict pytest generation pipeline with a custom Python entrypoint. |
+| `repo_map` | Deterministic preprocessing, bottom-up Agent analysis, batching, and progress persistence. |
+| `codex_exec_demo` | Local `codex exec` registered as normal Agent tools with fixed arguments. |
 
 ```bash
-uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
-```
-
-Run Repo Map with a custom Python entrypoint:
-
-```bash
+# Repository architecture map
 uv run python applications/repo_map/repo_map_app.py /path/to/project \
-  --output_dir /tmp/repo-map-output \
-  --exclude_dirs vendor \
-  --exclude_dirs build
-```
+  --output_dir /tmp/repo-map-output
 
-Generate pytest tests for selected functions:
-
-```bash
+# Pytest generation for selected functions
 uv run python applications/unit_test_studio/studio_runner.py \
-  /path/to/your/project \
-  "src/utils.py:parse_config,src/core.py:run_pipeline" \
+  /path/to/project "src/utils.py:parse_config" \
   --output_dir tests/generated
-```
 
-Run the local Codex Exec tool example:
-
-```bash
+# Local Codex tool example
 uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
 ```
 
-## Core Concepts
-
-### Supervisor / Worker
-
-A Supervisor Agent coordinates the task. Worker Agents specialize in one part of the job. In multi-agent apps, the Supervisor references Workers through `worker_agents`, and Workers expose callable contracts through `agent_function_schema`.
-
-### Agent as Tool
-
-Worker Agents can be exported as callable tools. AgentLoom generates function signatures, validates required inputs, builds the task payload, and returns a string result. The same Worker can expose `.batch(tasks)` for parallel execution.
-
-### Skills and Hooks
-
-Skills provide reusable knowledge through Claude-style `SKILL.md` packages. Hooks are independent, explicitly configured Shell extensions for the eleven supported tool, task, Agent, and session events. A Skill cannot declare or register a Hook; reusable Hooks live in explicitly referenced `HOOK.yaml` Bundles. See [Hook configuration](docs/en/hooks.md).
-
-### Local Codex Tool
-
-AgentLoom includes `src.tools.codex.codex_tool.codex`, which exposes local `codex exec` as a normal function tool. Register it in Agent YAML with `module/function`. Use `fixed_args` to lock inputs such as `prompt`, `cwd`, `sandbox`, and `search`; fixed inputs are removed from the LLM-visible tool schema.
-
-Before running the tool, make sure `codex` is on `PATH` and `codex login status` succeeds.
-
-## CLI Reference
+## CLI reference
 
 | Command | Purpose |
 |---|---|
-| `uv run loom run <workflow>` | Run an AgentLoom application. |
-| `uv run loom run <workflow> --output-format jsonl` | Stream versioned lifecycle events for programmatic consumers. |
-| `uv run loom create <workflow>` | Generate a Python entry script for an application. |
-| `uv run loom ui` | Open the Web visualization panel. |
+| `uv run loom run <workflow>` | Run an application. |
+| `uv run loom run <workflow> --output-format jsonl` | Stream versioned lifecycle events. |
+| `uv run loom create <workflow>` | Generate a Python entrypoint. |
+| `uv run loom list-tasks` | List resumable tasks. |
 | `uv run loom dashboard` | Open the terminal task dashboard. |
-| `uv run loom list-tasks` | List resumable checkpoint tasks. |
-| `uv run loom clean-tasks` | Clean old checkpoint data. |
-| `uv run loom clean-runtime` | Apply configured retention to completed run directories and raw artifacts. |
-| `uv run loom migrate-runtime --dry-run` | Preview legacy checkpoint candidates plus the unscoped `.runtime` workspace without changing disk state. |
-| `uv run loom migrate-runtime --apply` | Migrate checkpoints, archive `.logs`, and atomically preserve `.runtime` under `.agentloom/workspaces/legacy-unscoped/`. |
-| `uv run loom schedules ...` | Add, list, pause, resume, remove, run, serve, or inspect schedules. |
-| `uv run loom sessions search\|scroll\|index\|prune ...` | Search and maintain execution history. |
+| `uv run loom ui` | Open the Web visualization panel. |
+| `uv run loom schedules ...` | Manage durable schedules. |
+| `uv run loom sessions ...` | Search and maintain execution history. |
 | `uv run loom learn review ...` | Trigger Application or Project review. |
-| `uv run loom reviews status\|apply\|rollback ...` | Inspect and apply scoped review inboxes, or roll back a review. |
-| `uv run loom memory list\|add\|replace\|remove\|pending\|stats\|export ...` | Administer curated memory and pending-write audit records. |
-| `uv run loom feedback submit <run_id> ...` | Attach an accepted, rejected, or corrected verdict to a run. |
+| `uv run loom reviews ...` | Inspect, apply, or roll back review decisions. |
+| `uv run loom memory ...` | Administer curated memory. |
+| `uv run loom feedback submit <run_id> ...` | Attach outcome feedback to a Run. |
+| `uv run loom clean-tasks` | Remove retained checkpoint tasks. |
+| `uv run loom clean-runtime` | Apply configured Run and artifact retention. |
+| `uv run loom migrate-runtime --dry-run\|--apply` | Preview or apply legacy runtime migration. |
+
+Run `uv run loom <command> --help` for the full command contract.
 
 ## Documentation
 
-| Document | Description |
+| Document | Covers |
 |---|---|
-| [Configuration Overview](docs/en/config-overview.md) | Configuration layers, merge rules, and model configuration isolation. |
-| [Agent Configuration](docs/en/agent_config.md) | Supervisor/Worker fields, tools, model selection, workflows, and skills. |
-| [LLM Configuration](docs/en/llm_config.md) | Model types, provider settings, inheritance, retries, and prompt cache settings. |
-| [System Configuration](docs/en/system_config.md) | Runtime settings, permissions, logging, execution environments, and tools. |
-| [Skills Configuration](docs/en/skills_config.md) | Skill package format, loading, runtime policy, and built-in skills. |
-| [Hooks Reference](docs/en/hooks.md) | Direct Hooks, Bundles, lifecycle events, matching, and execution behavior. |
-| [Checkpoint Resume](docs/en/checkpoint.md) | Checkpoint layout, resume behavior, and long-task recovery. |
-| [Self-Learning v6](docs/en/self_learning.md) | History, typed candidates, review triggers, approval, and Project promotion. |
-| [Structured Run API](docs/en/run_observability.md) | Python receipts, typed errors, lifecycle events, and JSONL CLI output. |
+| [Configuration Overview](docs/en/config-overview.md) | Configuration layers, merging, and isolation. |
+| [Agent Configuration](docs/en/agent_config.md) | Supervisor and Worker YAML fields. |
+| [LLM Configuration](docs/en/llm_config.md) | Model types, providers, retries, and caching. |
+| [System Configuration](docs/en/system_config.md) | Runtime, permissions, execution environments, and tools. |
+| [Skills Configuration](docs/en/skills_config.md) | Skill packages, loading, and policy. |
+| [Hooks Reference](docs/en/hooks.md) | Direct Hooks, Bundles, events, and execution. |
+| [Checkpoint Resume](docs/en/checkpoint.md) | Run evidence, checkpoint layout, and recovery. |
+| [Self-Learning v6](docs/en/self_learning.md) | History, candidates, review, approval, and promotion. |
+| [Structured Run API](docs/en/run_observability.md) | Python receipts, typed errors, event sinks, and JSONL. |
 
-## AgentLoom Framework Skill
+## Development and support
 
-The repository includes one root-level Agent Skill for AI coding assistants: `agentloom-framework-skill/`.
+```bash
+# Framework tests
+uv run pytest tests -q
 
-Use it when you want Codex, Claude Code, or another coding assistant to develop with AgentLoom instead of guessing the required files and fields from scratch. Ask the assistant to read `agentloom-framework-skill/SKILL.md`, then describe the application capability you want to build.
+# TUI tests
+cd agentloom-tui
+bun test
+bun run typecheck
+```
 
-This Skill is a development aid for coding assistants. It is not stored under `skills/`, so AgentLoom runtime applications do not auto-load it as a normal runtime Skill.
-
-## Support and Contributing
-
-AgentLoom is built as a practical framework for complex agent automation. Issues, feature ideas, documentation improvements, and example applications are welcome.
-
-- Open an issue: [GitHub Issues](https://github.com/linora-u/AgentLoom/issues)
+- Issues: [github.com/linora-u/AgentLoom/issues](https://github.com/linora-u/AgentLoom/issues)
 - Contact: [raine_walker@163.com](mailto:raine_walker@163.com?subject=AgentLoom%20Collaboration)
-- If the project helps you, a GitHub star makes it easier for others to find.
+- TUI upstream provenance and license: [agentloom-tui/upstream/README.md](agentloom-tui/upstream/README.md)
+
+If AgentLoom helps your project, consider starring the repository or contributing a focused example, fix, or documentation improvement.

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -5,11 +5,11 @@
 <h1 align="center">AgentLoom</h1>
 
 <p align="center">
-  <strong>用 YAML 构建应用级 multi-agent 系统的框架。</strong>
+  <strong>创建、运行并查看由 YAML 定义的多 Agent 应用。</strong>
 </p>
 
 <p align="center">
-  通过 YAML 构建 multi-agent 应用，为不同子 Agent 选择合适模型，加载 Skills / MCP / 工具，并发处理重复任务，并从保存的状态恢复长任务。
+  在终端 Builder 中通过对话设计 Agent 系统，使用 AgentLoom Python Runtime 运行，并在同一个项目视图里查看每个 Agent、Worker 和 Run。
 </p>
 
 <p align="center">
@@ -22,98 +22,112 @@
   <img alt="AgentLoom application flow" src="../assets/agentloom-application-flow.svg">
 </p>
 
----
+## 安装
 
-## 3 分钟快速开始
-
-AgentLoom 面向想构建可直接运行的 Agent 应用的开发者：YAML 定义 Agent，Worker 有明确调用契约，模型可以按 Agent 路由，运行过程有日志、checkpoint 状态和可选 UI 监控。
+推荐从源码安装脚本开始。它会同时准备 TUI、Python Runtime 和所需依赖，不需要手工搭建多套环境。
 
 ```bash
-git clone <repo-url> AgentLoom
+git clone https://github.com/linora-u/AgentLoom.git
 cd AgentLoom
-
-uv sync
-# 如果 PyPI 在你的网络环境中较慢或不可用：
-# UV_DEFAULT_INDEX=https://mirrors.aliyun.com/pypi/simple uv sync
-
-cp config/llm.example.yaml config/llm.yaml
-# 编辑 config/llm.yaml，填入你的模型配置。
-
-uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
+./install
 ```
 
-第一次运行后，你应该能看到：
-
-- 带 Agent 名称、Task ID、Step 耗时和 Token 统计的结构化终端日志；
-- `.agentloom/runs/<application_id>/<run_id>/` 下本次执行 attempt 的 manifest、有界 runtime log、Shell audit 和原始 artifacts；
-- 开启 checkpoint 后位于 `.agentloom/checkpoints/<application_id>/<task_id>/` 的可恢复任务状态；
-- 可通过 `uv run loom ui` 打开的 Web 可视化面板；
-- 可通过 `uv run loom dashboard` 打开的终端任务监控面板。
-- 可通过 [`agentloom-tui/`](../../agentloom-tui/README.md) 打开的交互式 Agent
-  Builder 和全项目 Run 目录。
-
-`run_id` 标识一次执行 attempt，resume 时会改变；`task_id` 标识同一个逻辑任务，resume 时保持不变。因此 resume 会写入新的 run 目录，同时继续使用原 checkpoint 和 `.agentloom/workspaces/agents/<application_id>/<agent_path>/tasks/<task_id>/`。`insights.md` 位于 agent workspace 根目录并跨 task 共享。
-
-### 使用 AgentLoom TUI
-
-TUI 是一个轻量的 Agent Builder 和项目状态浏览器。它可以对话、查看当前项目的
-Agent 目录，并通过受限工具生成 Agent YAML；它本身不会执行 Shell、Git 或
-Agent 任务。
-
-#### 1. 安装并打开项目
+安装完成后打开一个新终端，在仓库根目录验证命令：
 
 ```bash
-./install
-# 首次安装后打开一个新终端，然后在要查看的 AgentLoom 项目中运行：
+agentloom --version
+agentloom --snapshot
+```
+
+安装脚本会：
+
+- 通过官方安装器补齐缺少的 `uv` 和 Bun；
+- 在 `~/.agentloom/venv` 创建锁定的 Python 环境；
+- 构建当前平台的 TypeScript/OpenTUI 原生程序；
+- 将 `agentloom` 和 `agentloom-tui` 安装到 `~/.agentloom/bin`；
+- 在存在可写 Shell 配置时，把该目录加入 `PATH`。
+
+源码安装脚本目前面向 macOS 和 Linux Shell。它需要 Git 和 Bash；仅在缺少 `uv` 或 Bun 时需要 `curl`。
+
+需要自定义安装目录或不修改 `PATH` 时，可以使用：
+
+```bash
+AGENTLOOM_INSTALL_DIR="$HOME/tools/agentloom" ./install
+./install --no-modify-path
+```
+
+### 配置模型
+
+使用 TUI 对话或运行 Agent 前，先复制模型配置模板：
+
+```bash
+cp config/llm.example.yaml config/llm.yaml
+```
+
+编辑 `config/llm.yaml` 并替换占位内容。不要提交这个文件；它包含凭证，已经被 Git 忽略。
+
+```yaml
+model:
+  default_model_type: powerful
+  powerful:
+    model: "openai/<model-id>"
+    api_key: "<api-key>"
+    base_url: "https://<openai-compatible-endpoint>"  # OpenAI 官方端点可省略
+    tool_choice: "auto"
+```
+
+Agent 任务使用 AgentLoom 原有模型运行时。TUI 对话目前要求 OpenAI-compatible Chat Completions 接口；创建 YAML 还要求模型支持流式响应和原生 tool/function calling。
+
+## 从 TUI 开始
+
+在需要查看的项目中运行 `agentloom`，也可以显式指定项目：
+
+```bash
+cd /path/to/AgentLoom
 agentloom
 
-# 也可以显式指定项目：
+# 查看另一个 AgentLoom 项目
 agentloom --project /path/to/project
 ```
 
-源码安装器沿用 OpenCode 的原生二进制安装方式：为当前平台构建
-TypeScript/OpenTUI 单文件程序，安装到 `~/.agentloom/bin`，并在
-`~/.agentloom/venv` 创建隔离、锁定的 Python 环境。安装阶段会自动查找或安装
-`uv` 和 Bun；之后运行 `agentloom` 不需要激活 venv，也不用输入 `uv run`。
-如果不希望修改 Shell 配置，可用 `./install --no-modify-path`；也可通过
-`AGENTLOOM_INSTALL_DIR` 指定其他安装根目录。
+TUI 是 Agent Builder 和项目控制面。它可以讨论设计、检查已有定义、暂存并校验 Agent YAML，以及读取标准运行状态。
 
-#### 2. 选择 TUI 对话模型
+它不会执行 Shell、Git 或 Agent 任务。是否写入 YAML 由你决定，Agent 也需要在另一个终端中运行。
 
-TUI 从 `config/llm.yaml` 读取模型列表和默认模型。开始对话前，至少配置一个
-OpenAI-compatible 模型：包含 `model`、`api_key`，并提供 HTTPS `base_url`
-（本机地址可用 HTTP），或者使用走 OpenAI 默认端点的 `openai/...` 模型 ID。
-TUI 对话会直接请求这个 Provider；真正运行 Agent 时仍使用 AgentLoom 原有的
-运行时模型链路。要创建 YAML，模型还必须支持流式 Chat Completions 和原生
-tool/function calling，并将 `tool_choice` 保持为 `auto` 或 `required`，不能设为
-`none`。
+### 1. 描述 Agent 系统
 
-在 TUI 中输入 `/models` 打开模型选择器，或用 `/model <type>` 直接切换，
-例如 `/model summary`。
-
-#### 3. 通过对话创建或修改 Agent YAML
-
-按 `Enter` 发送需求，例如：
+按 `Enter` 发送需求。一个有效的初始描述应写清应用、角色、输入、输出和验收标准：
 
 ```text
-创建一个名为 release_review 的应用。使用一个 Supervisor 和两个 Worker，
-分别负责 API 审查和测试审查。模型类型从 config/llm.yaml 中选择，先展示
-准备创建的文件，不要直接写入。
+创建一个名为 release_review 的应用。
+使用一个 Supervisor 和两个 Worker，分别负责 API 审查和测试审查。
+模型类型从 config/llm.yaml 中选择。
+写入前先展示准备创建的文件和调用契约。
 ```
 
-Builder 会按需读取已有 Agent YAML 定义、在内存中暂存草稿并进行校验。你可以
-继续对话修改，确认后再输入 `/apply`。只有当前通过校验的草稿会被写入；普通对话
-不会改文件，`/apply` 也不会启动 Agent。
+Builder 只读取需要的项目上下文，在内存中暂存草稿并校验 YAML。可以继续对话，直到拓扑和调用契约符合预期。
 
-#### 4. 自己运行 Agent
+### 2. 检查并写入 YAML
 
-在另一个终端中，使用草稿里显示的实际路径直接运行 YAML：
+普通对话不会修改文件。输入 `/apply` 才会写入当前通过校验的草稿。这个命令只写 YAML，不会启动 Agent。
+
+使用 `/models` 打开模型选择器，或用 `/model <type>` 直接切换：
+
+```text
+/models
+/model summary
+/apply
+```
+
+### 3. 运行 Agent
+
+打开另一个终端，运行 Builder 显示的 Supervisor 路径：
 
 ```bash
 uv run loom run applications/<app>/workflows/<agent>.yaml
 ```
 
-如果希望通过 Python 文件启动，可以先生成入口文件再运行：
+也可以生成 Python 入口：
 
 ```bash
 uv run loom create applications/<app>/workflows/<agent>.yaml \
@@ -121,98 +135,166 @@ uv run loom create applications/<app>/workflows/<agent>.yaml \
 uv run python applications/<app>/<app>_app.py
 ```
 
-运行期间可以保持 TUI 打开。`loom run` 和调用 `src.runner.run_app` 的 Python
-入口都会发布标准运行状态；如果直接调用底层 Agent `.run()`，会绕过这套生命周期，
-TUI 因此无法展示完整 Run。
+Agent 运行时可以保持 TUI 打开。`loom run` 和自动生成的入口都会发布标准生命周期，供整个项目查看状态。
 
-#### 5. 查看项目中的全部 Agent 和 Run 状态
+直接调用底层 Agent `.run()` 会绕过该生命周期，任何 UI 都无法从中还原完整 Run。
 
-- 按 `Ctrl+P` 或 `Tab`，输入 Application、Agent、Worker、Run、Skill 或
-  Schedule 名称，再用 `↑` / `↓` 和 `Enter` 打开；工作区中的条目也可点击。
-- Agent 详情会显示从未运行的定义、拓扑、文件和校验信息。Run 详情会区分
-  运行中、成功、失败、崩溃、中断和未知状态，并展示 Worker 状态及保留结果。
-- 失败 Run 只展示关键错误、异常 Worker、日志文件路径、产物索引和有界的结果预览，
-  不会把全部原始日志铺满界面。在该 Run 中按 `a`，可以让 TUI 助手基于经过清洗、
-  严格限长的失败上下文分析原因。
-- 用 `F6` 在对话框和详情页之间切换焦点。详情页获得焦点后支持 `PgUp` / `PgDn`、
-  `Home` / `End`、方向键和鼠标滚轮；按 `Esc` 或 `b` 返回。运行状态会自动刷新；
-  在详情页按 `r` 或输入 `/refresh` 可重新建立项目索引。
+### 4. 查看 Agent 与 Run
 
-更多 TUI 架构与开发说明见 [`agentloom-tui/README.md`](../../agentloom-tui/README.md)。
+按 `Ctrl+P` 或 `Tab` 搜索 Application、Agent、Worker、Run、Skill、Schedule 和命令。可以使用键盘或鼠标选择条目。
 
-TUI 创建的定时任务会持久保存；要让任务自动触发，需要在另一个终端显式运行前台调度服务：
+详情页会区分从未运行、运行中、完成、失败、崩溃、中断和未知状态。它展示拓扑、校验、Worker 状态、结果和产物路径，不会把完整日志铺满界面。
+
+选择失败 Run 后按 `a`，TUI 助手会分析经过清洗且严格限长的失败上下文。完整日志仍保存在磁盘，详情页会显示路径。
+
+使用 `F6` 切换焦点。详情页聚焦后支持方向键、`PgUp` / `PgDn`、`Home` / `End` 和鼠标滚轮。按 `Esc` 或 `b` 返回。
+
+| 操作 | 命令 / 按键 |
+|---|---|
+| 发送对话 | `Enter` |
+| 浏览项目 | `Ctrl+P` 或 `Tab` |
+| 选择模型 | `/models` 或 `/model <type>` |
+| 写入已校验草稿 | `/apply` |
+| 刷新完整索引 | `/refresh` 或在详情页按 `r` |
+| 切换对话/详情焦点 | `F6` |
+| 分析选中的失败 Run | `a` |
+
+TUI 架构与开发说明见 [agentloom-tui/README.md](../../agentloom-tui/README.md)。
+
+### 5. 显式运行调度服务
+
+TUI 可以创建和管理持久化 Schedule。自动触发由独立的前台服务负责，因此关闭 TUI 后不会留下隐藏 daemon。
 
 ```bash
 agentloom schedules --project /path/to/project serve
 ```
 
-## 以 Codex 为例快速创建多 Agent 应用
+## 运行已有 Agent
 
-最快的方式是让 Codex 使用仓库自带的 framework skill。Codex 不只是生成 YAML：它也可以直接运行 AgentLoom 应用，检查 `.agentloom/` 下的 run 与 checkpoint 证据，并在 Worker 卡住或配置出错时继续修改应用。
+如果想先验证框架而不创建新应用，可以运行仓库自带的代码审查示例：
 
-可以这样对 Codex 说：
+```bash
+uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
+```
+
+一次运行会在 `.agentloom/runs/<application_id>/<run_id>/` 下生成 receipt。开启 checkpoint 后，可恢复状态位于 `.agentloom/checkpoints/<application_id>/<task_id>/`。
+
+`run_id` 标识一次 attempt，resume 后会改变；`task_id` 标识逻辑任务，resume 时保持不变。
+
+## AgentLoom 如何工作
+
+AgentLoom 把多 Agent 系统视为一个应用，而不是一组松散的 Prompt。
+
+| 概念 | 职责 |
+|---|---|
+| Supervisor | 拆解应用任务，并协调 Worker 和工具。 |
+| Worker | 负责一个专门角色，并暴露 typed callable contract。 |
+| Agent YAML | 定义角色、工作流、模型类型、工具、Skill、Worker 和运行策略。 |
+| Python Runtime | 负责模型路由、Worker 工具生成、并发、日志、checkpoint 和产物。 |
+
+编排逻辑可以复用，确定性的前处理、校验、缓存和结果写入仍然由普通 Python 代码完成。
+
+### 核心能力
+
+| 需求 | AgentLoom 提供 |
+|---|---|
+| 从配置构建应用 | 使用 `loom run` 直接执行 YAML，并可生成 Python 入口。 |
+| 为不同角色选择模型 | 每个 Agent 设置 `model_type`，凭证隔离在 `config/llm.yaml`。 |
+| 像工具一样调用 Agent | Worker 的 `agent_function_schema` 会转换成带校验的 callable function。 |
+| 处理重复输入 | 固定或自动 Worker 并发，并支持 `.batch(tasks)`。 |
+| 扩展 Agent | 内置工具、本地 Python 函数、MCP Server、Claude-style Skill 和显式 Hook。 |
+| 恢复并检查任务 | Run receipt、有界日志、Shell audit、checkpoint resume、结构化事件、Web UI、dashboard 和 TUI。 |
+
+## 手工创建应用
+
+一个应用把 Supervisor、Worker、Prompt、可选工具和输出放在一起：
+
+```text
+applications/release_review/
+├── workflows/
+│   ├── release_review_agent.yaml
+│   └── worker_agents/
+│       ├── api_reviewer.yaml
+│       └── test_reviewer.yaml
+├── config/system.yaml          # 可选的应用级覆盖
+├── sysprompt/                  # 可选 Prompt 模板
+└── README.md
+```
+
+最小 Supervisor 会引用 Worker YAML：
+
+```yaml
+name: "release_review"
+description: "Review an API release and its test evidence."
+model_type: "powerful"
+tool_call_type: "tool_call"
+
+worker_agents:
+  - path: "applications/release_review/workflows/worker_agents/api_reviewer.yaml"
+  - path: "applications/release_review/workflows/worker_agents/test_reviewer.yaml"
+
+workflow: |
+  Ask both Workers for evidence, reconcile conflicts, and return one release decision.
+
+tools: []
+skills: []
+max_steps: 12
+```
+
+每个 Worker 定义 Supervisor 可见的调用契约：
+
+```yaml
+name: "api_reviewer"
+description: "Review API compatibility risks."
+model_type: "fast"
+tool_call_type: "tool_call"
+
+agent_function_schema:
+  description: "Review one release request."
+  inputs:
+    request:
+      description: "Release scope and API diff."
+      required: true
+  output:
+    description: "Evidence-backed compatibility findings."
+
+workflow: |
+  Review the request, cite evidence, and return prioritized findings.
+
+tools: []
+worker_agents: []
+skills: []
+max_steps: 8
+```
+
+确认真实 `model_type` 存在于 `config/llm.yaml`，然后运行 Supervisor：
+
+```bash
+uv run loom run applications/release_review/workflows/release_review_agent.yaml
+```
+
+完整字段见 [Agent 配置参考](agent_config.md)。
+
+## 使用编程助手创建应用
+
+仓库提供 `agentloom-framework-skill/`，供 Codex、Claude Code 和其他支持 Skill 的编程助手使用。
+
+创建文件前，先要求助手读取该 Skill：
 
 ```text
 先读取 agentloom-framework-skill/SKILL.md。
 
 为下面目标创建一个名为 <app_name> 的 AgentLoom 应用：
-<说明用户任务、输入、输出和验收标准>
+<任务、输入、输出和验收标准>
 
-要求：
-- 所有文件放在 applications/<app_name>/ 下。
-- 使用一个 Supervisor YAML 和至少两个 Worker YAML。
-- 每个 Worker 必须定义 agent_function_schema，写清输入和输出。
-- model_type 只能从 config/llm.yaml 中选择。
-- 只有对这个应用有帮助时，才添加 Skills 或 MCP 配置。
-- 编写应用 README，包含运行命令、Worker 分工、验证记录和已知限制。
-- 运行应用，观察日志和 checkpoint，并修复发现的 YAML 或工具问题。
+在 applications/<app_name>/ 下创建一个 Supervisor 和必要的 Worker。
+只使用 config/llm.yaml 中存在的模型类型。
+用 agent_function_schema 定义每个 Worker 的输入和输出。
+校验 YAML、运行应用、检查 .agentloom 证据，
+并报告通过、失败和仍有限制的内容。
 ```
 
-你可以让 Codex 帮你运行和观察，也可以自己运行：
-
-```bash
-uv run loom run applications/<app_name>/workflows/<app_name>_agent.yaml
-```
-
-运行过程中常用的查看命令：
-
-```bash
-uv run loom list-tasks
-uv run loom dashboard
-
-manifest=$(find .agentloom/runs -name manifest.json -type f -print | sort | tail -1)
-run_dir=$(dirname "$manifest")
-sed -n '1,160p' "$manifest"
-tail -n 80 "$run_dir/logs/runtime.log"
-tail -n 80 "$run_dir/audit/shell.jsonl"
-```
-
-如果你更习惯 Claude Code，也可以用同样的思路：先读 `agentloom-framework-skill/SKILL.md`，在 `applications/<app_name>/` 下创建应用，运行它，并总结成功和失败的地方。
-
-核心配置可以先理解成四件事：
-
-- `model_type`：这个 Agent 用哪一类已配置好的模型。
-- `worker_agents`：Supervisor 可以调用哪些 Worker YAML。
-- `agent_function_schema`：Worker 接收什么输入、返回什么输出。
-- `skills` / `mcp_servers`：可选的额外知识和外部工具。
-
-## 为什么选择 AgentLoom
-
-很多 Agent 框架提供的是组件。AgentLoom 提供的是完整应用结构。
-
-复杂 Agent 应用经常重复写同一批基础代码：Worker 注册、参数适配、运行入口、批量并发、日志、checkpoint 和安全控制。AgentLoom 把这些可复用部分放进 YAML 和运行时里。你的应用代码只需要关注领域任务：前处理、校验、产物落盘，以及真正的 Agent 分工。
-
-实际收益是：
-
-| 需求 | AgentLoom 的方式 |
-|---|---|
-| 构建完整 multi-agent 应用 | 用 YAML 定义 Supervisor、Workers、工具、Skills 和运行时行为。 |
-| 为不同角色选择不同模型 | 每个 Agent 设置自己的 `model_type`，真实密钥和端点隔离在 `config/llm.yaml`。 |
-| 把子 Agent 当工具调用 | Worker 定义 `agent_function_schema`，Supervisor 像调用普通工具一样调用它。 |
-| 复用编程助手知识 | 加载 Claude-style `SKILL.md` 包，支持按需加载或全文预加载。 |
-| 接入外部工具 | 注册本地 Python 工具、本地 `codex exec`，并通过 `mcp_servers` 接入 MCP servers。 |
-| 处理重复性工作 | 用 Worker `concurrency` 和 `tool.batch(tasks)` 并发处理独立输入。 |
-| 理解长任务状态 | 读取 run manifest、有界 runtime log、Shell audit、task checkpoint，并使用 `loom ui` 和 `loom dashboard`。 |
+Framework Skill 是提供给编程助手的开发说明。它不是 Runtime Skill，也不会被 Agent 应用自动加载。
 
 ## 架构
 
@@ -220,132 +302,83 @@ tail -n 80 "$run_dir/audit/shell.jsonl"
   <img alt="AgentLoom runtime architecture" src="../assets/agentloom-runtime-architecture.svg">
 </p>
 
-关键边界是：
+Worker Agent 会转换成生成的工具。Supervisor 可以同时调用 Worker，以及普通 Python、MCP、文件、Shell、搜索、Git、Codex 或 Skill 工具。
 
-- Worker Agent 定义自己的角色、工具、输入和输出契约。
-- AgentLoom 把 Worker 转成带真实函数签名的可调用工具。
-- Supervisor 协调 Workers 和普通工具，完成应用级任务。
-- Python 仍然可以负责确定性的前处理、校验、缓存和产物落盘。
-
-## 核心能力
-
-| 能力 | 已实现内容 |
-|---|---|
-| 应用优先的 YAML | `loom run` 直接执行 Agent YAML；`loom create` 生成 Python 入口脚本；`run_app()` 可嵌入 Python。 |
-| 按 Agent 路由模型 | 每个 Agent 选择 `model_type`；真实 provider、key、endpoint、retry 和参数在 `config/llm.yaml` 中管理。 |
-| Agent-as-Tool 协作 | Worker 通过 `agent_function_schema` 导出为可调用工具，包含必填输入校验和字符串输出。 |
-| Skills、MCP 与工具 | Agent 可加载 `SKILL.md` 包、本地 Python 函数、内置文件/Shell/搜索/Git 工具、本地 Codex 工具，并通过 `mcp_servers` 接入 MCP Client 工具。 |
-| 并发重复任务 | Worker `concurrency: auto` 或固定并发配合 `.batch(tasks)` 处理大量独立输入。 |
-| 状态与可观测性 | Rich 终端日志、有界的 per-run 文件日志、每步耗时、Token 统计、run manifest、checkpoint resume、Web UI 和 TUI dashboard。 |
+Runtime 负责执行身份和证据。TUI 与其他观察端读取这套标准状态，而不是根据进程输出猜测结果。
 
 ## 示例应用
 
-`applications/` 目录包含多个可运行示例，展示 AgentLoom 的推荐使用方式。
-
-| 应用 | 构建内容 | 证明的框架能力 |
-|---|---|---|
-| `ai_quality_analysis` | 多维度代码审查应用。 | 12 个 Worker Agent、分阶段审查、直接 `loom run`、长时间代码库分析。 |
-| `unit_test_studio` | Python pytest 生成工作流。 | 严格多步骤流水线、自定义入口脚本、函数接收、场景规划、测试生成、精炼、交付报告。 |
-| `repo_map` | 仓库架构地图生成器。 | 确定性 Python 预处理 + Agent 架构分析、Bottom-Up 目录处理、`tool.batch(tasks)`、进度持久化。 |
-| `codex_exec_demo` | 本地 Codex Exec 工具调用示例。 | 直接 `loom run`、普通 function tool 注册、`fixed_args` 固定 Codex 参数、结构化 `tool_call` 顺序调用。 |
-
-运行默认代码审查示例：
+| 应用 | 展示能力 |
+|---|---|
+| `ai_quality_analysis` | 十二个专门 Worker 协作完成分阶段代码审查。 |
+| `unit_test_studio` | 使用自定义 Python 入口的严格 pytest 生成流水线。 |
+| `repo_map` | 确定性前处理、Bottom-Up Agent 分析、批处理和进度持久化。 |
+| `codex_exec_demo` | 将本地 `codex exec` 注册为带固定参数的普通 Agent 工具。 |
 
 ```bash
-uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
-```
-
-用自定义 Python 入口运行 Repo Map：
-
-```bash
+# 生成仓库架构地图
 uv run python applications/repo_map/repo_map_app.py /path/to/project \
-  --output_dir /tmp/repo-map-output \
-  --exclude_dirs vendor \
-  --exclude_dirs build
-```
+  --output_dir /tmp/repo-map-output
 
-为指定函数生成 pytest 测试：
-
-```bash
+# 为指定函数生成 pytest
 uv run python applications/unit_test_studio/studio_runner.py \
-  /path/to/your/project \
-  "src/utils.py:parse_config,src/core.py:run_pipeline" \
+  /path/to/project "src/utils.py:parse_config" \
   --output_dir tests/generated
-```
 
-运行本地 Codex Exec 工具示例：
-
-```bash
+# 本地 Codex 工具示例
 uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
 ```
 
-## 核心概念
-
-### Supervisor / Worker
-
-Supervisor Agent 负责协调任务。Worker Agent 专注其中一个部分。多 Agent 应用中，Supervisor 通过 `worker_agents` 引用 Workers，Workers 通过 `agent_function_schema` 暴露可调用契约。
-
-### Agent 即工具
-
-Worker Agent 可以导出为可调用工具。AgentLoom 会生成函数签名、校验必填输入、构造任务载荷并返回字符串结果。同一个 Worker 还可以暴露 `.batch(tasks)` 用于并发执行。
-
-### Skills 与 Hooks
-
-Skills 通过 Claude-style `SKILL.md` 包提供可复用知识。Hooks 是独立、显式配置的 Shell 扩展，只覆盖 11 个真实的工具、任务、Agent 和会话事件。Skill 不能声明或注册 Hook；可复用 Hook 位于显式引用的 `HOOK.yaml` Bundle。详见 [Hook 配置](hooks.md)。
-
-### 本地 Codex 工具
-
-AgentLoom 内置 `src.tools.codex.codex_tool.codex`，用于把本机 `codex exec` 作为普通 function tool 暴露给 Agent。在 Agent YAML 的 `tools` 中通过 `module/function` 注册即可。使用 `fixed_args` 可以锁定 `prompt`、`cwd`、`sandbox`、`search` 等输入；被固定的参数不会出现在 LLM 可见的 tool schema 中。
-
-使用前需要确保 `codex` 在 `PATH` 中，并且 `codex login status` 成功。
-
-## CLI 命令
+## CLI 参考
 
 | 命令 | 用途 |
 |---|---|
-| `uv run loom run <workflow>` | 运行一个 AgentLoom 应用。 |
-| `uv run loom run <workflow> --output-format jsonl` | 为程序调用方输出有版本的生命周期事件流。 |
-| `uv run loom create <workflow>` | 为应用生成 Python 入口脚本。 |
+| `uv run loom run <workflow>` | 运行应用。 |
+| `uv run loom run <workflow> --output-format jsonl` | 输出带版本的生命周期事件流。 |
+| `uv run loom create <workflow>` | 生成 Python 入口。 |
+| `uv run loom list-tasks` | 列出可恢复任务。 |
+| `uv run loom dashboard` | 打开终端任务 dashboard。 |
 | `uv run loom ui` | 打开 Web 可视化面板。 |
-| `uv run loom dashboard` | 打开终端任务监控面板。 |
-| `uv run loom list-tasks` | 列出可恢复的 checkpoint 任务。 |
-| `uv run loom clean-tasks` | 清理旧 checkpoint 数据。 |
-| `uv run loom clean-runtime` | 按配置的 retention 清理已结束 run 与 raw artifacts。 |
-| `uv run loom migrate-runtime --dry-run` | 只预览旧 checkpoint 候选和未分域的 `.runtime`，不改磁盘状态。 |
-| `uv run loom migrate-runtime --apply` | 迁移 checkpoint、归档 `.logs`，并将 `.runtime` 原子保存在 `.agentloom/workspaces/legacy-unscoped/`。 |
-| `uv run loom schedules ...` | 新增、列出、暂停、恢复、删除、运行、服务或查看调度。 |
-| `uv run loom sessions search\|scroll\|index\|prune ...` | 搜索和维护执行历史。 |
+| `uv run loom schedules ...` | 管理持久化 Schedule。 |
+| `uv run loom sessions ...` | 搜索和维护执行历史。 |
 | `uv run loom learn review ...` | 触发 Application 或 Project review。 |
-| `uv run loom reviews status\|apply\|rollback ...` | 查看并应用 scoped review inbox，或回滚一次 review。 |
-| `uv run loom memory list\|add\|replace\|remove\|pending\|stats\|export ...` | 管理 Curated Memory 和 pending-write 审计记录。 |
-| `uv run loom feedback submit <run_id> ...` | 为 run 提交 accepted、rejected 或 corrected 反馈。 |
+| `uv run loom reviews ...` | 查看、应用或回滚 review decision。 |
+| `uv run loom memory ...` | 管理 Curated Memory。 |
+| `uv run loom feedback submit <run_id> ...` | 为 Run 添加结果反馈。 |
+| `uv run loom clean-tasks` | 删除保留的 checkpoint 任务。 |
+| `uv run loom clean-runtime` | 执行已配置的 Run 和 artifact retention。 |
+| `uv run loom migrate-runtime --dry-run\|--apply` | 预览或执行旧 Runtime 迁移。 |
+
+使用 `uv run loom <command> --help` 查看完整命令契约。
 
 ## 文档
 
-| 文档 | 说明 |
+| 文档 | 内容 |
 |---|---|
-| [配置体系总览](config-overview.md) | 配置层级、合并规则和模型配置隔离机制。 |
-| [Agent 配置](agent_config.md) | Supervisor/Worker 字段、工具、模型选择、工作流和 Skills。 |
-| [LLM 配置](llm_config.md) | 模型类型、Provider 设置、继承、重试和 Prompt 缓存。 |
-| [系统配置](system_config.md) | 运行时设置、权限、日志、执行环境和工具系统。 |
-| [Skills 配置](skills_config.md) | Skill 包格式、加载方式、运行时策略和内置 Skills。 |
-| [Hooks 参考](hooks.md) | 直接 Hook、Bundle、生命周期事件、匹配规则和执行行为。 |
-| [Checkpoint 断点恢复](checkpoint.md) | Checkpoint 布局、恢复行为和长任务恢复机制。 |
-| [Self-learning v6](self_learning.md) | History、typed candidates、review trigger、审批和 Project promotion。 |
-| [结构化 Run API](run_observability.md) | Python receipt、typed errors、生命周期事件和 JSONL CLI 输出。 |
+| [配置体系总览](config-overview.md) | 配置层级、合并和隔离。 |
+| [Agent 配置](agent_config.md) | Supervisor 和 Worker YAML 字段。 |
+| [LLM 配置](llm_config.md) | 模型类型、Provider、重试和缓存。 |
+| [系统配置](system_config.md) | Runtime、权限、执行环境和工具。 |
+| [Skill 配置](skills_config.md) | Skill 包、加载方式和策略。 |
+| [Hook 参考](hooks.md) | 直接 Hook、Bundle、事件和执行方式。 |
+| [Checkpoint 恢复](checkpoint.md) | Run 证据、checkpoint 布局和恢复。 |
+| [Self-learning v6](self_learning.md) | History、candidate、review、审批和 promotion。 |
+| [结构化 Run API](run_observability.md) | Python receipt、typed error、event sink 和 JSONL。 |
 
-## AgentLoom Framework Skill
+## 开发与支持
 
-仓库根目录提供一个给 AI 编程助手使用的框架级 Skill：`agentloom-framework-skill/`。
+```bash
+# Framework 测试
+uv run pytest tests -q
 
-当你想让 Codex、Claude Code 或其他编程助手基于 AgentLoom 开发，而不是从零猜框架结构时，让助手先读取 `agentloom-framework-skill/SKILL.md`，再描述你要构建的应用能力。
+# TUI 测试
+cd agentloom-tui
+bun test
+bun run typecheck
+```
 
-这个 Skill 是开发辅助，不放在 `skills/` 运行时自动发现目录下，因此不是运行 AgentLoom 应用的必需依赖。
-
-## 支持与参与
-
-AgentLoom 是面向复杂 Agent 自动化任务的实用框架。欢迎提交 Issue、功能建议、文档改进和新的示例应用。
-
-- 提 Issue：[GitHub Issues](https://github.com/linora-u/AgentLoom/issues)
+- Issue：[github.com/linora-u/AgentLoom/issues](https://github.com/linora-u/AgentLoom/issues)
 - 联系方式：[raine_walker@163.com](mailto:raine_walker@163.com?subject=AgentLoom%20Collaboration)
-- 如果这个项目对你有帮助，欢迎给一个 GitHub Star，让更多人看到它。
+- TUI 上游来源与许可证：[agentloom-tui/upstream/README.md](../../agentloom-tui/upstream/README.md)
+
+如果 AgentLoom 对你的项目有帮助，欢迎 Star 仓库，或贡献一个范围明确的示例、修复或文档改进。


### PR DESCRIPTION
## Summary

- restructure the English README around installation, TUI usage, architecture, and examples
- apply the corresponding structure updates to the Chinese README
- merge the documentation changes already reviewed on `dev` into `main`

## Testing

Not run (documentation-only changes).