### PR TITLE
fix: expose New Application in command palette

### DIFF
--- a/agentloom-tui/src/app/controller.ts
+++ b/agentloom-tui/src/app/controller.ts
@@ -78,6 +78,7 @@ export type PaletteItem =
       title: string
       description: string
       action:
+        | "new-application"
         | "chat"
         | "refresh"
         | "models"
@@ -278,6 +279,13 @@ export function buildPaletteItems(snapshot: BootstrapResultDto): PaletteItem[] {
     },
   }))
   return [
+    {
+      key: "command:new-application",
+      category: "Commands",
+      title: "新建 Application",
+      description: "创建一个全新的 AgentLoom Application",
+      action: "new-application",
+    },
     {
       key: "command:chat",
       category: "Commands",

--- a/agentloom-tui/src/app/view.tsx
+++ b/agentloom-tui/src/app/view.tsx
@@ -407,6 +407,7 @@ export function AgentLoomApp(props: AgentLoomAppProps) {
       return
     }
     closePalette()
+    if (item.action === "new-application") void props.session.beginApplicationCreation()
     if (item.action === "chat") props.session.goBuilder()
     if (item.action === "refresh") void props.session.refresh()
     if (item.action === "permission-full") void props.session.setPermissionMode("full_access")

--- a/agentloom-tui/test/app/controller.test.ts
+++ b/agentloom-tui/test/app/controller.test.ts
@@ -189,6 +189,7 @@ describe("TUI controller", () => {
   test("builds one searchable command and entity catalog instead of a permanent list", () => {
     const items = buildPaletteItems(bootstrap)
     expect(items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: "new-application", title: "新建 Application" }),
       expect.objectContaining({ action: "permission-full", title: "启用 Full Access" }),
       expect.objectContaining({ action: "permission-application", title: "恢复 Application Only" }),
       expect.objectContaining({
@@ -199,6 +200,7 @@ describe("TUI controller", () => {
     ]))
 
     expect(items.filter((item) => item.category === "Commands").map((item) => item.title)).toEqual([
+      "新建 Application",
       "返回对话",
       "刷新工作区",
       "启用 Full Access",

--- a/agentloom-tui/test/app/view.test.tsx
+++ b/agentloom-tui/test/app/view.test.tsx
@@ -637,6 +637,39 @@ describe("AgentLoom TUI view", () => {
     expect(setup.captureCharFrame()).toContain("New Application · Application Only")
   })
 
+  test("Ctrl+X exposes New Application and starts creation with Enter", async () => {
+    const client: TuiClient = {
+      async request<Method extends RpcMethod>() {
+        return catalogSnapshot as RpcResult<Method>
+      },
+      close() {},
+    }
+    const session = new AgentLoomSession({
+      client,
+      snapshot: catalogSnapshot,
+      sessionID: "new-application-command-test",
+    })
+    const setup = await testRender(
+      () => <AgentLoomApp session={session} projectRoot="/repo" onExit={() => {}} refreshIntervalMs={0} />,
+      { width: 140, height: 32 },
+    )
+    renderers.push(setup.renderer)
+    await setup.renderOnce()
+
+    setup.mockInput.pressKey("x", { ctrl: true })
+    await Bun.sleep(5)
+    await setup.mockInput.typeText("新建 Application")
+    await setup.renderOnce()
+    expect(setup.captureCharFrame()).toContain("创建一个全新的 AgentLoom Application")
+
+    setup.mockInput.pressEnter()
+    await Bun.sleep(20)
+    await setup.renderOnce()
+
+    expect(session.state.studioTarget).toEqual({ type: "new" })
+    expect(setup.captureCharFrame()).toContain("New Application · Application Only")
+  })
+
   test("wide terminals keep Studio chat and the Application directory together", async () => {
     const client: TuiClient = {
       async request<Method extends RpcMethod>() {


### PR DESCRIPTION
## Summary

- Add 新建 Application as the first Ctrl+X command.
- Start a fresh isolated Studio creation session directly from the command palette.
- Keep the existing homepage + New Application entry and unified command palette behavior consistent.

## Validation

- bun test: 170 passed, 0 failed.
- bun run typecheck: passed.
- bun run build: passed.
- ./install: passed.
- Real installed TUI: Ctrl+X shows 新建 Application first; Enter opens New Application · Application Only.