### PR TITLE
feat: add supervisor-owned goal mode

### DIFF
--- a/GOAL_MODE_SPEC.md
+++ b/GOAL_MODE_SPEC.md
@@ -1,0 +1,199 @@
+# AgentLoom Goal Mode Specification
+
+Status: Implemented and validated (2026-08-04)
+
+## Problem Statement
+
+AgentLoom 当前通过 Agent YAML 的 workflow 定义 Supervisor 的长期职责和执行流程。普通字符串 workflow 会作为一次任务上下文执行；Supervisor 的 workflow 列表则具有特殊执行语义，每个列表项都会触发一次独立的运行，后续项通过保留 memory 延续前序结果。
+
+这种机制适合预先确定的阶段式流程，但无法表达另一类自动化任务：用户只关心一个最终目标，希望主 Agent 在单次回答或单轮执行结束后仍能持续推进，直到它明确确认目标已经完成，或者累计 token 预算达到上限。现有 final answer、Todo、max_steps 和 workflow 列表都不能提供这种生命周期保证：
+
+- final answer 只代表一次模型运行停止，不代表最终目标已经满足；
+- Todo 是执行进度状态，不是目标完成门槛；
+- max_steps 是单次运行的安全边界，不是整个目标的生命周期边界；
+- workflow 列表是预定义的多次运行，不会在列表结束后依据目标状态自动续跑；
+- Worker 与 Supervisor 的 token 消耗没有统一汇总，预算容易被委派绕过；
+- 当前运行状态没有 budget_limited，无法准确表达“目标未完成，但预算已经阻止继续运行”；
+- Goal 配置如果开放给 Worker，会产生多个互相竞争的目标事实源。
+
+用户需要一个由 Supervisor 独占的 Goal Mode。它应通过现有 Agent YAML 显式启用，将 description、workflow 和本次 task 组合为一个目标上下文，在同一个 Agent 和记忆上持续 continuation，并由主 Agent 通过明确的 Goal 工具提交完成证据。Goal Mode 必须兼容现有 workflow 字段，但启用后应采用 Codex 风格的目标驱动执行，而不是继续把 workflow 列表解释为多个独立运行。
+
+## Solution
+
+为 AgentLoom 增加一个与现有 Agent 角色和 workflow 配置正交的 Goal Mode。
+
+Goal Mode 仅允许顶层 Supervisor 配置。配置支持布尔简写，也支持包含 enabled 和可选 token_budget 的完整 mapping。布尔 true 表示启用且预算无上限；布尔 false 或缺少 goal 表示关闭；mapping 中 enabled 必填，token_budget 省略时同样表示无上限。
+
+启用后，系统根据 description、完整 workflow 和本次运行 task 自动创建唯一的 active goal。用户不需要在 YAML 中重复填写 objective。字符串 workflow 直接作为目标要求；列表 workflow 按原顺序编号并合并为一个目标上下文，只触发一次初始运行。文档推荐 Goal Mode 使用多行字符串 workflow，同时明确列表在 Goal Mode 与普通模式下具有不同语义。
+
+主 Agent 获得 get_goal 和 update_goal 两个内部生命周期工具。get_goal 返回目标、状态、预算、累计用量和完成证据。update_goal 只接受 complete 状态和非空 evidence。普通 final answer 不会自动完成 goal；只要 goal 仍为 active，运行时就在同一 Agent 和记忆上发送 continuation prompt。max_steps 仅结束当前 continuation 分段，不终止 active goal。
+
+Goal 工具既从 Worker 的工具目录中隐藏，也在执行时验证调用者确实是根 Supervisor。Worker 可以执行主 Agent 委派的工作，但不能读取或修改根 Goal。所有 Worker 的模型 token 仍计入根 Goal 的累计预算。
+
+token_budget 统计整个根 Agent 树的 prompt_tokens 与 completion_tokens。限制是软边界：已经发出的模型请求不会被取消，并发 Worker 可能造成少量超额；响应完成后系统原子累计用量，达到预算时将 Goal 和 run 置为 budget_limited，保存 checkpoint，停止新的模型请求与 continuation。用户提高 YAML 预算或移除预算后可以 resume，既有用量不会清零。
+
+Goal 状态和用量随 task checkpoint 持久化。checkpoint 记录 Goal 是否已经启动，resume 时恢复现有 memory 并发送 continuation prompt，不重新注入或重新执行初始 workflow。目标内容通过稳定指纹绑定；workflow、description 或 task 发生变化时拒绝恢复。手动中断和真实运行错误保留 active goal；完成状态一旦由 update_goal 持久化便不回滚。若完成提交后、最终回复落盘前发生崩溃，系统与 Codex 一致，不自动补写最终回复。
+
+成功完成前，Goal 的 objective、终态、token 用量、预算和 evidence 会复制到持久化 run manifest，再按现有成功清理策略清除 checkpoint。CLI、JSON/JSONL 和 TUI 运行详情均展示 Goal 状态与用量。未启用 Goal 时，不注入工具、提示或计量逻辑，不改变现有 workflow 行为。
+
+## User Stories
+
+1. As an AgentLoom user, I want to enable Goal Mode with a boolean YAML value, so that a simple goal does not require verbose configuration.
+2. As an AgentLoom user, I want to disable Goal Mode explicitly, so that I can preserve ordinary workflow behavior.
+3. As an application author, I want a full Goal mapping with an explicit enabled field, so that configuration remains predictable and avoids implicit mapping semantics.
+4. As an application author, I want token_budget to be optional, so that omitting it intentionally means unlimited execution.
+5. As an application author, I want token_budget to accept only positive integers, so that invalid or ambiguous limits fail before execution.
+6. As an application author, I want unknown Goal configuration fields to fail validation, so that typos cannot silently change runtime guarantees.
+7. As a Supervisor author, I want Goal Mode to derive its objective from description, workflow, and the current task, so that I do not duplicate the same objective in YAML.
+8. As a Supervisor author, I want a multiline string workflow to be the recommended Goal format, so that one coherent objective is easy to read and maintain.
+9. As a Supervisor author, I want a workflow list to remain accepted in Goal Mode, so that existing content can be adopted without a schema rewrite.
+10. As a Supervisor author, I want Goal Mode to merge workflow list items in their original order with visible numbering, so that the model retains every requirement and its boundary.
+11. As an existing AgentLoom user, I want ordinary non-Goal workflow lists to retain their current sequential run behavior, so that enabling this feature elsewhere does not change my workflows.
+12. As an AgentLoom user, I want one active Goal per root run, so that completion, budget, and recovery have one authoritative lifecycle.
+13. As an AgentLoom user, I want a normal final answer to leave an unfinished Goal active, so that one premature model stop cannot silently terminate the objective.
+14. As an AgentLoom user, I want an active Goal to continue automatically on the same Agent and memory, so that long-running work can progress across multiple model segments.
+15. As an AgentLoom user, I want continuation prompts to omit the initial workflow payload, so that resume and continued execution do not duplicate the task.
+16. As an AgentLoom user, I want max_steps to delimit one continuation segment rather than fail the whole Goal, so that the existing safety cap remains useful for long-running objectives.
+17. As a main Agent, I want to inspect the active Goal through get_goal, so that I can reason from the canonical status and remaining budget.
+18. As a main Agent, I want to complete a Goal through update_goal with evidence, so that completion is explicit and auditable.
+19. As an AgentLoom user, I want completion evidence to be non-empty, so that a terminal Goal records why the Agent considered it finished.
+20. As an AgentLoom user, I want the root Agent's completion assertion to be accepted without another evaluator model call, so that completion remains deterministic and cost-efficient.
+21. As a Worker, I want Goal lifecycle tools to be unavailable, so that I cannot accidentally mutate the Supervisor's objective.
+22. As an AgentLoom operator, I want Goal writes to validate root identity at execution time, so that hiding a tool alone is not the security boundary.
+23. As a Supervisor, I want to delegate work normally while Goal Mode is active, so that Goal ownership does not prevent multi-Agent execution.
+24. As an AgentLoom user, I want Worker model usage included in the root Goal budget, so that delegation cannot bypass the configured limit.
+25. As an AgentLoom user, I want token usage to count provider-reported prompt and completion tokens, so that accounting uses the categories AgentLoom can observe reliably.
+26. As an AgentLoom user, I want an unlimited Goal when token_budget is absent, so that budget policy remains opt-in.
+27. As an AgentLoom user, I want a configured budget to apply cumulatively across initial execution, continuations, Workers, failures, and resumes, so that resume cannot reset cost.
+28. As an AgentLoom user, I want in-flight requests to finish after a soft budget crossing, so that the runtime does not corrupt tool calls or partially cancel model responses.
+29. As an AgentLoom operator, I want new model requests blocked after the shared budget is exhausted, so that overshoot remains bounded to already-started work.
+30. As an AgentLoom user, I want budget exhaustion represented as budget_limited rather than completed, failed, or interrupted, so that the run outcome is truthful.
+31. As an AgentLoom user, I want budget_limited state to preserve the checkpoint, so that I can continue after changing the budget.
+32. As an AgentLoom user, I want to resume by increasing token_budget, so that unfinished work can continue without losing prior progress.
+33. As an AgentLoom user, I want to resume a budget-limited Goal by removing token_budget, so that I can intentionally switch the remaining Goal to unlimited execution.
+34. As an AgentLoom user, I want previously consumed tokens retained after a budget change, so that accounting remains a lifetime total.
+35. As an AgentLoom user, I want a reduced or unchanged exhausted budget to remain budget_limited, so that resume cannot pretend capacity exists.
+36. As an AgentLoom user, I want manual interruption to leave the Goal active, so that an intentional stop does not abandon the objective.
+37. As an AgentLoom user, I want tool, model, or checkpoint failures to mark the run failed while preserving the active Goal, so that I can fix the cause and resume.
+38. As an AgentLoom user, I want resume to reject changed objective content, so that old progress cannot be attached to a different workflow or task.
+39. As an AgentLoom user, I want resume to reject an active Goal whose YAML has been disabled, so that configuration cannot silently cancel persisted state.
+40. As an AgentLoom user, I want Goal-started state to survive process restart, so that resume sends a continuation rather than the original task again.
+41. As an AgentLoom user, I want a completed Goal to remain complete after interruption or process failure, so that committed completion is never rolled back.
+42. As an AgentLoom user, I want a hard crash after completion but before final delivery not to restart substantive work, so that a terminal Goal remains terminal.
+43. As an AgentLoom operator, I want completed Goal evidence and usage copied into the run manifest, so that successful checkpoint cleanup does not erase audit information.
+44. As a CLI user, I want to see Goal status, used tokens, and configured budget, so that I can understand why a run continued or stopped.
+45. As a machine client, I want JSON and JSONL output to contain structured Goal state, so that automation does not parse human text.
+46. As a TUI user, I want run details to show active, complete, and budget_limited states, so that Goal lifecycle is visible during and after execution.
+47. As a scheduler user, I want scheduled workflows to support Goal Mode, so that unattended objectives can use the same lifecycle.
+48. As a scheduler user, I want documentation to warn about unlimited unattended Goals, so that I can configure a budget when a human will not monitor execution.
+49. As a Worker YAML author, I want Goal configuration to fail validation, so that Supervisor-only ownership is enforced before runtime.
+50. As an AgentLoom user, I want Goal-disabled workflows to have no extra prompts, tools, token accounting, persistence, or status changes, so that the feature is zero-impact when unused.
+51. As an AgentLoom maintainer, I want runtime, offline validation, builder validation, and documentation to share one Goal contract, so that configuration behavior cannot diverge by entry point.
+52. As an AgentLoom maintainer, I want Codex used as the lifecycle reference and OpenCode used as the permission reference, so that the implementation borrows proven boundaries without copying incompatible architecture.
+53. As an AgentLoom maintainer, I want the bundled reference repositories left untouched, so that AgentLoom owns its own Goal implementation.
+54. As an AgentLoom maintainer, I want ordinary workflow-list resume behavior left outside this change, so that Goal Mode does not expand into an unrelated execution-cursor refactor.
+55. As a documentation reader, I want the different list semantics in Goal and non-Goal modes stated explicitly, so that YAML shape alone does not create surprising execution.
+
+## Implementation Decisions
+
+- Goal Mode is a Supervisor-owned execution-lifecycle overlay, not a third Agent role, a Todo variant, a collaboration mode, or a new workflow field type.
+- The implementation targets the AgentLoom Python runtime and its TUI/CLI surfaces. The bundled Codex checkout and the externally inspected OpenCode repository are reference implementations only and must not be modified.
+- Accepted Goal configuration has exactly three forms: boolean true, boolean false, or a mapping with required enabled and optional token_budget. A missing goal field is equivalent to false.
+- In mapping form, enabled must be a boolean and token_budget must be a positive integer when present. Unknown keys, null, strings, zero, negative values, floats, and booleans used as integers are rejected.
+- Goal configuration is legal only on a top-level Supervisor definition. Runtime Worker construction, offline application validation, builder validation, and Worker-as-tool loading all reject Goal configuration fail-closed.
+- Boolean true enables an unlimited Goal. Boolean false disables Goal Mode. A mapping with enabled true and no token_budget is unlimited. A mapping with enabled false may not include token_budget.
+- Goal-disabled execution remains byte-for-byte compatible at the behavior boundary: ordinary string workflow behavior and sequential Supervisor list behavior are unchanged.
+- The canonical Goal objective is a deterministic composition of the normalized Supervisor description, normalized workflow content, and the original task request.
+- In Goal Mode, a string workflow remains one coherent block. A workflow list is normalized in original order into numbered Goal requirements and then handled as one initial runtime task. It never creates multiple runtime runs.
+- Documentation recommends a multiline string workflow for Goal Mode and treats list support as compatibility input, not as a staged executor.
+- Goal state is scoped to one root task. Only one Goal exists for that task, and a second Goal cannot be created through model tools.
+- YAML activation creates the Goal automatically. There is no create_goal tool.
+- The model-facing lifecycle surface contains get_goal and update_goal. update_goal accepts only status complete and a required non-empty evidence string. There are no blocked, cancelled, paused, create, clear, or arbitrary budget-mutation tools.
+- get_goal returns the canonical objective, status, configured budget, cumulative used tokens, remaining budget when bounded, completion evidence when terminal, and stable Goal identity.
+- The Goal status state machine contains active, budget_limited, and complete. budget_limited transitions back to active only after a valid budget increase or removal during resume. complete is terminal.
+- Run status remains distinct from Goal status. Goal-aware runs can be running, completed, budget_limited, interrupted, failed, or crashed according to the existing run lifecycle plus the new resumable budget_limited outcome.
+- A normal model final answer does not change Goal status. When a runtime segment returns while Goal is active, the host starts another continuation segment on the same runtime Agent with reset disabled and preserved memory.
+- The first segment receives the complete Goal context. Later in-process continuation and resumed execution receive a bounded Codex-style continuation prompt containing stable Goal identity, current status, used budget, remaining budget, and instructions to continue or explicitly complete. It relies on restored conversation memory and does not reinject the workflow; the root Agent can call get_goal to reread the canonical objective when needed.
+- A persisted goal_started marker distinguishes initial execution from continuation. Resume never replays the initial Goal prompt after this marker has committed.
+- max_steps remains a per-segment safety cap. A max-steps result while Goal is active and budget remains is converted into the next continuation segment rather than a terminal run failure.
+- True model-provider failures, tool failures that abort the run, checkpoint corruption, and unrecoverable runtime errors stop the current attempt. They preserve an active Goal and resumable checkpoint under the existing failed, interrupted, or crashed semantics.
+- Root-only Goal tools are enforced twice: they are appended only to the Supervisor tool surface when Goal Mode is enabled, and their handlers validate root local-run identity, root-run identity, top-level HookRun ownership, and active Goal configuration before reading or writing state.
+- Worker prompts contain no Goal lifecycle tool instructions. The Supervisor passes only the subtask context needed for delegation.
+- Goal token accounting is owned by shared root-run state inherited by Supervisor and Workers, including parallel Worker execution.
+- The charge unit is provider-reported prompt_tokens plus completion_tokens for every model response in the root Agent tree. AgentLoom does not invent separate cache or reasoning accounting when the provider abstraction cannot expose it consistently.
+- Accounting occurs once at the model-response boundary, not by summing cumulative RunResult totals. This avoids double-counting memory-preserving workflow and continuation runs.
+- A bounded Goal performs a pre-request check against already committed usage. Exact future token cost is unknown, so an allowed request may cross the budget. Concurrent in-flight calls may increase the overshoot.
+- The runtime never cancels an already-started provider response solely because the Goal budget crossed. After each response, usage is atomically added to the root total. Once used tokens meet or exceed the budget, no new provider request or continuation may start.
+- A budget crossing transitions both Goal and current run to budget_limited, persists all recoverable state, emits structured status, and preserves the checkpoint. It does not report complete or failed.
+- token_budget is a lifetime cumulative limit. Resume does not reset used tokens. A budget-limited Goal resumes only when the new configuration raises the budget above used tokens or removes the limit. Budget decreases are rejected for an existing Goal.
+- Resume validates an objective fingerprint derived from description, normalized workflow, and original task. Any objective change is rejected. Budget is validated separately so a permitted increase does not invalidate the objective fingerprint.
+- Changing an active persisted Goal to disabled causes resume to fail with an actionable configuration error. Starting a new task with Goal disabled remains valid.
+- Goal state uses a task-scoped, versioned, atomically persisted checkpoint record. It contains stable Goal identity, schema version, objective and fingerprint, status, goal_started, token budget, used tokens, completion evidence, timestamps, and the configuration facts needed for safe resume.
+- Checkpoint-disabled execution may keep Goal state in root-run memory for the current process, but crash resume is unavailable under the existing checkpoint contract.
+- update_goal completion is idempotent. Once complete has committed, later abort or failure processing cannot revert it to active.
+- A tool-calling root Agent may claim one in-process completion-settlement model request after update_goal commits, provided the completing response did not exhaust the token budget. The request is bound to the same root local-run identity, exposes only final_answer when a tool schema is present, and is not persisted; scheduled planning is skipped locally, pending smart summary uses deterministic local truncation instead of a model request, a max-steps prose fallback may consume the same allowance, and a crash or resume cannot recreate it.
+- Completion state and model transcript settlement are not a cross-system transaction. Following Codex semantics, a crash after completion commits but before the final assistant response persists may leave a complete Goal without a final delivery. Resume does not regenerate that response or restart substantive work; get_goal and durable audit evidence remain authoritative.
+- Before successful checkpoint cleanup, the runtime copies a compact Goal summary into the run manifest or its linked audit evidence. The summary includes objective, Goal identity, final status, configured budget, used tokens, completion evidence, and relevant timestamps.
+- budget_limited, interrupted, failed, and crashed attempts retain the Goal checkpoint. Existing retention and explicit task-cleanup behavior remain authoritative for abandoned runs; no cancel_goal tool is introduced.
+- CLI human output displays Goal status and token usage at lifecycle boundaries. JSON and JSONL use a stable structured Goal object. TUI run details display the same canonical state rather than reconstructing it from log text.
+- Scheduled runs accept the same Goal YAML. Unlimited scheduled Goals remain legal; documentation gives a strong operational warning to set token_budget for unattended execution.
+- Ordinary non-Goal workflow lists retain current sequential execution and current resume behavior. A generic execution cursor is explicitly excluded from this feature.
+- Agent configuration documentation, checkpoint documentation, run observability documentation, framework-skill YAML contract, examples, and validation guidance are updated together.
+
+## Testing Decisions
+
+- Good tests assert behavior visible at a public boundary: accepted YAML, model-visible prompt and tools, provider-call count, continuation, Goal status, token usage, run outcome, persisted resume behavior, and CLI/TUI/JSON output. They do not assert private helper names or internal object layout.
+- The primary and highest test seam is a full Supervisor runtime invocation through the same runner used by loom run, backed by a deterministic fake model and fake Worker models. Most feature behavior should be proven at this seam.
+- The primary runtime suite covers boolean and mapping activation, unlimited and bounded execution, single-string workflow context, list merging into one numbered context, ordinary non-Goal list regression, final-without-complete continuation, explicit completion, evidence, and completion termination.
+- The same runtime seam verifies that get_goal and update_goal are visible to the root Supervisor, absent from Workers, and rejected when called under a forged or inherited non-root execution context.
+- Multi-Agent runtime tests verify that Supervisor and parallel Worker prompt/completion tokens accumulate exactly once into the root Goal and that delegated calls cannot bypass budget.
+- Budget integration tests verify exact-boundary usage, one-response soft overshoot, parallel overshoot, no new calls after limit, budget_limited output, preserved checkpoint, increased-budget resume, unlimited resume, unchanged exhausted budget, and retained cumulative usage.
+- Continuation tests verify same-runtime memory preservation, no repeated initial workflow payload, bounded continuation prompt content, continuation after max_steps, and termination only after complete or budget_limited.
+- Resume tests verify goal_started recovery, stable objective fingerprint acceptance, changed workflow/description/task rejection, enabled-to-disabled rejection, manual interruption recovery, failed-attempt recovery, and no token reset.
+- Completion crash tests cover complete committed before final assistant persistence. They assert that Goal remains complete, no new substantive continuation starts, completion is not replayed, and durable evidence remains readable.
+- Configuration contract tests exercise the public runtime validator and the offline application validator with the same table of valid and invalid values. Valid cases are true, false, enabled true without a budget, enabled true with a positive budget, and enabled false without a budget.
+- Invalid configuration tests cover mapping without enabled, enabled false with a budget, unknown keys, null, strings, empty mappings, zero, negative, float, and boolean budget values.
+- Role validation tests prove Supervisor acceptance and Worker rejection through both direct runtime loading and Worker-as-tool/application validation paths.
+- A focused Goal state-store contract test covers atomic replacement, schema versioning, idempotent completion, status transitions, concurrent accounting, corrupt state handling under the existing checkpoint policy, and isolation by application/task.
+- A focused model-accounting test verifies charging at each response boundary rather than cumulative RunResult totals, including planning responses when provider usage is available and nested Worker responses propagated through root-run context.
+- Run lifecycle tests verify that complete is eligible for existing success cleanup only after manifest/audit persistence, while budget_limited, interrupted, failed, and crashed preserve resumable state.
+- Output-contract tests verify that CLI text, JSON, JSONL, and TUI run details agree on canonical status, budget, used tokens, remaining tokens, and evidence visibility.
+- Schedule integration tests verify that Goal-enabled YAML is accepted by the scheduler and that the launched run uses the same lifecycle and budget semantics as a direct run.
+- Documentation examples are validated through the existing application YAML validation seam so published boolean, mapping, string-workflow, and list-workflow examples cannot drift from runtime parsing.
+- Prior art should be reused from existing suites for Supervisor task transformation, sequential workflow execution, deterministic runtime construction, checkpoint resume, runner status/cleanup, runtime summary, TUI bridge contracts, schedule RPC, YAML definition validation, Worker tool isolation, and token monitoring.
+- The bundled Codex and external OpenCode sources are not test dependencies. AgentLoom tests assert the decisions in this specification rather than pinning implementation details from reference repositories.
+
+## Out of Scope
+
+- Modifying, extending, or patching the bundled Codex checkout.
+- Vendoring or modifying OpenCode.
+- Multiple simultaneous Goals for one root task.
+- Worker-owned, child-thread, shared-mutable, or nested Goals.
+- create_goal, cancel_goal, blocked, paused, usage_limited, or arbitrary status mutation tools.
+- Automatic completion evaluation by a second model, judge, rubric engine, or host-side heuristic.
+- Treating Todo completion as Goal completion.
+- Treating a normal final answer as Goal completion.
+- A hard pre-response token limit with exact cancellation at the configured number.
+- Separate billing rules for cached, reasoning, cache-write, monetary cost, wall-clock time, or provider quotas.
+- Resetting token usage on resume.
+- Replaying or regenerating a missing final assistant response after complete has already committed.
+- Exactly-once delivery guarantees across Goal state, model transcript persistence, CLI delivery, and external side effects.
+- A generic workflow-stage execution cursor or changes to ordinary workflow-list resume.
+- Preserving ordinary list-as-multiple-runs semantics inside Goal Mode.
+- Goal configuration in global system configuration, Worker YAML, runtime model tools, or user-created dynamic Goal instances.
+- Migration from an older AgentLoom Goal schema because no prior Goal feature exists.
+- Distributed multi-host Goal ownership, leases, or consensus.
+- A dedicated long-term Goal database independent from the task checkpoint and run audit lifecycle.
+- A new interactive approval, cancellation, or budget-editing UI.
+
+## Further Notes
+
+- Codex is the primary lifecycle reference. Its Goal is orthogonal to normal collaboration mode, persists status independently, uses explicit get/create/update tools, continues only active Goals, applies soft token limits, and does not roll back a committed complete state when final delivery is missing.
+- AgentLoom intentionally differs from Codex by auto-creating the Goal from Supervisor YAML, omitting create and blocked operations, and charging Worker usage to the root Goal.
+- OpenCode is the primary permission-boundary reference. Its child sessions receive restricted capabilities, state-changing tools perform execution-time permission checks, and persisted tool side effects are not blindly replayed after interruption.
+- Neither Codex nor OpenCode has AgentLoom's sequential YAML workflow-list execution model. Goal Mode therefore changes list interpretation to one merged context rather than introducing a workflow-stage cursor.
+- Goal Mode and Todo solve different problems. Todo may help the Agent plan work inside a Goal, but Todo state is not authoritative for Goal completion or continuation.
+- Unlimited means exactly no Goal token ceiling. Existing provider, context, infrastructure, user interruption, and retention limits still apply.
+- Soft-budget overshoot is unavoidable because response token cost is only known after a provider response and parallel Workers may already be in flight. The UI and manifest report actual used tokens, including any overshoot.
+- The main implementation risk is lifecycle coordination across model accounting, checkpoint persistence, run finalization, and output surfaces. The implementation should keep one canonical Goal state provider and project that state outward rather than creating separate truths in CLI, TUI, JSON, and manifest code.
+- This specification is stored locally at the project root at the user's request. No external issue or tracker item is created.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ The TUI can create and manage durable schedules. Automatic firing is a separate 
 agentloom schedules --project /path/to/project serve
 ```
 
+Scheduled YAML can enable Goal Mode, but unattended Goals should set a
+`token_budget`; an omitted budget is intentionally unlimited. Budget exhaustion
+is recorded as the resumable `budget_limited` schedule status, not as an ordinary
+execution failure.
+
 ## Run an existing Agent
 
 To verify the framework without creating a new application, run the included code review example:
@@ -200,6 +205,20 @@ One run creates a receipt under `.agentloom/runs/<application_id>/<run_id>/`. Wh
 
 `run_id` identifies one attempt and changes after resume. `task_id` identifies the logical task and remains stable.
 
+For work that must continue beyond one final answer or `max_steps` segment, a
+top-level Supervisor can enable Goal Mode. Only the root Supervisor can complete
+the Goal; Worker token usage is included in the same optional soft budget:
+
+```yaml
+goal:
+  enabled: true
+  token_budget: 120000  # omit for unlimited
+```
+
+An active Goal continues on the same runtime and memory. `budget_limited` keeps
+its checkpoint and can resume after the budget is raised or removed. See
+[Goal Mode](docs/en/goal_mode.md).
+
 ## How AgentLoom works
 
 AgentLoom treats a multi-agent system as an application, not a loose collection of prompts.
@@ -209,6 +228,7 @@ AgentLoom treats a multi-agent system as an application, not a loose collection 
 | Supervisor | Decomposes the application task and coordinates Workers and tools. |
 | Worker | Owns one specialized role and exposes a typed callable contract. |
 | Agent YAML | Defines role, workflow, model type, tools, Skills, Workers, and runtime policy. |
+| Goal Mode | Keeps one Supervisor objective active across continuation segments, Worker delegation, and resume. |
 | Python runtime | Handles model routing, generated Worker tools, concurrency, logs, checkpoints, and artifacts. |
 
 This keeps orchestration reusable while leaving deterministic preprocessing, validation, caching, and output writing in normal Python code.
@@ -285,7 +305,14 @@ workflow: |
 tools: []
 skills: []
 max_steps: 12
+goal:
+  enabled: true
+  token_budget: 120000
 ```
+
+In Goal Mode a workflow list is merged and numbered into one objective context.
+With Goal disabled, a Supervisor workflow list retains its sequential multi-run
+behavior. Worker YAML must never define `goal`.
 
 Each Worker defines the contract that the Supervisor sees:
 
@@ -380,6 +407,7 @@ uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
 | Command | Purpose |
 |---|---|
 | `uv run loom run <workflow>` | Run an application. |
+| `uv run loom run <workflow> --output-format json` | Emit one versioned terminal lifecycle event. |
 | `uv run loom run <workflow> --output-format jsonl` | Stream versioned lifecycle events. |
 | `uv run loom create <workflow>` | Generate a Python entrypoint. |
 | `uv run loom list-tasks` | List resumable tasks. |
@@ -407,9 +435,10 @@ Run `uv run loom <command> --help` for the full command contract.
 | [System Configuration](docs/en/system_config.md) | Runtime, permissions, execution environments, and tools. |
 | [Skills Configuration](docs/en/skills_config.md) | Skill packages, loading, and policy. |
 | [Hooks Reference](docs/en/hooks.md) | Direct Hooks, Bundles, events, and execution. |
+| [Goal Mode](docs/en/goal_mode.md) | Supervisor-owned continuation, explicit completion, budgets, resume, schedules, CLI, and TUI. |
 | [Checkpoint Resume](docs/en/checkpoint.md) | Run evidence, checkpoint layout, and recovery. |
 | [Self-Learning v6](docs/en/self_learning.md) | History, candidates, review, approval, and promotion. |
-| [Structured Run API](docs/en/run_observability.md) | Python receipts, typed errors, event sinks, and JSONL. |
+| [Structured Run API](docs/en/run_observability.md) | Python receipts, typed errors, event sinks, JSON, and JSONL. |
 
 ## Development and support
 

--- a/agentloom-framework-skill/SKILL.md
+++ b/agentloom-framework-skill/SKILL.md
@@ -23,6 +23,10 @@ argument-hint: "<AgentLoom task or application path>"
 - 用户说“有哪些配置 / 这个配置能不能写 / skill 漏了配置 / system.yaml、llm.yaml、Agent YAML 怎么配”：先读 [`references/configuration-surface.md`](references/configuration-surface.md)，再按需要读 `docs/en/*.md` 和对应代码交叉验证。
 - 需要生成或修改 `applications/<app_name>/`：读 [`references/application-generation.md`](references/application-generation.md)。
 - 需要写 Agent YAML / Worker YAML / `agent_function_schema` / `worker_agents`：读 [`references/yaml-contract.md`](references/yaml-contract.md)。
+- 需要配置或实现 Goal Mode、长期 continuation、根 Agent 树 token 预算或
+  `budget_limited` resume：读 [`references/yaml-contract.md`](references/yaml-contract.md)
+  的 Goal 契约和 [`references/validation-and-review.md`](references/validation-and-review.md)
+  的真实 Goal 验证矩阵；用户语义以 `docs/en/goal_mode.md` 为准。
 - 需要为 Application 配置私有 Skill 或独立 Hook Bundle：读 [`references/configuration-surface.md`](references/configuration-surface.md) 的 Skills/Hook 配置，再读 [`references/application-generation.md`](references/application-generation.md) 的目录规范。
 - 需要配置或验证 shell 权限、allowlist、audit log、sandbox、路径安全、后台任务或 stall 检测：先读 [`references/shell-security-audit.md`](references/shell-security-audit.md)，再按需要读配置面和验证评审。
 - 需要验证是否真是多 Agent、是否能运行、问题怎么记录：读 [`references/validation-and-review.md`](references/validation-and-review.md)。
@@ -38,7 +42,7 @@ argument-hint: "<AgentLoom task or application path>"
 | 需求路由 | 用户只说一个功能，判断 AgentLoom 应该怎么落地 | `function-routing.md` | 实现路径、需要问的问题、应用边界 |
 | 配置面 | 判断 system/llm/Agent/Skill/Hook/MCP/checkpoint 等配置写在哪里、是否可覆盖 | `configuration-surface.md` | 配置位置、字段、覆盖层级、验证来源 |
 | Application 生成 | 新建/扩展 `applications/<app_name>` | `application-generation.md` | 目录、入口脚本、workflow、README |
-| YAML 契约 | Supervisor/Worker/Tool/Skill 配置 | `yaml-contract.md` | 合法 Agent YAML 与 Worker schema |
+| YAML 契约 | Supervisor/Worker/Goal/Tool/Skill 配置 | `yaml-contract.md` | 合法 Agent YAML、Goal 生命周期与 Worker schema |
 | 验证评审 | 结构扫描、YAML 校验、运行边界、checkpoint/resume 功能、架构风险 | `validation-and-review.md` | 验证命令、结果、问题清单 |
 | README 交付 | 给用户和后续 Agent 看的使用说明 | `readme-template.md` | 可运行说明、验证记录、已知问题 |
 

--- a/agentloom-framework-skill/references/application-generation.md
+++ b/agentloom-framework-skill/references/application-generation.md
@@ -31,6 +31,10 @@ applications/<app_name>/
 
 1. `workflows/<app_name>_agent.yaml`
 2. `workflows/worker_agents/*.yaml`
+
+如果用户要求长期自动推进目标，可在第 1 个顶层 Supervisor YAML 配置 Goal Mode。
+推荐 `goal: {enabled: true, token_budget: <正整数>}`，无人值守或 schedule 场景必须
+主动讨论预算；省略预算意味着无限 continuation。Worker YAML 一律不写 `goal`。
 3. `skills/<skill_name>/SKILL.md` 与必要资源
 4. `hooks/<hook_name>/HOOK.yaml` 与脚本（仅需要 Hook 时）
 5. `agent_tools/*.py`

--- a/agentloom-framework-skill/references/configuration-surface.md
+++ b/agentloom-framework-skill/references/configuration-surface.md
@@ -6,7 +6,7 @@
 
 配置相关改动至少交叉看这几类文件：
 
-- 用户文档：`docs/en/config-overview.md`、`agent_config.md`、`system_config.md`、`llm_config.md`、`skills_config.md`、`hooks.md`、`checkpoint.md`。
+- 用户文档：`docs/en/config-overview.md`、`agent_config.md`、`goal_mode.md`、`system_config.md`、`llm_config.md`、`skills_config.md`、`hooks.md`、`checkpoint.md`。
 - 系统配置加载：`src/lib/config/config.py`、`layered_builder.py`、`config_validation.py`。
 - LLM 配置：`src/lib/config/llm_config.py`、`src/lib/smolagents/models/model_types.py`、`model_manager.py`。
 - Agent YAML 校验：`src/lib/smolagents/agent/agent_validation.py`、`yaml_agent_factory.py`、`base_agent.py`。
@@ -59,6 +59,7 @@ workflow: |
 | `execution_env` | `dict` | `code_act` 的执行环境：`local`、`docker`、`e2b`、`wasm` |
 | `prompt` | `str` 或 `{path: ...}` | 自定义系统 prompt 模板路径 |
 | `skills` | `str` / `dict` / `list` | 当前 Agent 私有 Skill 配置 |
+| `goal` | `bool` 或 `{enabled: bool, token_budget?: int}` | 仅顶层 Supervisor；开启 continuation、显式完成和根 Agent 树软 token 预算 |
 
 `tool_call` 模式的主路径是 provider/native tool calls。只要当前 Agent 有可用工具，AgentLoom 就发送结构化 tools schema；如果 provider 返回文本 fallback，也只接受明确结构化容器，例如 `{name, arguments}`、dump 出来的 native `tool_calls/function`、XML/invoke wrapper。不要设计依赖自由文本正则兜底的 workflow。
 
@@ -70,6 +71,11 @@ worker_agents:
 ```
 
 规则：`worker_agents` item 只支持 `path`，不支持 `name`。路径可以是绝对路径、项目根相对路径、`worker_agents/` 下的文件名，或不带后缀的 worker 名。
+
+Supervisor 还可配置 `goal: true/false`，或显式 mapping。Goal mapping 不做类型宽松
+转换；`token_budget` 缺失表示无限制。开启后 workflow list 合并为一个目标上下文，
+并提供仅根 Supervisor 可见的 `get_goal` / `update_goal`。Schedule 可以使用同一 YAML，
+但无人值守 Goal 强烈建议设置预算。
 
 Worker 专属：
 
@@ -85,6 +91,8 @@ agent_function_schema:
 ```
 
 规则：`inputs` 的 key 必须是合法 Python 标识符；`required` 只能是 bool；runtime 会把所有参数类型归一为 `"string"`，不要用 `Optional[...]` 或 `Union[...]` 表达可选性。
+
+Worker YAML 如果出现任何 `goal` key 必须 fail-closed；不能用 `goal: false` 占位。
 
 ## Agent YAML 白名单覆盖
 

--- a/agentloom-framework-skill/references/readme-template.md
+++ b/agentloom-framework-skill/references/readme-template.md
@@ -42,6 +42,10 @@ applications/<app_name>/
 .venv/bin/loom run applications/<app_name>/workflows/<agent>.yaml
 ```
 
+如果 Supervisor 开启 Goal Mode，README 必须列出 `goal.enabled`、是否设置
+`token_budget`、`budget_limited` 后的 resume 命令、完成 evidence 在 manifest/audit
+中的位置。Schedule 场景必须明确警告：省略预算表示无限制。
+
 如果应用提供了自定义 Python wrapper，再补充 wrapper 用法：
 
 ```bash

--- a/agentloom-framework-skill/references/validation-and-review.md
+++ b/agentloom-framework-skill/references/validation-and-review.md
@@ -36,6 +36,7 @@ print(scan_app_structure('applications/<app_name>'))
 - `tools` 是否与 workflow 动作匹配。
 - `model_type`、`tool_call_type`、`max_steps` 是否合理。
 - Agent YAML 是否误写 LLM 参数、无效 `planning_interval`/`todo.mode`/`concurrency`、错误 `prompt`、错误 `fixed_args`、错误 `mcp_servers`。
+- Goal mapping 是否显式配置 `enabled`、预算是否为正整数、Worker 是否错误配置 Goal；Goal workflow list 是否按一个编号上下文运行。
 
 ```bash
 .venv/bin/python -m py_compile applications/<app_name>/<app_name>_app.py
@@ -114,6 +115,7 @@ export AGENTLOOM_RUNTIME_ROOT=/tmp/agentloom-runtime-checkpoint
 - 新 checkpoint 有 `task_events.jsonl`；`task_tree.json` 只是投影且能被 `loom list-tasks --detail` 展示。
 - 多 Worker 或重复 Worker 调用场景下，`workers/<worker>/calls/<call_index>/checkpoint.json` 存在，`call_index` 不互相覆盖。
 - resume 场景要实际执行 `loom run <workflow.yaml> --resume <task_id>`；若为了制造中断而提前停止，记录中断方式和恢复结果。
+- Goal 改动必须真实验证：普通 final 与 `max_steps` 后 continuation、根工具完成、Worker 工具隔离、Worker token 聚合、`budget_limited` 保留 checkpoint、提高/移除预算 resume、目标指纹拒绝、manifest/JSONL/TUI canonical Goal 对象。至少一条应是 30 分钟级复杂多 Worker Application，不能用简单问答替代。
 - Resume 后必须证明 `task_id` 不变、`run_id` 改变，新旧 attempt 分属两个 run 目录，但都关联同一个 task checkpoint；heartbeat 和 run event 使用新 `run_id`。
 - 涉及 subagent/Worker checkpoint 时，要分别验证 Supervisor 中断恢复和 Worker 半路中断恢复；Worker 恢复必须证明没有新开重复 `call_index`，且能从 per-call memory checkpoint 继续。
 - file-history 场景要检查 `file-history/snapshots.json` 和备份文件，确认早期备份没有被后续 snapshot 覆盖。

--- a/agentloom-framework-skill/references/yaml-contract.md
+++ b/agentloom-framework-skill/references/yaml-contract.md
@@ -34,6 +34,19 @@ workflow: |
 - `path` 支持绝对路径、AgentLoom 根目录相对路径、`worker_agents/` 下文件名、或不带后缀的 Worker 名；生成时推荐写完整项目相对路径。
 - Supervisor 推荐 `tool_call`，因为 Worker 调用、参数和结果可结构化审计；只有需要 Python 控制流时才用 `code_act`。
 
+长期目标可在顶层 Supervisor 配置：
+
+```yaml
+goal:
+  enabled: true
+  token_budget: 120000  # 可选；省略为无限制
+```
+
+只接受 `goal: true/false` 或显式包含 `enabled: bool` 的 mapping；mapping 仅允许
+`enabled` 与正整数 `token_budget`。Goal 模式推荐单个多行 workflow；list 会按顺序
+编号并合并为一个目标上下文。Goal 的完成、预算、resume、checkpoint 和 schedule
+语义见项目 `docs/cn/goal_mode.md`。
+
 ## Worker
 
 ```yaml
@@ -65,6 +78,7 @@ workflow: |
 - runtime 会把输入类型归一为 `string`；不要依赖复杂类型声明。
 - 输出应是可被下游 Worker 或 Supervisor 直接使用的文本。
 - `todo.mode` 支持 `auto`、`on`、`off`；默认 `auto`。它与 `planning_interval` 独立，不要在 `tools` 中重复声明 `todo_write`。
+- Worker YAML 禁止配置 `goal`，包括 `goal: false`；Goal 工具与生命周期只属于根 Supervisor。
 
 ## 模型与配置
 

--- a/agentloom-framework-skill/scripts/validate_application_yaml.py
+++ b/agentloom-framework-skill/scripts/validate_application_yaml.py
@@ -17,6 +17,12 @@ from typing import Any
 
 import yaml
 
+_FRAMEWORK_ROOT = Path(__file__).resolve().parents[2]
+if str(_FRAMEWORK_ROOT) not in sys.path:
+    sys.path.insert(0, str(_FRAMEWORK_ROOT))
+
+from src.lib.goal.model import normalize_goal_config  # noqa: E402
+
 REQUIRED_FIELDS = ("name", "description", "workflow")
 FORBIDDEN_TOP_LEVEL = {"model", "llm", "langfuse"}
 GLOBAL_ONLY_TOP_LEVEL = {"runtime", "logging"}
@@ -223,6 +229,21 @@ def _validate_common_rules(
     errors: list[dict[str, str]],
     project_root: Path,
 ) -> None:
+    try:
+        normalize_goal_config(config, source=str(file_path))
+    except ValueError as exc:
+        _add_error(
+            errors,
+            file_path=file_path,
+            field="goal",
+            rule="valid_goal_config",
+            message=str(exc),
+            suggestion=(
+                "使用 goal: true/false，或 goal: {enabled: true, "
+                "token_budget: <正整数>}；mapping 必须显式配置 enabled"
+            ),
+            project_root=project_root,
+        )
     for field in ("name", "description"):
         value = config.get(field)
         if not isinstance(value, str) or not value.strip():
@@ -1058,6 +1079,16 @@ def _validate_worker_schema(
     errors: list[dict[str, str]],
     project_root: Path,
 ) -> None:
+    if "goal" in config:
+        _add_error(
+            errors,
+            file_path=worker_file,
+            field="goal",
+            rule="supervisor_only",
+            message="Worker Agent 不允许配置 goal；Goal Mode 仅属于顶层 Supervisor",
+            suggestion="从 Worker YAML 删除 goal，并在顶层 Supervisor YAML 配置",
+            project_root=project_root,
+        )
     schema = config.get("agent_function_schema")
     if not isinstance(schema, dict):
         _add_error(

--- a/agentloom-tui/README.md
+++ b/agentloom-tui/README.md
@@ -48,6 +48,10 @@ environment. `agentloom --snapshot` is the non-interactive health check.
   workflow source files, and validation. It does not expose model credentials.
 - Recent Runs are secondary navigation. Their default detail is a compact,
   actionable summary; raw event objects and full log bodies are not dumped.
+- Goal-aware Runs expose `active`, `complete`, and `budget_limited` state in the
+  same list/detail projection. Run detail shows cumulative/remaining tokens,
+  objective, and completion evidence. While a Run is active the bridge reads
+  canonical checkpoint `goal.json`; terminal Runs use the manifest/audit copy.
 
 ## Studio Agent Loop
 

--- a/agentloom-tui/src/app/controller.ts
+++ b/agentloom-tui/src/app/controller.ts
@@ -434,6 +434,7 @@ function agentRuntimeStatusLabel(status: RuntimeStatus): string {
     never_run: "尚未运行",
     running: "运行中",
     completed: "已完成",
+    budget_limited: "预算已达上限",
     interrupted: "已中断",
     failed: "失败",
     crashed: "崩溃",

--- a/agentloom-tui/src/app/presentation.ts
+++ b/agentloom-tui/src/app/presentation.ts
@@ -598,6 +598,17 @@ export function runDetailSections(detail: RunDetailResultDto): DetailSection[] {
       ],
     },
     ...(issue ? [{ title: "关键问题", lines: [issue] }] : []),
+    ...(summary.goal ? [{
+      title: "Goal",
+      lines: [
+        `状态: ${goalStatusLabel(summary.goal.status)}`,
+        ...(summary.goal.goal_id ? [`Goal ID: ${summary.goal.goal_id}`] : []),
+        `Token: ${summary.goal.used_tokens}/${summary.goal.token_budget ?? "unlimited"}`,
+        ...(summary.goal.remaining_tokens === null ? [] : [`剩余 Token: ${summary.goal.remaining_tokens}`]),
+        ...(summary.goal.objective ? [`目标: ${previewText(summary.goal.objective, 600)}`] : []),
+        ...(summary.goal.evidence ? [`完成证据: ${previewText(summary.goal.evidence, 600)}`] : []),
+      ],
+    }] : []),
     ...(["failed", "crashed", "interrupted", "unknown"].includes(summary.status)
       ? [{
           title: "AI 分析",
@@ -618,7 +629,7 @@ export function runDetailSections(detail: RunDetailResultDto): DetailSection[] {
         ...(problemWorkers.length > 5 ? [`还有 ${problemWorkers.length - 5} 个异常 Worker`] : []),
       ],
     }] : []),
-    ...((detail.logs.length || ["failed", "crashed", "interrupted", "unknown"].includes(summary.status)) ? [{
+    ...((detail.logs.length || ["failed", "crashed", "interrupted", "unknown", "budget_limited"].includes(summary.status)) ? [{
       title: "日志文件",
       lines: [
         ...(detail.limits.logs.truncated
@@ -726,6 +737,7 @@ function primaryRunIssue(detail: RunDetailResultDto): string | null {
     .findLast((line) => Boolean(line))
   if (logIssue) return previewText(redactDiagnostic(logIssue), 400)
   if (status === "interrupted") return "运行已中断；未完成。"
+  if (status === "budget_limited") return "Goal 已达到 token_budget；提高或移除预算后可 resume。"
   if (status === "crashed") return "进程异常退出；未记录正常失败终态。"
   if (status === "failed") return "运行失败，但未记录结构化错误；请查看日志文件。"
   if (status === "unknown") return "无法从存储记录判断运行终态；请检查日志文件。"
@@ -750,6 +762,7 @@ function countWorkerStatuses(detail: RunDetailResultDto): Record<string, number>
 function workerCountLine(counts: Record<string, number>): string {
   const statuses = [
     ["completed", "成功"],
+    ["budget_limited", "预算受限"],
     ["failed", "失败"],
     ["crashed", "崩溃"],
     ["interrupted", "中断"],
@@ -759,7 +772,7 @@ function workerCountLine(counts: Record<string, number>): string {
   const parts = statuses.flatMap(([status, label]) => (
     counts[status] ? [`${counts[status]} ${label}`] : []
   ))
-  const known = ["completed", "failed", "crashed", "interrupted", "running", "unknown"]
+  const known = ["completed", "budget_limited", "failed", "crashed", "interrupted", "running", "unknown"]
     .reduce((total, status) => total + (counts[status] ?? 0), 0)
   const total = Object.values(counts).reduce((sum, count) => sum + count, 0)
   if (total > known) parts.push(`${total - known} 其他`)
@@ -770,10 +783,19 @@ function runStatusLabel(status: RunDetailResultDto["summary"]["status"]): string
   return {
     running: "运行中",
     completed: "已完成",
+    budget_limited: "预算已达上限",
     interrupted: "已中断",
     failed: "运行失败",
     crashed: "进程崩溃",
     unknown: "状态未知",
+  }[status]
+}
+
+function goalStatusLabel(status: "active" | "budget_limited" | "complete"): string {
+  return {
+    active: "进行中",
+    budget_limited: "预算已达上限",
+    complete: "已完成",
   }[status]
 }
 

--- a/agentloom-tui/src/app/view.tsx
+++ b/agentloom-tui/src/app/view.tsx
@@ -1194,7 +1194,7 @@ function WorkspaceOverview(props: {
             {props.groups.runs.length} 次 · {count("completed")} 成功 · {count("failed")} 失败
           </text>
           <text fg={props.theme.text}>
-            {count("crashed")} 崩溃 · {count("interrupted")} 中断 · {active().length} 运行中
+            {count("budget_limited")} 预算受限 · {count("crashed")} 崩溃 · {count("interrupted")} 中断 · {active().length} 运行中
           </text>
           <Show when={count("unknown") > 0}>
             <text fg={props.theme.warning}>{count("unknown")} 状态未知</text>
@@ -1284,6 +1284,7 @@ function workspaceRunStatusLabel(status: SidebarRunEntry["status"]): string {
   return {
     running: "运行中",
     completed: "成功",
+    budget_limited: "预算已达上限",
     interrupted: "已中断",
     failed: "失败",
     crashed: "崩溃",

--- a/agentloom-tui/src/cli/args.ts
+++ b/agentloom-tui/src/cli/args.ts
@@ -65,7 +65,7 @@ export function formatSnapshot(snapshot: BootstrapResultDto): string {
 function statusCounts(statuses: readonly RuntimeStatus[], includeNeverRun: boolean) {
   const counts: Record<string, number> = { total: statuses.length }
   if (includeNeverRun) counts.never_run = 0
-  for (const status of ["running", "completed", "interrupted", "failed", "crashed", "unknown"] as const) {
+  for (const status of ["running", "completed", "budget_limited", "interrupted", "failed", "crashed", "unknown"] as const) {
     counts[status] = 0
   }
   for (const status of statuses) {

--- a/agentloom-tui/src/domain/dto.ts
+++ b/agentloom-tui/src/domain/dto.ts
@@ -26,6 +26,24 @@ export interface ValidationDto {
   errors: string[]
 }
 
+export interface GoalStateDto {
+  schema_version?: number
+  goal_id?: string
+  objective?: string
+  objective_fingerprint?: string
+  status: "active" | "budget_limited" | "complete"
+  token_budget: number | null
+  prompt_tokens?: number
+  completion_tokens?: number
+  used_tokens: number
+  remaining_tokens: number | null
+  evidence?: string | null
+  goal_started?: boolean
+  created_at?: string
+  updated_at?: string
+  completed_at?: string | null
+}
+
 export interface RunSummaryDto {
   run_id: string
   system_id: string | null
@@ -35,6 +53,7 @@ export interface RunSummaryDto {
   status: RunStatus
   started_at: string | null
   ended_at: string | null
+  goal?: GoalStateDto | null
 }
 
 export interface SystemSummaryDto {

--- a/agentloom-tui/src/domain/status.ts
+++ b/agentloom-tui/src/domain/status.ts
@@ -5,6 +5,7 @@ export const runtimeStatuses = [
   "never_run",
   "running",
   "completed",
+  "budget_limited",
   "interrupted",
   "failed",
   "crashed",
@@ -22,6 +23,7 @@ const runtimeStatusAliases: Readonly<Record<string, RuntimeStatus>> = {
   succeeded: "completed",
   success: "completed",
   cached: "completed",
+  budget_limited: "budget_limited",
   interrupted: "interrupted",
   cancelled: "interrupted",
   canceled: "interrupted",
@@ -42,5 +44,5 @@ export function runtimeStatus(value: string): ObservedRuntimeStatus {
 }
 
 export function isProblemRuntimeStatus(value: string): boolean {
-  return ["interrupted", "failed", "crashed", "unknown"].includes(runtimeStatus(value))
+  return ["budget_limited", "interrupted", "failed", "crashed", "unknown"].includes(runtimeStatus(value))
 }

--- a/agentloom-tui/src/ui/status.ts
+++ b/agentloom-tui/src/ui/status.ts
@@ -4,6 +4,7 @@ export type ExecutionStatus =
   | "never_run"
   | "running"
   | "completed"
+  | "budget_limited"
   | "interrupted"
   | "failed"
   | "crashed"
@@ -23,6 +24,7 @@ const presentations = {
   crashed: { label: "Crashed", symbol: "×", tone: "error", priority: 0 },
   failed: { label: "Failed", symbol: "×", tone: "error", priority: 1 },
   interrupted: { label: "Interrupted", symbol: "■", tone: "warning", priority: 2 },
+  budget_limited: { label: "Budget limited", symbol: "!", tone: "warning", priority: 2 },
   unknown: { label: "Unknown", symbol: "?", tone: "warning", priority: 3 },
   running: { label: "Running", symbol: "●", tone: "info", priority: 4 },
   unavailable: { label: "Unavailable", symbol: "–", tone: "warning", priority: 4 },

--- a/agentloom-tui/test/app/view.test.tsx
+++ b/agentloom-tui/test/app/view.test.tsx
@@ -739,7 +739,15 @@ describe("AgentLoom TUI view", () => {
   })
 
   test("Workspace separates explicit Run outcomes instead of combining or inferring them", async () => {
-    const statuses = ["completed", "failed", "crashed", "interrupted", "running", "unknown"] as const
+    const statuses = [
+      "completed",
+      "budget_limited",
+      "failed",
+      "crashed",
+      "interrupted",
+      "running",
+      "unknown",
+    ] as const
     const runs = statuses.map((status, index) => ({
       ...clickableRun,
       run_id: `run-${status}`,
@@ -764,8 +772,9 @@ describe("AgentLoom TUI view", () => {
     await setup.renderOnce()
 
     const frame = setup.captureCharFrame()
-    expect(frame).toContain("6 次 · 1 成功 · 1 失败")
-    expect(frame).toContain("1 崩溃 · 1 中断 · 1 运行中")
+    expect(frame).toContain("7 次 · 1 成功 · 1 失败")
+    expect(frame).toContain("1 预算受限 · 1 崩溃 · 1 中断 · 1")
+    expect(frame).toContain("运行中")
     expect(frame).toContain("1 状态未知")
     expect(frame).not.toContain("failed/crashed")
   })

--- a/agentloom-tui/test/cli/args.test.ts
+++ b/agentloom-tui/test/cli/args.test.ts
@@ -78,12 +78,22 @@ describe("agentloom CLI", () => {
         never_run: 1,
         running: 0,
         completed: 0,
+        budget_limited: 0,
         interrupted: 0,
         failed: 0,
         crashed: 0,
         unknown: 0,
       },
-      runs: { total: 0, running: 0, completed: 0, interrupted: 0, failed: 0, crashed: 0, unknown: 0 },
+      runs: {
+        total: 0,
+        running: 0,
+        completed: 0,
+        budget_limited: 0,
+        interrupted: 0,
+        failed: 0,
+        crashed: 0,
+        unknown: 0,
+      },
     })
   })
 })

--- a/applications/goal_mode_validation/README.md
+++ b/applications/goal_mode_validation/README.md
@@ -1,0 +1,74 @@
+# Goal Mode Validation Application
+
+This Application exercises Goal Mode with real model and Worker calls against the
+current AgentLoom checkout. Generated reports go to ignored `outputs/`; durable
+Goal evidence lives in `.agentloom/runs` and `.agentloom/checkpoints`.
+
+## Scenarios
+
+| Workflow | Goal config | Purpose | Expected first outcome |
+|---|---|---|---|
+| `goal_unlimited_endurance_agent.yaml` | `goal: true` | 16 sequential specialist audits plus synthesis; intended 30-minute-class validation | `complete` |
+| `goal_bounded_list_agent.yaml` | mapping, 600000 tokens | workflow list merged into one context, Worker accounting, explicit completion | `complete` |
+| `goal_parallel_budget_agent.yaml` | mapping, 50000 tokens | six parallel Worker calls cross a shared soft budget | `budget_limited` |
+
+Only the endurance scenario is unlimited. The other Applications set explicit
+limits. Goal configuration appears only in Supervisor YAML; every Worker omits the
+key entirely.
+
+## Validation commands
+
+```bash
+uv run python agentloom-framework-skill/scripts/validate_application_yaml.py \
+  --app-root applications/goal_mode_validation
+
+uv run loom run \
+  applications/goal_mode_validation/workflows/goal_bounded_list_agent.yaml \
+  --output-format jsonl
+
+uv run loom run \
+  applications/goal_mode_validation/workflows/goal_parallel_budget_agent.yaml \
+  --output-format jsonl
+```
+
+The parallel run should exit `1` with `run.budget_limited`. Record its `task_id`,
+then either increase `token_budget` above `used_tokens` or remove the field and run:
+
+```bash
+uv run loom run \
+  applications/goal_mode_validation/workflows/goal_parallel_budget_agent.yaml \
+  --resume <task_id> --output-format jsonl
+```
+
+Resume must retain the same `task_id`, create a new `run_id`, avoid rerunning the
+batch, and finish with the existing cumulative usage. An unchanged exhausted
+budget must remain `budget_limited`.
+
+For the long validation:
+
+```bash
+uv run loom run \
+  applications/goal_mode_validation/workflows/goal_unlimited_endurance_agent.yaml \
+  --output-format jsonl
+```
+
+After every run inspect `manifest.json`, `audit/goal.json`, runtime log, task
+events, Worker call checkpoints, and the report under this Application's
+`outputs/`. A successful Goal must contain non-empty completion evidence; a
+budget-limited Goal must retain its task checkpoint.
+
+## Recorded real-model acceptance run
+
+The implementation was exercised against real configured models on 2026-08-05:
+
+| Scenario | Task / run evidence | Observed result |
+|---|---|---|
+| Bounded workflow list | `task_20260804T170322505383Z_ce6d1069128f` / `run_20260804T170322505417Z_2cf0cabe1e45` | `complete`; numbered workflow merged into one objective; 427317 whole-tree tokens used from a 600000 budget |
+| Parallel soft budget | `task_20260804T160413595075Z_01366ffd580c` / `run_20260804T160413595101Z_a7fadf21dc1f` | six concurrent Workers crossed 50000 tokens and produced `budget_limited` with 79190 tokens used |
+| Parallel resume | same task / `run_20260804T160808447806Z_d3e1886fb5e8` | removing the cap resumed the same Goal and completed without rerunning the durable batch |
+| Unlimited endurance | `task_20260804T171358741591Z_4e38fa57de4b` / `run_20260804T172155752890Z_cec594f24de9` | `complete` after about 29 minutes; an interrupted first attempt resumed under the same Goal; 2584069 tokens used with `token_budget: null` |
+| Goal disabled regression | `task_20260804T174338049253Z_9414de2529c9` / `run_20260804T174338049282Z_c0027ab1580d` | ordinary workflow returned `TODO_AUTO_TRIVIAL_OK`; manifest omitted the Goal payload |
+
+The generated Markdown reports and runtime directories are intentionally ignored
+artifacts. The identifiers above make the local manifests and logs discoverable
+without committing model output.

--- a/applications/goal_mode_validation/__init__.py
+++ b/applications/goal_mode_validation/__init__.py
@@ -1,0 +1,1 @@
+"""Real-LLM validation Application for AgentLoom Goal Mode."""

--- a/applications/goal_mode_validation/agent_tools/__init__.py
+++ b/applications/goal_mode_validation/agent_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic evidence tools for Goal Mode validation."""

--- a/applications/goal_mode_validation/agent_tools/report_tools.py
+++ b/applications/goal_mode_validation/agent_tools/report_tools.py
@@ -1,0 +1,358 @@
+"""Persist and verify real-LLM Goal Mode validation evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+_APP_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _APP_ROOT.parents[1]
+_OUTPUT_ROOT = _APP_ROOT / "outputs"
+_SAFE_NAME = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_AUDIT_WORKERS = {
+    "contract": "contract_auditor.yaml",
+    "lifecycle": "lifecycle_adversary.yaml",
+    "observability": "observability_auditor.yaml",
+    "documentation": "documentation_auditor.yaml",
+}
+_EVIDENCE_FILES = {
+    "contract": (
+        "src/lib/goal/model.py",
+        "src/lib/goal/provider.py",
+        "src/lib/smolagents/agent/runtime_validation.py",
+        "src/lib/smolagents/agent/yaml_agent_factory.py",
+        "tests/goal_test/test_goal_config.py",
+        "tests/goal_test/test_goal_state.py",
+        "tests/agent_test/llm_cfg_test/test_supervisor_task_spec_format.py",
+        "tests/agent_test/runtime_builder_test/test_runtime_builder.py",
+    ),
+    "lifecycle": (
+        "src/lib/goal/model.py",
+        "src/lib/goal/provider.py",
+        "src/lib/smolagents/agent/base_agent.py",
+        "src/lib/checkpoint/checkpoint_manager.py",
+        "src/lib/checkpoint/coordinator.py",
+        "src/runner.py",
+        "tests/goal_test/test_goal_model_accounting.py",
+        "tests/agent_test/runtime_builder_test/test_runtime_builder.py",
+    ),
+    "observability": (
+        "src/application_run.py",
+        "src/runner.py",
+        "src/schedules/runner.py",
+        "src/schedules/store.py",
+        "src/tui_bridge/bridge.py",
+        "src/tui_bridge/domain_cli.py",
+        "agentloom-tui/src/app/presentation.ts",
+        "agentloom-tui/src/domain/status.ts",
+        "tests/schedules_test/test_schedule_runner_cli.py",
+        "tests/tui_bridge_test/test_runtime_summary.py",
+        "agentloom-tui/test/app/view.test.tsx",
+    ),
+    "documentation": (
+        "README.md",
+        "docs/cn/goal_mode.md",
+        "docs/en/goal_mode.md",
+        "docs/cn/agent_config.md",
+        "docs/en/agent_config.md",
+        "docs/cn/checkpoint.md",
+        "docs/en/checkpoint.md",
+        "agentloom-framework-skill/references/yaml-contract.md",
+        "agentloom-framework-skill/references/validation-and-review.md",
+    ),
+}
+_EVIDENCE_PATTERN = re.compile(
+    r"goal|budget_limited|token_budget|workflow|continu|resume|checkpoint|"
+    r"supervisor|worker|manifest|schedule|tui|jsonl|目标|预算|恢复",
+    re.IGNORECASE,
+)
+_EVIDENCE_LINES_PER_FILE = 4
+
+
+def _evenly_sample(values: list[int], limit: int) -> list[int]:
+    if len(values) <= limit:
+        return values
+    return [values[index * (len(values) - 1) // (limit - 1)] for index in range(limit)]
+
+
+def load_goal_audit_evidence(topic: str) -> str:
+    """Load a bounded, line-numbered evidence bundle for one audit topic.
+
+    Args:
+        topic: One of contract, lifecycle, observability, or documentation.
+    """
+
+    files = _EVIDENCE_FILES.get(topic)
+    if files is None:
+        raise ValueError(
+            "topic must be contract, lifecycle, observability, or documentation"
+        )
+    records: list[dict[str, object]] = []
+    for relative in files:
+        path = _REPO_ROOT / relative
+        content = path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        selected: set[int] = set()
+        for index, line in enumerate(lines):
+            if _EVIDENCE_PATTERN.search(line):
+                selected.add(index)
+        ordered = _evenly_sample(sorted(selected), _EVIDENCE_LINES_PER_FILE)
+        excerpts = [f"{index + 1}: {lines[index]}" for index in ordered]
+        records.append(
+            {
+                "path": relative,
+                "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+                "excerpts": excerpts,
+                "truncated": len(selected) > len(ordered),
+            }
+        )
+    return json.dumps(
+        {"topic": topic, "repository_root": str(_REPO_ROOT), "files": records},
+        ensure_ascii=False,
+    )
+
+
+def run_goal_audit_batch(
+    worker_name: str,
+    tasks_json: str,
+    concurrency: int = 1,
+) -> str:
+    """Run a validated real-LLM audit batch through AgentLoom's parallel API.
+
+    Args:
+        worker_name: One of contract, lifecycle, observability, or documentation.
+        tasks_json: JSON array of objects containing unique task_id and query strings.
+        concurrency: Positive Worker concurrency for this batch.
+    """
+
+    filename = _AUDIT_WORKERS.get(worker_name)
+    if filename is None:
+        raise ValueError(f"unsupported audit worker: {worker_name}")
+    if (
+        isinstance(concurrency, bool)
+        or not isinstance(concurrency, int)
+        or not 1 <= concurrency <= 10
+    ):
+        raise ValueError("concurrency must be an integer from 1 through 10")
+    tasks = json.loads(tasks_json)
+    if not isinstance(tasks, list) or not tasks or len(tasks) > 20:
+        raise ValueError("tasks_json must contain 1 through 20 tasks")
+    task_ids: set[str] = set()
+    normalized: list[dict[str, str]] = []
+    for task in tasks:
+        if not isinstance(task, dict) or set(task) != {"task_id", "query"}:
+            raise ValueError("each audit task must contain only task_id and query")
+        task_id = task["task_id"]
+        query = task["query"]
+        if (
+            not isinstance(task_id, str)
+            or not _SAFE_NAME.fullmatch(task_id)
+            or task_id in task_ids
+            or not isinstance(query, str)
+            or not 20 <= len(query.strip()) <= 8000
+        ):
+            raise ValueError("audit task_id/query is invalid or duplicated")
+        task_ids.add(task_id)
+        evidence = load_goal_audit_evidence(worker_name)
+        normalized.append(
+            {
+                "task_id": task_id,
+                "query": (
+                    f"{query.strip()}\n\n"
+                    "Use only the following read-only, line-numbered evidence bundle. "
+                    "Do not call tools or inspect other files.\n"
+                    f"EVIDENCE_BUNDLE={evidence}"
+                ),
+            }
+        )
+
+    from src.lib.smolagents.agent.yaml_agent_factory import YamlAgentFactory
+
+    worker_path = _APP_ROOT / "workflows" / "worker_agents" / filename
+    results = YamlAgentFactory.run_agents_parallel(
+        worker_path,
+        normalized,
+        max_workers=concurrency,
+    )
+    return json.dumps(
+        [
+            {
+                "task_id": result.task_id,
+                "status": result.status,
+                "duration_seconds": round(result.duration_seconds, 3),
+                "result": result.result,
+                "error": result.error,
+            }
+            for result in results
+        ],
+        ensure_ascii=False,
+    )
+
+
+def run_parallel_goal_budget_probe(tasks_json: str, concurrency: int = 6) -> str:
+    """Run parallel contract Workers, persist evidence, then enforce the Goal fence.
+
+    Args:
+        tasks_json: JSON array of contract-audit task objects.
+        concurrency: Positive Worker concurrency for this batch.
+    """
+
+    from src.lib.goal import get_current_goal_provider
+
+    provider = get_current_goal_provider(required=True)
+    existing = json.loads(inspect_parallel_goal_budget_report())
+    if existing["matches_current_goal"]:
+        return json.dumps(
+            {
+                "status": "existing_report",
+                "batch_rerun": False,
+                "report": existing,
+                "goal": provider.snapshot().to_dict(),
+            },
+            ensure_ascii=False,
+        )
+
+    batch_json = run_goal_audit_batch(
+        "contract",
+        tasks_json,
+        concurrency,
+    )
+    results = json.loads(batch_json)
+    lines = [
+        "# Parallel Goal Budget",
+        "",
+        "## Batch Results",
+        "",
+    ]
+    for result in results:
+        lines.extend(
+            [
+                f"- **{result['task_id']}**: status={result['status']}, "
+                f"duration_seconds={result['duration_seconds']}",
+                f"  Result: {result.get('result') or result.get('error') or 'none'}",
+                "",
+            ]
+        )
+    state = provider.snapshot()
+    lines.extend(
+        [
+            "## Accounting",
+            "",
+            f"goal_id={state.goal_id}",
+            f"used_tokens={state.used_tokens}",
+            f"token_budget={state.token_budget}",
+            f"status={state.status}",
+            "",
+            "## Resume Instructions",
+            "",
+            "Increase or remove token_budget, resume the same task_id, verify this report, and complete the Goal without rerunning the batch.",
+        ]
+    )
+    persisted = persist_goal_validation_report(
+        "parallel_budget",
+        "\n".join(lines),
+    )
+    # This is intentionally after the durable report write. If the shared
+    # Worker tree crossed the soft limit, raise before model code can claim
+    # completion in the same in-flight Supervisor response.
+    provider.assert_request_allowed()
+    return json.dumps(
+        {
+            "status": "within_budget",
+            "batch": results,
+            "report": json.loads(persisted),
+            "goal": provider.snapshot().to_dict(),
+        },
+        ensure_ascii=False,
+    )
+
+
+def inspect_parallel_goal_budget_report() -> str:
+    """Report whether persisted parallel evidence belongs to the current Goal."""
+
+    from src.lib.goal import get_current_goal_provider
+
+    state = get_current_goal_provider(required=True).snapshot()
+    target = _OUTPUT_ROOT / "parallel_budget.md"
+    required = [
+        "# Parallel Goal Budget",
+        "## Batch Results",
+        "## Accounting",
+        "## Resume Instructions",
+        f"goal_id={state.goal_id}",
+    ]
+    try:
+        content = target.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        content = ""
+    missing = [marker for marker in required if marker not in content]
+    return json.dumps(
+        {
+            "matches_current_goal": not missing,
+            "goal_id": state.goal_id,
+            "path": str(target),
+            "missing_markers": missing,
+        },
+        ensure_ascii=False,
+    )
+
+
+def persist_goal_validation_report(run_name: str, report: str) -> str:
+    """Atomically persist one bounded Goal validation report.
+
+    Args:
+        run_name: Stable lowercase validation scenario name.
+        report: Markdown or JSON evidence produced by the audit workers.
+    """
+
+    if not _SAFE_NAME.fullmatch(run_name):
+        raise ValueError("run_name must be a safe lowercase identifier")
+    report = str(report).strip()
+    if len(report) < 80:
+        raise ValueError("validation report is too short to be evidence")
+    _OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+    target = _OUTPUT_ROOT / f"{run_name}.md"
+    temporary = _OUTPUT_ROOT / f".{run_name}.tmp"
+    temporary.write_text(report + "\n", encoding="utf-8")
+    temporary.replace(target)
+    return json.dumps(
+        {
+            "status": "persisted",
+            "path": str(target),
+            "chars": len(report),
+        },
+        ensure_ascii=False,
+    )
+
+
+def verify_goal_validation_report(run_name: str, required_markers: str) -> str:
+    """Verify that one persisted report contains every requested marker.
+
+    Args:
+        run_name: Stable lowercase validation scenario name.
+        required_markers: JSON array of non-empty marker strings.
+    """
+
+    if not _SAFE_NAME.fullmatch(run_name):
+        raise ValueError("run_name must be a safe lowercase identifier")
+    markers = json.loads(required_markers)
+    if not isinstance(markers, list) or not markers or not all(
+        isinstance(marker, str) and marker.strip() for marker in markers
+    ):
+        raise ValueError("required_markers must be a non-empty JSON string array")
+    target = _OUTPUT_ROOT / f"{run_name}.md"
+    content = target.read_text(encoding="utf-8")
+    missing = [marker for marker in markers if marker not in content]
+    if missing:
+        raise ValueError(f"validation report is missing markers: {missing}")
+    return json.dumps(
+        {
+            "status": "verified",
+            "path": str(target),
+            "chars": len(content),
+            "markers": markers,
+        },
+        ensure_ascii=False,
+    )

--- a/applications/goal_mode_validation/workflows/goal_bounded_list_agent.yaml
+++ b/applications/goal_mode_validation/workflows/goal_bounded_list_agent.yaml
@@ -1,0 +1,35 @@
+name: "goal_bounded_list_agent"
+description: "Validate bounded Goal completion and Goal-mode workflow-list merging."
+model_type: "powerful"
+tool_call_type: "code_act"
+max_steps: 20
+goal:
+  enabled: true
+  token_budget: 600000
+
+workflow:
+  - "Call run_goal_audit_batch for worker_name=contract, concurrency=1, and one task config_contract covering strict config, stable goal_id, and numbered list semantics; retain its completed result."
+  - "Call run_goal_audit_batch for worker_name=lifecycle, concurrency=1, and one task lifecycle_contract covering normal-final continuation, max_steps continuation, explicit completion, and resume budget invariants; retain its completed result."
+  - "Call run_goal_audit_batch for worker_name=observability, concurrency=1, and one task observability_contract covering manifest, JSONL, schedule budget_limited, TUI, and disabled-mode zero-impact agreement; retain its completed result."
+  - "Send the three results to goal_evidence_synthesizer, persist them as run_name bounded_list, and verify markers [\"# Goal Mode Validation\", \"## Configuration Contract\", \"## Verdict\"]."
+  - "Call get_goal, verify the configured budget is 600000 and usage includes Worker calls, then call update_goal(status=\"complete\", evidence=<report path and verification result>). Do not treat final_answer or Todo as completion."
+
+tools:
+  - name: "run_goal_audit_batch"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "run_goal_audit_batch"
+  - name: "persist_goal_validation_report"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "persist_goal_validation_report"
+  - name: "verify_goal_validation_report"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "verify_goal_validation_report"
+
+worker_agents:
+  - path: "applications/goal_mode_validation/workflows/worker_agents/evidence_synthesizer.yaml"
+
+skills: []
+execution_env:
+  type: "local"
+  executor_kwargs:
+    timeout_seconds: 1200

--- a/applications/goal_mode_validation/workflows/goal_parallel_budget_agent.yaml
+++ b/applications/goal_mode_validation/workflows/goal_parallel_budget_agent.yaml
@@ -1,0 +1,57 @@
+name: "goal_parallel_budget_agent"
+description: "Exercise shared soft-budget accounting across parallel Worker responses and resume."
+model_type: "powerful"
+tool_call_type: "code_act"
+max_steps: 16
+goal:
+  enabled: true
+  token_budget: 50000
+
+workflow: |
+  # Parallel soft-budget and resume validation
+
+  In one Python block call get_goal and inspect_parallel_goal_budget_report. Trust
+  the report only when the tool returns matches_current_goal=true; it checks all
+  four required headings and the exact current goal_id. A same-named report from
+  another Goal must be ignored. If no matching report exists, immediately call
+  run_parallel_goal_budget_probe with six distinct deep audit queries serialized
+  as JSON and concurrency=6. Each task must have task_id and
+  query. The queries must cover
+  config, state, continuation, accounting, resume, and tool permissions. Collect
+  The probe persists completed/failed status, durations, and result/error text into
+  a Markdown report with headings `# Parallel Goal Budget`, `## Batch Results`,
+  `## Accounting`, and `## Resume Instructions`, then enforces the shared Goal
+  request fence. Do not catch or replace a budget exception and do not call
+  update_goal during the bounded attempt. The host must classify the crossed
+  shared budget as budget_limited and preserve the checkpoint.
+
+  On resume after token_budget is increased or removed, do not rerun the batch.
+  Verify all four headings plus the exact current goal_id marker in the existing
+  parallel_budget report, call get_goal to confirm cumulative usage was retained
+  and the Goal is active, then call update_goal with complete status and evidence
+  naming the persisted report and retained usage.
+
+tools:
+  - name: "inspect_parallel_goal_budget_report"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "inspect_parallel_goal_budget_report"
+  - name: "run_parallel_goal_budget_probe"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "run_parallel_goal_budget_probe"
+  - name: "run_goal_audit_batch"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "run_goal_audit_batch"
+  - name: "persist_goal_validation_report"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "persist_goal_validation_report"
+  - name: "verify_goal_validation_report"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "verify_goal_validation_report"
+
+worker_agents: []
+
+skills: []
+execution_env:
+  type: "local"
+  executor_kwargs:
+    timeout_seconds: 1200

--- a/applications/goal_mode_validation/workflows/goal_unlimited_endurance_agent.yaml
+++ b/applications/goal_mode_validation/workflows/goal_unlimited_endurance_agent.yaml
@@ -1,0 +1,61 @@
+name: "goal_unlimited_endurance_agent"
+description: |
+  Run a deep, read-only, multi-Worker acceptance audit of the AgentLoom Goal Mode
+  implementation and persist a reproducible evidence report.
+model_type: "powerful"
+tool_call_type: "code_act"
+max_steps: 30
+goal: true
+
+workflow: |
+  # Unlimited endurance validation
+
+  This is the intentionally long real-LLM validation path. Execute all work; do
+  not replace Worker calls with your own guesses. It is designed to make 16 deep
+  specialist calls sequentially plus one synthesis call and may run around 30
+  minutes. All review is read-only except the report tool under this Application's
+  ignored outputs directory.
+
+  In Python, call run_goal_audit_batch once for each specialist with four tasks,
+  concurrency=1, and a JSON array where every task object contains only task_id
+  and query.
+
+  1. goal_contract_auditor: audit strict YAML/Worker rejection; objective and list
+     normalization; Goal state schema/identity; offline/runtime validator parity.
+  2. goal_lifecycle_adversary: audit premature final/max_steps; soft boundary and
+     parallel overshoot; budget increase/removal; completion-commit crash recovery.
+  3. goal_observability_auditor: audit Python/manifest; CLI/JSONL; schedule status;
+     TUI bridge/TypeScript presentation.
+  4. goal_documentation_auditor: audit root docs; cn/en Goal docs; config/checkpoint
+     docs; framework-skill contract and validation guidance.
+
+  Each query must name its acceptance criterion and the relevant paths under src/,
+  tests/, docs/, agentloom-tui/, and agentloom-framework-skill/. Collect every
+  TaskResult. Fail if any status is not completed. Send a JSON representation of
+  all results to goal_evidence_synthesizer. Persist its Markdown using
+  persist_goal_validation_report(run_name="unlimited_endurance", report=...).
+  Verify markers ["# Goal Mode Validation", "## Lifecycle and Resume",
+  "## Token Accounting", "## Observability", "## Verdict"]. Call get_goal and
+  confirm it is still active and unlimited. Finally call
+  update_goal(status="complete", evidence=<paths, worker count, and verification>)
+  exactly once. Todo or a normal final answer is not completion.
+
+tools:
+  - name: "run_goal_audit_batch"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "run_goal_audit_batch"
+  - name: "persist_goal_validation_report"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "persist_goal_validation_report"
+  - name: "verify_goal_validation_report"
+    module: "applications.goal_mode_validation.agent_tools.report_tools"
+    function: "verify_goal_validation_report"
+
+worker_agents:
+  - path: "applications/goal_mode_validation/workflows/worker_agents/evidence_synthesizer.yaml"
+
+skills: []
+execution_env:
+  type: "local"
+  executor_kwargs:
+    timeout_seconds: 2400

--- a/applications/goal_mode_validation/workflows/worker_agents/contract_auditor.yaml
+++ b/applications/goal_mode_validation/workflows/worker_agents/contract_auditor.yaml
@@ -1,0 +1,32 @@
+name: "goal_contract_auditor"
+description: "Audit one Goal Mode configuration or state-contract slice against code and tests."
+model_type: "summary"
+tool_call_type: "tool_call"
+max_steps: 2
+concurrency: 1
+
+workflow: |
+  Inspect the requested AgentLoom Goal Mode contract slice using only the
+  EVIDENCE_BUNDLE embedded in the query, then return a concise evidence record with
+  these exact headings: CONTRACT, EVIDENCE, TESTS, RISKS, VERDICT. Cite concrete
+  repository paths and symbols. Do not edit files. Do not infer a pass when the
+  implementation or test evidence is absent. Keep the response under 1800 words.
+  Do not call tools or request more evidence. The specification alone is not
+  implementation evidence. Your first model response must be the final verdict.
+
+agent_function_schema:
+  description: "Audit one Goal Mode configuration or persisted-state contract slice."
+  inputs:
+    task_id:
+      description: "Stable audit case identifier used by the batch ledger."
+      required: true
+    query:
+      description: "Audit lens, acceptance criteria, and exact repository paths."
+      required: true
+  output:
+    description: "Evidence-backed contract verdict with cited code and tests."
+
+tools: []
+
+skills: []
+worker_agents: []

--- a/applications/goal_mode_validation/workflows/worker_agents/documentation_auditor.yaml
+++ b/applications/goal_mode_validation/workflows/worker_agents/documentation_auditor.yaml
@@ -1,0 +1,33 @@
+name: "goal_documentation_auditor"
+description: "Audit Goal Mode documentation and examples against executable contracts."
+model_type: "summary"
+tool_call_type: "tool_call"
+max_steps: 2
+concurrency: 1
+
+workflow: |
+  Use only the EVIDENCE_BUNDLE embedded in the query. Compare the requested Goal
+  documentation slice with code and validator truth.
+  Check YAML forms, Supervisor-only ownership, list semantics, budgets, resume,
+  schedules, CLI/TUI, and zero-impact claims as applicable. Return exact headings:
+  DOCUMENTS, CODE_TRUTH, EXAMPLES, DRIFT, VERDICT. Cite paths and quote only short
+  field names or commands. Do not edit files. Keep the response under 1600 words.
+  Do not call any other tool or request more evidence. Your second model response
+  must be the final verdict. Do not call tools; your first response is final.
+
+agent_function_schema:
+  description: "Audit one Goal documentation slice against current code truth."
+  inputs:
+    task_id:
+      description: "Stable audit case identifier used by the batch ledger."
+      required: true
+    query:
+      description: "Documentation topic, expected claims, and repository paths."
+      required: true
+  output:
+    description: "Documentation consistency verdict and exact drift list."
+
+tools: []
+
+skills: []
+worker_agents: []

--- a/applications/goal_mode_validation/workflows/worker_agents/evidence_synthesizer.yaml
+++ b/applications/goal_mode_validation/workflows/worker_agents/evidence_synthesizer.yaml
@@ -1,0 +1,26 @@
+name: "goal_evidence_synthesizer"
+description: "Synthesize multiple Goal audits into one bounded acceptance report."
+model_type: "summary"
+tool_call_type: "tool_call"
+max_steps: 8
+
+workflow: |
+  Synthesize the supplied worker evidence without inventing missing facts. Produce
+  Markdown with these exact headings: # Goal Mode Validation, ## Scope,
+  ## Configuration Contract, ## Lifecycle and Resume, ## Token Accounting,
+  ## Observability, ## Documentation, ## Risks, ## Verdict. Preserve cited paths.
+  State PASS only when every supplied audit verdict is supported; otherwise state
+  PARTIAL or FAIL and enumerate the blockers. Keep the report under 6000 words.
+
+agent_function_schema:
+  description: "Combine Goal Mode audit evidence into a final acceptance report."
+  inputs:
+    query:
+      description: "JSON or text containing all worker evidence records."
+      required: true
+  output:
+    description: "One bounded Markdown Goal Mode validation report."
+
+tools: []
+skills: []
+worker_agents: []

--- a/applications/goal_mode_validation/workflows/worker_agents/lifecycle_adversary.yaml
+++ b/applications/goal_mode_validation/workflows/worker_agents/lifecycle_adversary.yaml
@@ -1,0 +1,32 @@
+name: "goal_lifecycle_adversary"
+description: "Adversarially audit Goal continuation, budget, completion, and resume semantics."
+model_type: "summary"
+tool_call_type: "tool_call"
+max_steps: 2
+concurrency: 1
+
+workflow: |
+  Act as a failure-injection reviewer. Use only the EVIDENCE_BUNDLE embedded in
+  the query, then trace the requested transition through public runner behavior, Base Agent,
+  checkpoint state, and tests. Return exact headings: SCENARIO, TRANSITIONS,
+  DURABILITY, FAILURE_INJECTION, TEST_EVIDENCE, VERDICT. Cite paths and symbols.
+  Identify root causes, not speculative patches. Do not modify files. Keep the
+  response under 2000 words. Do not call tools or request more evidence.
+  Your first model response must be the final verdict.
+
+agent_function_schema:
+  description: "Audit one adversarial Goal lifecycle and recovery scenario."
+  inputs:
+    task_id:
+      description: "Stable audit case identifier used by the batch ledger."
+      required: true
+    query:
+      description: "Failure scenario, required invariants, and repository paths."
+      required: true
+  output:
+    description: "Traceable lifecycle verdict and any uncovered failure modes."
+
+tools: []
+
+skills: []
+worker_agents: []

--- a/applications/goal_mode_validation/workflows/worker_agents/observability_auditor.yaml
+++ b/applications/goal_mode_validation/workflows/worker_agents/observability_auditor.yaml
@@ -1,0 +1,32 @@
+name: "goal_observability_auditor"
+description: "Audit agreement across Python API, CLI, JSONL, schedule, bridge, and TUI."
+model_type: "summary"
+tool_call_type: "tool_call"
+max_steps: 2
+concurrency: 1
+
+workflow: |
+  Use only the EVIDENCE_BUNDLE embedded in the query. Audit one Goal observability
+  surface end to end. Compare canonical state fields,
+  statuses, errors, artifacts, and resume identity across the supplied Python and
+  TypeScript paths. Return exact headings: SURFACE, PRODUCER, TRANSPORT, CONSUMER,
+  TEST_EVIDENCE, DRIFT, VERDICT. Cite concrete paths/symbols. Do not modify files.
+  Keep the response under 1800 words. Do not call any other tool or request more
+  evidence. Do not call tools. Your first model response must be the final verdict.
+
+agent_function_schema:
+  description: "Audit one cross-surface Goal observability contract."
+  inputs:
+    task_id:
+      description: "Stable audit case identifier used by the batch ledger."
+      required: true
+    query:
+      description: "Surface boundary, invariants, and repository paths."
+      required: true
+  output:
+    description: "Cross-surface observability verdict with drift analysis."
+
+tools: []
+
+skills: []
+worker_agents: []

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -85,6 +85,24 @@ model:
 ```
 
 这份文件是 Studio 与 Application Agent 唯一共享的模型配置源。
+
+## Goal Mode
+
+顶层 Supervisor 可以通过 `goal: true` 或
+`goal: {enabled: true, token_budget: 120000}` 开启长期目标模式。它会在普通 final
+或 `max_steps` 后继续使用同一 runtime 和记忆，Worker 用量计入同一预算，并且只有
+根 Supervisor 的 `update_goal(complete, evidence)` 能完成。预算耗尽时 run 进入
+`budget_limited`，提高或移除预算后用同一个 `task_id` resume。完整的配置、状态、
+checkpoint、CLI/JSONL/TUI 和调度说明见 [Goal Mode](goal_mode.md)。
+
+文档导航：
+
+- [配置体系总览](config-overview.md)：配置层级、overlay 与运行时目录；
+- [Agent YAML](agent_config.md)：Supervisor/Worker 的全部字段与严格校验；
+- [Goal Mode](goal_mode.md)：continuation、显式完成、预算、resume 与可观测性；
+- [Checkpoint](checkpoint.md)：task/run 身份、持久化布局和恢复；
+- [Run 可观测性](run_observability.md)：Python receipt、typed outcome 与 JSONL；
+- [系统配置](system_config.md)、[模型配置](llm_config.md)、[Skills](skills_config.md)、[Hooks](hooks.md) 和 [自学习](self_learning.md)。
 Application Agent 由 Python Runtime 按 YAML `model_type` 解析；TypeScript
 Studio 适配器把同一批 Profile、端点、凭证和兼容请求参数安全映射给内置
 Studio Runtime。`/models` 或 `Ctrl+X` 只切换当前 Studio Session 使用的
@@ -370,6 +388,7 @@ uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
 | 命令 | 用途 |
 |---|---|
 | `uv run loom run <workflow>` | 运行应用。 |
+| `uv run loom run <workflow> --output-format json` | 输出一个带版本的终态生命周期事件。 |
 | `uv run loom run <workflow> --output-format jsonl` | 输出带版本的生命周期事件流。 |
 | `uv run loom create <workflow>` | 生成 Python 入口。 |
 | `uv run loom list-tasks` | 列出可恢复任务。 |
@@ -397,9 +416,10 @@ uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
 | [系统配置](system_config.md) | Runtime、权限、执行环境和工具。 |
 | [Skill 配置](skills_config.md) | Skill 包、加载方式和策略。 |
 | [Hook 参考](hooks.md) | 直接 Hook、Bundle、事件和执行方式。 |
+| [Goal Mode](goal_mode.md) | Supervisor continuation、显式完成、预算、resume、调度、CLI 与 TUI。 |
 | [Checkpoint 恢复](checkpoint.md) | Run 证据、checkpoint 布局和恢复。 |
 | [Self-learning v6](self_learning.md) | History、candidate、review、审批和 promotion。 |
-| [结构化 Run API](run_observability.md) | Python receipt、typed error、event sink 和 JSONL。 |
+| [结构化 Run API](run_observability.md) | Python receipt、typed error、event sink、JSON 和 JSONL。 |
 
 ## 开发与支持
 

--- a/docs/cn/agent_config.md
+++ b/docs/cn/agent_config.md
@@ -192,6 +192,25 @@ workflow:
     基于上一轮记忆继续执行，并输出最终结果。
 ```
 
+#### Goal Mode（仅 Supervisor）
+
+```yaml
+goal:
+  enabled: true
+  token_budget: 120000  # 可选；省略即无限制
+```
+
+也可使用 `goal: true` / `goal: false`。Mapping 必须显式包含布尔 `enabled`，只允许
+可选正整数 `token_budget`，未知字段或宽松类型会直接失败。Worker YAML 不允许出现
+任何 `goal` key。
+
+Goal 开启时，objective 由 `description + workflow + runtime task` 生成。推荐单个
+多行 workflow；如果配置 list，框架会按原顺序编号并合并成一个初始目标上下文，
+不会采用上面普通模式的逐项多 run 语义。普通 final 与 `max_steps` 只结束一个
+continuation segment；根 Supervisor 必须调用 `update_goal(complete, evidence)` 才会
+完成。Worker 模型用量计入同一可选软预算。配置、状态、恢复和可观测性详见
+[Goal Mode](goal_mode.md)。
+
 #### Workflow 书写规范与建议
 
 `workflow` 是 Agent 最核心的配置——它本质上是发送给 LLM 的**任务指令（Prompt）**。一个结构清晰的 workflow 能显著提升 Agent 的执行质量。
@@ -1778,6 +1797,7 @@ rg 'SECURITY_BLOCK|WHITELIST_REJECT|PATH_VIOLATION' "$run_dir/audit/shell.jsonl"
 | `name` | ✅ | ✅ | ✅ | `str` | — |
 | `description` | ✅ | ✅ | ✅ | `str` | — |
 | `workflow` | ✅ | ✅ | ✅ | `str`/`list[str]` | — |
+| `goal` | ❌ | ✅ | ❌ | `bool`/`dict` | `false` |
 | `tools` | ❌ | ✅ | ✅ | `list[dict]` | `[]` |
 | `model_type` | ❌ | ✅ | ✅ | `str` | `config/llm.yaml` 中的 `model.default_model_type`；无隐式默认值 |
 | `tool_call_type` | ❌ | ✅ | ✅ | `str` | `"code_act"` |

--- a/docs/cn/checkpoint.md
+++ b/docs/cn/checkpoint.md
@@ -24,7 +24,8 @@ AgentLoom 将“一次执行尝试”和“需要恢复的逻辑任务”分开�
 │   │   ├── shell.jsonl
 │   │   ├── shell.jsonl.1 ... shell.jsonl.2
 │   │   ├── task_tree.json
-│   │   └── task_events.jsonl
+│   │   ├── task_events.jsonl
+│   │   └── goal.json            # Goal Mode 运行证据（存在时）
 │   └── artifacts/
 │       ├── result.txt
 │       ├── shell/
@@ -37,6 +38,8 @@ AgentLoom 将“一次执行尝试”和“需要恢复的逻辑任务”分开�
 │   ├── heartbeat.json
 │   ├── todos.json
 │   ├── todos.lock
+│   ├── goal.json                # canonical Goal 状态（存在时）
+│   ├── goal.lock
 │   ├── workers/<worker_name>/
 │   │   ├── calls/<call_index>/checkpoint.json
 │   │   └── heartbeat.json
@@ -57,6 +60,7 @@ AgentLoom 将“一次执行尝试”和“需要恢复的逻辑任务”分开�
 - Checkpoint 直接按 `<application_id>/<task_id>` 定位，不依赖日志目录、`.task_index.json` 或历史 run 扫描。
 - 用户交付物仍由 Application 的 `output_dir` 管理，runtime 清理不会遍历 Application output 目录。
 - Agent 的持久 recall 使用 `.agentloom/workspaces/agents/<application_id>/<agent_path>/` 下、归 Application 所有的 `insights.md`。当前任务的 Todo 在启用 checkpoint 时随 `<application_id>/<task_id>/todos.json` 共同恢复和清理；未启用 checkpoint 时只保存在本次 run 的内存中。它既不是 run artifact，也不承担长期项目管理。
+- Goal Mode 使用 task-scoped `goal.json` 保存 objective 指纹、`goal_started`、状态、累计 token、预算和 evidence。`active`、`budget_limited`、`interrupted`、`failed`、`crashed` 都保留 checkpoint；只有显式完成后才进入现有成功清理流程。清理前状态会复制到 run manifest 和 `audit/goal.json`。
 
 ## 配置
 
@@ -100,6 +104,11 @@ loom run applications/<app>/workflows/<agent>.yaml --no-file-log
 # 新执行 attempt + 原逻辑任务/checkpoint
 loom run applications/<app>/workflows/<agent>.yaml --resume task_xxx
 ```
+
+Goal resume 额外校验 description、规范化 workflow 和原 runtime task 的指纹。
+`budget_limited` 可以恢复，但必须提高 `token_budget` 到累计用量之上，或移除预算；
+累计用量不会清零。活动 Goal 对应 YAML 改为禁用、目标内容改变或预算降低都会拒绝
+恢复。详见 [Goal Mode](goal_mode.md)。
 
 CLI 不再提供 `--log-to-file`。默认是否写文件由 `logging.file_enabled` 决定，`--no-file-log` 是单次运行的关闭开关。
 

--- a/docs/cn/config-overview.md
+++ b/docs/cn/config-overview.md
@@ -10,7 +10,7 @@ AgentLoom 的配置主要分为三大类，分别存放在不同的配置文件�
 |----------|----------|------------|
 | `system.yaml` | `config/system.yaml` | **全局系统配置**。控制执行环境、工具列表、工作区路径、代码执行权限等系统级行为。 |
 | `llm.yaml` | `config/llm.yaml` | **全局模型配置**。独立管理所有 LLM 模型的参数（`api_key`、`base_url`、温度、超时、重试策略等）以及 Langfuse 观测配置。 |
-| `agent_xxx.yaml` | `applications/<app>/workflows/*.yaml` | **Agent 配置**。定义单个智能体的角色、工作流（Workflow）、所用工具、模型类型（`model_type`）等；Worker Agent 还可通过 `concurrency` 字段支持批量并发调用（详见 [Agent 配置文档 3.11 节](agent_config.md#311-concurrency--并发度配置)）。 |
+| `agent_xxx.yaml` | `applications/<app>/workflows/*.yaml` | **Agent 配置**。定义角色、workflow、工具和模型类型；顶层 Supervisor 还可配置 [Goal Mode](goal_mode.md)，Worker 不允许配置 Goal。 |
 | *应用级系统配置* | `applications/<app>/config/system.yaml` | **可选的应用级覆盖**。用于覆盖特定应用的默认系统行为（例如修改工作区或替换默认工具）。 |
 
 > 详情参考：
@@ -113,3 +113,12 @@ full_dict = C.raw
 1. **懒加载 (Lazy Load)**：首次访问 `C` 时，触发从根目录寻找并合并所有层级的配置文件。
 2. **全局缓存**：解析结果被缓存在 `_ACTIVE_CONFIG` 中，保证全生命周期配置一致。
 3. **双轨存储**：`UnifiedConfig` 对象内部同时维护了合并后的 `_raw` 字典以及独立的 `_llm_config` (Pydantic 对象)。
+
+## 5. Goal Mode 的配置边界
+
+Goal Mode 只能配置在顶层 Supervisor Agent YAML，不属于全局或 Application
+`system.yaml` overlay，Worker 也不能配置。Goal task checkpoint 额外包含
+`goal.json`；每个 run manifest 暴露相同的结构化状态，终态复制到
+`audit/goal.json`。`budget_limited` 保留 checkpoint，修改 YAML 预算后沿用同一
+`task_id` resume。完整字段、continuation、预算和调度语义见
+[Goal Mode](goal_mode.md)。

--- a/docs/cn/goal_mode.md
+++ b/docs/cn/goal_mode.md
@@ -1,0 +1,112 @@
+# Goal Mode
+
+Goal Mode 用于让一个顶层 Supervisor 持续推进一个长期目标。普通 Agent 在一次
+`final_answer` 或一个 `max_steps` 段结束后就会返回；Goal Mode 则保留同一个
+runtime、对话记忆、Worker 调用状态和 checkpoint，自动发送精简 continuation，
+直到根 Supervisor 显式提交完成，或 token 预算阻止下一次模型请求。
+
+## 配置
+
+`goal` 只能写在顶层 Supervisor YAML：
+
+```yaml
+# 简写：启用且不设置 Goal token 上限
+goal: true
+```
+
+```yaml
+# 完整形式：mapping 必须显式包含 enabled
+goal:
+  enabled: true
+  token_budget: 120000
+```
+
+```yaml
+goal: false
+```
+
+只接受布尔值，或只包含 `enabled`、`token_budget` 的 mapping。`enabled` 必须是
+布尔值；`token_budget` 必须是正整数，不能使用字符串、浮点数、0 或负数。
+`enabled: false` 时不能同时设置预算。省略 `token_budget` 表示无限制，而不是使用
+隐式默认值。Worker YAML 出现任何 `goal` key（包括 `false`）都会校验失败。
+
+目标内容由框架确定性组合 `description`、`workflow` 和本次 runtime task，不需要再
+配置 `objective`。推荐使用一个 `workflow: |` 多行字符串。Goal Mode 仍接受
+`workflow: list[str]`，但会把列表按原顺序编号后合并成一个目标上下文，并且只执行
+一次初始 run。未启用 Goal 时，Supervisor 的列表仍保持原有的逐项多次 run 语义。
+
+## 生命周期与工具
+
+一个根 task 只有一个 Goal，状态为：
+
+- `active`：继续运行；普通 final 不代表完成。
+- `budget_limited`：累计用量达到软预算，不再发起新模型请求；checkpoint 可恢复。
+- `complete`：根 Supervisor 已调用 `update_goal(status="complete", evidence="...")`；终态不可回滚。
+
+启用后，只有根 Supervisor 能看到 `get_goal` 和 `update_goal`。Worker 既看不到工具，
+也会被工具处理器的 root-run 身份校验拒绝。`evidence` 必须非空；Todo 全部完成、
+普通 final 或 host 侧猜测都不会自动完成 Goal。
+
+Tool-calling runtime 在 `update_goal` 后可能还需要一次模型响应来提交 `final_answer`。
+这次进程内结算只允许同一个根 Agent 使用；存在 tool schema 时只暴露 `final_answer`；
+它只能消费一次，且不会写入 checkpoint。结算前若碰到 planning，框架会在本地跳过；
+待触发的 smart summary 模型调用会改用确定性的本地截断；若刚好达到 max_steps，则无工具
+的最终文本 fallback 可以消费同一许可。完成响应已经耗尽 token 预算时不创建结算许可。
+
+初始 segment 接收完整目标。后续 segment 只接收稳定 `goal_id`、状态、已用/剩余预算和
+继续指令，依靠既有对话记忆推进，不重复注入或重新执行 workflow；需要时根 Agent 可用
+`get_goal` 重读 canonical objective。`max_steps` 是单个 continuation segment 的边界，
+不是 Goal 失败或完成。完成已经写入 `goal.json` 后，即使最终回复尚未落盘进程就
+崩溃，resume 也不会重新执行实质工作；持久化 evidence 是权威结果。
+
+## Token 预算
+
+`token_budget` 统计整个根 Agent 树中所有 Supervisor 和 Worker 模型响应上报的
+`prompt_tokens + completion_tokens`。它是 task 生命周期累计值，失败、interrupt 和
+resume 都不会清零。
+
+预算是软边界：请求开始前只检查已经提交的用量；在途响应和已经并发启动的 Worker
+允许完成，因此实际用量可能略高于预算。响应落地后原子累计；达到预算后，当前 run
+和 Goal 都进入 `budget_limited`，保存 checkpoint，并阻止新请求。
+
+恢复时可以提高 YAML 中的 `token_budget`，或删除该字段切换为无限制：
+
+```bash
+uv run loom run applications/<app>/workflows/<agent>.yaml --resume <task_id>
+```
+
+预算不能降低。保持一个已经耗尽的预算不变时，resume 仍会返回
+`budget_limited`；必须把新预算提高到 `used_tokens` 之上，或移除上限。
+
+## 持久化与可观测性
+
+开启 checkpoint 时，canonical 状态位于：
+
+```text
+.agentloom/checkpoints/<application_id>/<task_id>/goal.json
+```
+
+它保存稳定的 `goal_id`、objective 指纹、状态、`goal_started`、预算、prompt/completion/总用量、
+evidence 和时间戳。文件损坏会让恢复失败，不会像非关键缓存一样静默清空。
+description、规范化 workflow 或 runtime task 改变后，旧 Goal 拒绝 resume；活动 Goal
+对应的 YAML 改成禁用也会拒绝恢复。
+
+每个 run 的 `manifest.json` 包含结构化 `goal`。终态还会复制到
+`audit/goal.json`，所以成功清理 checkpoint 后仍保留审计证据。CLI 文本显示状态和
+用量；`--output-format json` 输出一个携带同一 Goal 对象的终态事件；
+`--output-format jsonl` 则在相关生命周期事件中携带它，包括 `run.completed`、
+`run.budget_limited`、`run.failed` 和 `run.interrupted`。TUI 的运行列表和详情读取相同
+状态。Python API 的预算终态抛出 `ApplicationRunBudgetLimited`，携带 run receipt、
+`goal` 和可恢复 task id。
+
+## 调度
+
+Schedule 直接运行同一份 Agent YAML，因此支持相同的 continuation、Worker 聚合预算、
+checkpoint 和 resume 语义。无限制 Goal 也允许被调度，但无人值守任务强烈建议设置
+`token_budget`；否则它会一直 continuation，直到显式完成、人工中断或真实错误。调度器
+使用隔离的 JSONL 生命周期通道识别预算终态；execution 和 job 的 `last_status` 会记录为
+`budget_limited`（并保留 Goal 用量诊断），不会误报为普通 `failed`。提高或移除预算后，
+使用该 execution 对应的 task id 执行 resume。
+
+Goal Mode 不是 Todo、第二个评估模型、通用 workflow cursor 或 Worker Goal。Todo 可
+用于内部计划，但不能改变 Goal 生命周期。

--- a/docs/cn/run_observability.md
+++ b/docs/cn/run_observability.md
@@ -19,29 +19,41 @@ print(result.run.run_id, result.run.manifest_path, result.run.log_path)
 print([event.event for event in events])
 ```
 
-`execute_app(...) -> ApplicationRunResult` 支持与 `run_app()` 相同的 `resume_task_id`、`task_override`、`file_logging`，并额外接受同步 `event_sink`。结果包含 `output`、`started_at`、`ended_at`，以及 `RunInfo` receipt：`application_id`、`task_id`、`run_id`、`run_dir`、`manifest_path`、`log_path`。
+`execute_app(...) -> ApplicationRunResult` 支持与 `run_app()` 相同的 `resume_task_id`、`task_override`、`file_logging`，并额外接受同步 `event_sink`。结果包含 `output`、`started_at`、`ended_at`、可选结构化 `goal`，以及 `RunInfo` receipt：`application_id`、`task_id`、`run_id`、`run_dir`、`manifest_path`、`log_path`。
 
 配置在 preflight 被拒绝时尚未分配存储：Python 抛出原配置异常，sink 只收到一个包含 typed `RunRejection` 的 `run.rejected`，没有 `run` receipt。分配成功后，事件序列是 `run.started` 加且仅加一个终态：
 
 - `run.completed`，包含 `output`；
+- `run.budget_limited`，包含 canonical `goal`、`error` 与 `phase`，Python 抛出携带同一 `RunInfo`、Goal snapshot 和可恢复 task id 的 `ApplicationRunBudgetLimited`；
 - `run.failed`，包含 `error` 与 `phase`，Python 抛出携带同一 `RunInfo` 的 `ApplicationRunError`；
 - `run.interrupted`，包含 `error` 与 `phase`，Python 抛出 `ApplicationRunInterrupted`。提供 resume 前必须检查其 `resumable` 标志；尚未产生可恢复状态时，该值可能为 `false`。
 
 生命周期事件使用 `schema_version: 1`。普通 observer 异常不会改变 run 结果；进程控制异常仍按进程控制信号处理。事件同步投递，因此 sink 应保持快速。
 
-## JSONL CLI 协议
+## JSON 与 JSONL CLI 协议
 
 ```bash
+uv run loom run applications/example/workflows/supervisor.yaml \
+  --output-format json
+
 uv run loom run applications/example/workflows/supervisor.yaml \
   --output-format jsonl
 ```
 
-JSONL 模式下，stdout 只输出生命周期事件，每行一个 JSON 对象。Application、Python、native 和子进程输出全部重定向到 stderr，避免污染协议。
+两种机器可读模式都把 stdout 保留给协议。`json` 只输出一个终态或拒绝事件；
+`jsonl` 按行输出生命周期事件流，包括 `run.started`。Application、Python、native
+和子进程输出全部重定向到 stderr，避免污染协议。
 
 ```json
 {"schema_version":1,"event":"run.started","run":{"application_id":"example","task_id":"task_...","run_id":"run_...","run_dir":"...","manifest_path":"...","log_path":"..."},"occurred_at":"..."}
 {"schema_version":1,"event":"run.completed","run":{"application_id":"example","task_id":"task_...","run_id":"run_...","run_dir":"...","manifest_path":"...","log_path":"..."},"occurred_at":"...","output":"done"}
 ```
+
+Goal 事件的 `goal` 对象包含 `status`、`token_budget`、`prompt_tokens`、
+`completion_tokens`、`used_tokens`、`remaining_tokens`、objective 指纹、evidence 和
+时间戳。CLI 文本模式也会显示 `Goal: <status> | tokens: <used>/<budget>`。预算终态
+退出码为 `1`，但它不是 `run.failed`；自动化应读取 `run.budget_limited` 并提示修改
+YAML 后 resume。详见 [Goal Mode](goal_mode.md)。
 
 Preflight 拒绝只产生 `run.rejected`，其中 `phase: "preflight"`、`error: {kind, message, retryable}`。因为没有创建 run 目录，所以不会伪造 `run` 对象。
 

--- a/docs/cn/system_config.md
+++ b/docs/cn/system_config.md
@@ -4,6 +4,8 @@
 > 关于配置文件之间的覆盖关系，请参阅 [配置体系总览](config-overview.md)。
 > 关于 LLM 模型参数，请参阅 [LLM 配置文档](llm_config.md)。
 > 关于 Agent YAML 参数，请参阅 [Agent 配置文档](agent_config.md)。
+> Goal Mode 不属于全局配置，只能在顶层 Supervisor Agent YAML 启用；详见
+> [Goal Mode](goal_mode.md)。
 
 `config/system.yaml` 是 AgentLoom 框架的**核心全局配置文件**，控制系统元数据、上下文压缩策略、顶层 prompt、全局 Skills、执行环境、代码执行权限、日志、工具系统、工作空间等。
 
@@ -1292,12 +1294,13 @@ Run 证据与 task 恢复状态在同一个 runtime root 下保持独立生命�
 ├── runs/<application_id>/<run_id>/
 │   ├── manifest.json
 │   ├── logs/runtime.log[.1-.3]
-│   ├── audit/{shell.jsonl[.1-.2],task_tree.json,task_events.jsonl}
+│   ├── audit/{shell.jsonl[.1-.2],task_tree.json,task_events.jsonl,goal.json}
 │   └── artifacts/{result.txt,shell,background,skills}/
 └── checkpoints/<application_id>/<task_id>/
     ├── task_events.jsonl
     ├── task_tree.json
     ├── checkpoint.json
+    ├── goal.json
     ├── heartbeat.json
     ├── workers/<worker_name>/calls/<call_index>/checkpoint.json
     ├── context_store/
@@ -1313,6 +1316,11 @@ Run 证据与 task 恢复状态在同一个 runtime root 下保持独立生命�
 - Checkpoint 直接按 Application/task canonical 路径定位，不依赖日志、`.task_index.json` 或 legacy 扫描
 - 日志关闭、轮转和 runtime retention 不会删除 checkpoint
 - Agent workspace 与 run artifacts 保持独立；Application `output_dir` 仍由 Application 管理
+- Supervisor Goal 会增加 canonical `goal.json`；完成时先复制到 run
+  manifest/audit 再执行成功清理，`budget_limited` 则保留该文件用于 resume
+
+完整存储契约见 [Checkpoint 恢复](checkpoint.md)，Goal 生命周期规则见
+[Goal Mode](goal_mode.md)。
 
 ### 12.2 心跳机制与崩溃检测
 

--- a/docs/en/agent_config.md
+++ b/docs/en/agent_config.md
@@ -190,6 +190,27 @@ workflow:
     Continue from the previous run's memory and produce the final answer.
 ```
 
+#### Goal Mode (Supervisor only)
+
+```yaml
+goal:
+  enabled: true
+  token_budget: 120000  # optional; omit for unlimited
+```
+
+`goal: true` and `goal: false` are also accepted. Mapping form requires an
+explicit boolean `enabled` and allows only optional positive-integer
+`token_budget`; unknown fields and permissive type coercions fail. Worker YAML
+must not contain any `goal` key.
+
+When enabled, the objective is derived from `description + workflow + runtime
+task`. Prefer one multiline workflow. A list is numbered and merged into one
+initial objective context instead of using the ordinary sequential multi-run
+semantics above. Normal final answers and `max_steps` end only one continuation
+segment; the root Supervisor must call `update_goal(complete, evidence)`. Worker
+model usage counts against the same optional soft budget. See [Goal Mode](goal_mode.md)
+for lifecycle, resume, persistence, CLI, TUI, and schedule behavior.
+
 #### Workflow Writing Guidelines and Recommendations
 
 `workflow` is the Agent's most critical configuration — it is essentially the **task instruction (Prompt)** sent to the LLM. A well-structured workflow can significantly improve Agent execution quality.
@@ -1746,6 +1767,7 @@ These tolerance mechanisms significantly reduce wasted retries caused by LLM out
 | `name` | ✅ | ✅ | ✅ | `str` | — |
 | `description` | ✅ | ✅ | ✅ | `str` | — |
 | `workflow` | ✅ | ✅ | ✅ | `str`/`list[str]` | — |
+| `goal` | ❌ | ✅ | ❌ | `bool`/`dict` | `false` |
 | `tools` | ❌ | ✅ | ✅ | `list[dict]` | `[]` |
 | `model_type` | ❌ | ✅ | ✅ | `str` | `model.default_model_type` from `config/llm.yaml`; no implicit default |
 | `tool_call_type` | ❌ | ✅ | ✅ | `str` | `"code_act"` |

--- a/docs/en/checkpoint.md
+++ b/docs/en/checkpoint.md
@@ -24,7 +24,8 @@ This boundary prevents log rotation or run cleanup from damaging resumable state
 │   │   ├── shell.jsonl
 │   │   ├── shell.jsonl.1 ... shell.jsonl.2
 │   │   ├── task_tree.json
-│   │   └── task_events.jsonl
+│   │   ├── task_events.jsonl
+│   │   └── goal.json            # Goal audit evidence, when present
 │   └── artifacts/
 │       ├── result.txt
 │       ├── shell/
@@ -37,6 +38,8 @@ This boundary prevents log rotation or run cleanup from damaging resumable state
 │   ├── heartbeat.json
 │   ├── todos.json
 │   ├── todos.lock
+│   ├── goal.json                # canonical Goal state, when present
+│   ├── goal.lock
 │   ├── workers/<worker_name>/
 │   │   ├── calls/<call_index>/checkpoint.json
 │   │   └── heartbeat.json
@@ -57,6 +60,7 @@ Important boundaries:
 - Checkpoint lookup uses the canonical `<application_id>/<task_id>` path. It does not depend on a log directory, `.task_index.json`, or a scan of historical runs.
 - User deliverables remain under the Application's configured `output_dir`. Runtime cleanup never traverses Application output directories.
 - Persistent Agent recall uses application-scoped `insights.md` under `.agentloom/workspaces/agents/<application_id>/<agent_path>/`. Current-task Todo state follows the checkpoint lifecycle in `<application_id>/<task_id>/todos.json` when checkpointing is enabled; otherwise it remains in run-scoped memory. It is neither a run artifact nor long-term project state.
+- Goal Mode stores the objective fingerprint, `goal_started`, state, cumulative tokens, budget, and evidence in task-scoped `goal.json`. `active`, `budget_limited`, interrupted, failed, and crashed work retains the checkpoint. Only explicit Goal completion enters normal success cleanup, after copying Goal state into the run manifest and `audit/goal.json`.
 
 ## Configuration
 
@@ -100,6 +104,12 @@ loom run applications/<app>/workflows/<agent>.yaml --no-file-log
 # New execution attempt, same logical task/checkpoint
 loom run applications/<app>/workflows/<agent>.yaml --resume task_xxx
 ```
+
+Goal resume also verifies the description, normalized workflow, and original
+runtime-task fingerprint. A `budget_limited` Goal resumes only after raising
+`token_budget` above cumulative usage or removing the limit; usage never resets.
+Disabling an active Goal, changing its objective, or reducing its budget rejects
+resume. See [Goal Mode](goal_mode.md).
 
 There is no `--log-to-file` flag. File logging follows `logging.file_enabled` by default, and `--no-file-log` is the per-run opt-out.
 

--- a/docs/en/config-overview.md
+++ b/docs/en/config-overview.md
@@ -10,7 +10,7 @@ The configuration of AgentLoom is primarily divided into three major categories,
 |----------|----------|------------|
 | `system.yaml` | `config/system.yaml` | **Global system configuration**. Controls execution environment, tool lists, tool access control, code execution permissions and other system-level behaviors. |
 | `llm.yaml` | `config/llm.yaml` | **Global model configuration**. Independently manages parameters for all LLM models (`api_key`, `base_url`, temperature, timeout, retry policies, etc.) and Langfuse observability configuration. |
-| `agent_xxx.yaml` | `applications/<app>/workflows/*.yaml` | **Agent configuration**. Defines a single agent's role, workflow, tools used, model type (`model_type`), etc. Worker Agents also support batch parallel invocation via the `concurrency` field (see [Agent Config 3.11](agent_config.md#311-concurrency--concurrency-configuration)). |
+| `agent_xxx.yaml` | `applications/<app>/workflows/*.yaml` | **Agent configuration**. Defines role, workflow, tools, and model type. A top-level Supervisor may also enable [Goal Mode](goal_mode.md); Workers cannot own Goals. |
 | *Application-level system configuration* | `applications/<app>/config/system.yaml` | **Optional application-level override**. Used to override default system behaviors for specific applications (e.g., modifying tool access control or replacing default tools). |
 
 > For more information, refer to:
@@ -123,3 +123,13 @@ full_dict = C.raw
 1. **Lazy loading**: On first access to `C`, it triggers finding and merging all configuration file layers from the root directory.
 2. **Global caching**: The parsed results are cached in `_ACTIVE_CONFIG`, ensuring configuration consistency throughout the lifecycle.
 3. **Dual storage**: The `UnifiedConfig` object internally maintains both the merged `_raw` dictionary and an independent `_llm_config` (Pydantic object).
+
+## 5. Goal Mode configuration boundary
+
+Goal Mode is configured only in a top-level Supervisor Agent YAML. It is not a
+global or Application `system.yaml` overlay, and Workers cannot configure it.
+Goal task checkpoints add `goal.json`; every run manifest projects the same
+structured state and terminal evidence is copied to `audit/goal.json`.
+`budget_limited` preserves the checkpoint so a YAML budget change can resume the
+same `task_id`. See [Goal Mode](goal_mode.md) for configuration, continuation,
+budget, and schedule behavior.

--- a/docs/en/goal_mode.md
+++ b/docs/en/goal_mode.md
@@ -1,0 +1,127 @@
+# Goal Mode
+
+Goal Mode lets one top-level Supervisor keep advancing a long-running objective.
+An ordinary Agent returns after one `final_answer` or `max_steps` segment. A Goal
+keeps the same runtime, conversation memory, Worker state, and checkpoint, then
+issues bounded continuation prompts until the root Supervisor explicitly commits
+completion or the token budget prevents another model request.
+
+## Configuration
+
+`goal` is legal only in a top-level Supervisor YAML:
+
+```yaml
+# Enabled with no Goal token ceiling
+goal: true
+```
+
+```yaml
+# Mapping form: enabled is required
+goal:
+  enabled: true
+  token_budget: 120000
+```
+
+```yaml
+goal: false
+```
+
+The value must be a boolean or a mapping containing only `enabled` and optional
+`token_budget`. `enabled` must be boolean. `token_budget` must be a positive
+integer—not a string, float, zero, or negative value—and is invalid with
+`enabled: false`. Omitting it means unlimited; there is no hidden default. Any
+`goal` key in Worker YAML, including `false`, is rejected.
+
+The objective is derived deterministically from `description`, `workflow`, and
+the runtime task; there is no separate `objective` field. Prefer one multiline
+`workflow: |`. Goal Mode accepts `workflow: list[str]`, but merges and numbers the
+items into one objective context and performs one initial run. With Goal disabled,
+Supervisor lists retain their existing sequential multi-run behavior.
+
+## Lifecycle and tools
+
+One root task owns one Goal with these states:
+
+- `active`: keep working; an ordinary final does not complete the Goal.
+- `budget_limited`: cumulative usage reached the soft budget; no new request starts and the checkpoint remains resumable.
+- `complete`: the root Supervisor called `update_goal(status="complete", evidence="...")`; this is terminal.
+
+Only the root Supervisor sees `get_goal` and `update_goal`. Workers do not receive
+the tools, and the handlers also enforce root run identity at execution time.
+Completion evidence must be non-empty. Completed Todos, normal final answers, and
+host-side guesses never complete a Goal.
+
+Tool-calling runtimes may need one model response after `update_goal` to deliver
+`final_answer`. That in-process settlement request is restricted to the same root
+Agent, exposes only `final_answer` when a tool schema is present, is consumed once,
+and is never persisted. Scheduled planning is skipped locally before settlement;
+a pending smart-summary model call is replaced by deterministic local truncation;
+a max-steps prose fallback may consume the same allowance. No allowance is created
+if the completing response already exhausted the token budget.
+
+The first segment receives the full objective. Later segments contain only the
+stable `goal_id`, current state, used/remaining budget, and continuation
+instructions, relying on existing conversation memory instead of reinjecting or
+replaying the workflow. The root Agent can call `get_goal` to reread the canonical
+objective when needed. `max_steps` ends a continuation segment, not the Goal. If
+completion reaches `goal.json` before a process crashes while delivering
+the final response, resume does not redo substantive work; persisted evidence is
+authoritative.
+
+## Token budget
+
+`token_budget` counts provider-reported `prompt_tokens + completion_tokens` for
+the entire root Agent tree, including Supervisor and Worker responses. Usage is
+cumulative for the task and is never reset by failures, interruption, or resume.
+
+The limit is soft. A request is fenced using previously committed usage; in-flight
+responses and already-started parallel Workers may finish, so actual usage can
+overshoot slightly. After a response commits the crossing, both the Goal and run
+become `budget_limited`, the checkpoint is saved, and new requests stop.
+
+Resume after increasing `token_budget` above `used_tokens`, or remove the field to
+make the remaining Goal unlimited:
+
+```bash
+uv run loom run applications/<app>/workflows/<agent>.yaml --resume <task_id>
+```
+
+Budgets cannot be reduced. An unchanged exhausted budget remains
+`budget_limited` on resume.
+
+## Persistence and observability
+
+With checkpointing enabled, canonical state is stored at:
+
+```text
+.agentloom/checkpoints/<application_id>/<task_id>/goal.json
+```
+
+It contains the stable `goal_id`, objective fingerprint, status, `goal_started`, budget,
+prompt/completion/total usage, evidence, and timestamps. Corruption fails recovery
+instead of silently clearing the state. Changing description, normalized workflow,
+or runtime task rejects resume; disabling YAML Goal Mode for an active persisted
+Goal also rejects resume.
+
+Every run `manifest.json` contains a structured `goal` object. Terminal evidence
+is also copied to `audit/goal.json`, so successful checkpoint cleanup does not erase
+the audit trail. CLI text shows status and usage. `--output-format json` emits one
+terminal event containing the same object; `--output-format jsonl` includes it on
+the relevant lifecycle events, including `run.completed`, `run.budget_limited`,
+`run.failed`, and `run.interrupted`. TUI run lists/details show the canonical state.
+The Python API raises `ApplicationRunBudgetLimited` with the run receipt, Goal
+snapshot, and resumable task id.
+
+## Schedules
+
+Schedules execute the same Agent YAML and therefore use identical continuation,
+Worker accounting, checkpoint, and resume semantics. Unlimited scheduled Goals
+are legal, but unattended runs should set `token_budget`; otherwise continuation
+can run until explicit completion, user interruption, or a real failure. The
+scheduler recognizes the isolated JSONL lifecycle event and records both the
+execution and job `last_status` as `budget_limited`, with Goal usage diagnostics,
+rather than misclassifying the outcome as an ordinary failure. Increase or remove
+the budget, then resume the event's task id.
+
+Goal Mode is not Todo, a second evaluator model, a generic workflow cursor, or a
+Worker-owned Goal. Todo can organize work inside a Goal but cannot complete it.

--- a/docs/en/run_observability.md
+++ b/docs/en/run_observability.md
@@ -19,29 +19,43 @@ print(result.run.run_id, result.run.manifest_path, result.run.log_path)
 print([event.event for event in events])
 ```
 
-`execute_app(...) -> ApplicationRunResult` accepts the same `resume_task_id`, `task_override`, and `file_logging` options as `run_app()`, plus a synchronous `event_sink`. The result contains `output`, `started_at`, `ended_at`, and a `RunInfo` receipt with `application_id`, `task_id`, `run_id`, `run_dir`, `manifest_path`, and `log_path`.
+`execute_app(...) -> ApplicationRunResult` accepts the same `resume_task_id`, `task_override`, and `file_logging` options as `run_app()`, plus a synchronous `event_sink`. The result contains `output`, `started_at`, `ended_at`, optional structured `goal`, and a `RunInfo` receipt with `application_id`, `task_id`, `run_id`, `run_dir`, `manifest_path`, and `log_path`.
 
 Preflight configuration rejection happens before storage is allocated: the original configuration exception is raised and the sink receives one `run.rejected` event with a typed `RunRejection`; it has no `run` receipt. Once allocation succeeds, the sink receives `run.started` followed by exactly one terminal event:
 
 - `run.completed` with `output`;
+- `run.budget_limited` with canonical `goal`, `error`, and `phase`, while Python raises `ApplicationRunBudgetLimited` containing the same `RunInfo`, Goal snapshot, and resumable task id;
 - `run.failed` with `error` and `phase`, while Python raises `ApplicationRunError` containing the same `RunInfo`;
 - `run.interrupted` with `error` and `phase`, while Python raises `ApplicationRunInterrupted`. Inspect its `resumable` flag before offering resume; an interruption before recoverable state exists can set it to `false`.
 
 Lifecycle events use `schema_version: 1`. Ordinary observer exceptions do not change the run outcome; process-control exceptions remain process-control signals. Keep the sink fast because delivery is synchronous.
 
-## JSONL CLI Protocol
+## JSON and JSONL CLI Protocol
 
 ```bash
+uv run loom run applications/example/workflows/supervisor.yaml \
+  --output-format json
+
 uv run loom run applications/example/workflows/supervisor.yaml \
   --output-format jsonl
 ```
 
-In JSONL mode, stdout is reserved for one lifecycle-event JSON object per line. Application, Python, native, and child-process output is redirected to stderr so it cannot corrupt the protocol.
+Both machine-readable modes reserve stdout for the protocol. `json` emits exactly
+one terminal or rejected lifecycle event. `jsonl` streams lifecycle events, including
+`run.started`, one object per line. Application, Python, native, and child-process
+output is redirected to stderr so it cannot corrupt either protocol.
 
 ```json
 {"schema_version":1,"event":"run.started","run":{"application_id":"example","task_id":"task_...","run_id":"run_...","run_dir":"...","manifest_path":"...","log_path":"..."},"occurred_at":"..."}
 {"schema_version":1,"event":"run.completed","run":{"application_id":"example","task_id":"task_...","run_id":"run_...","run_dir":"...","manifest_path":"...","log_path":"..."},"occurred_at":"...","output":"done"}
 ```
+
+Goal events include a structured `goal` object with `status`, `token_budget`,
+prompt/completion/total usage, `remaining_tokens`, objective fingerprint,
+evidence, and timestamps. Text mode also prints
+`Goal: <status> | tokens: <used>/<budget>`. Budget exhaustion exits `1` but is
+not `run.failed`; automation should handle `run.budget_limited`, edit YAML, and
+resume. See [Goal Mode](goal_mode.md).
 
 A rejected preflight emits only `run.rejected`, with `phase: "preflight"` and `error: {kind, message, retryable}`. It deliberately has no `run` object because no run directory exists.
 

--- a/docs/en/system_config.md
+++ b/docs/en/system_config.md
@@ -4,6 +4,8 @@
 > For override relationships between configuration files, see [Configuration System Overview](config-overview.md).
 > For LLM model parameters, see [LLM Configuration Reference](llm_config.md).
 > For Agent YAML parameters, see [Agent Configuration Reference](agent_config.md).
+> Goal Mode is not global configuration and can be enabled only in a top-level
+> Supervisor Agent YAML; see [Goal Mode](goal_mode.md).
 
 `config/system.yaml` is the AgentLoom framework's **core global configuration file**, controlling system metadata, context compression strategy, top-level prompts, global Skills, execution environment, code execution permissions, logging, tool system, tool access control, and more.
 
@@ -1266,12 +1268,13 @@ Run evidence and task recovery state have independent lifecycles under the same 
 ├── runs/<application_id>/<run_id>/
 │   ├── manifest.json
 │   ├── logs/runtime.log[.1-.3]
-│   ├── audit/{shell.jsonl[.1-.2],task_tree.json,task_events.jsonl}
+│   ├── audit/{shell.jsonl[.1-.2],task_tree.json,task_events.jsonl,goal.json}
 │   └── artifacts/{result.txt,shell,background,skills}/
 └── checkpoints/<application_id>/<task_id>/
     ├── task_events.jsonl
     ├── task_tree.json
     ├── checkpoint.json
+    ├── goal.json
     ├── heartbeat.json
     ├── workers/<worker_name>/calls/<call_index>/checkpoint.json
     ├── context_store/
@@ -1286,8 +1289,12 @@ Except for `manifest.json`, these run entries are conditional on logging being e
 - Checkpoint lookup uses the canonical Application/task path and never depends on logs, `.task_index.json`, or a legacy scan
 - Log closing, rotation, and runtime retention cannot remove checkpoint state
 - Agent workspaces remain separate from run artifacts; Application `output_dir` remains Application-owned
+- A Supervisor-owned Goal adds canonical `goal.json`; completion copies it to
+  the run manifest/audit before normal success cleanup, while
+  `budget_limited` keeps it resumable
 
-> For the full Checkpoint & Resume reference, see [Checkpoint & Resume](checkpoint.md).
+> See [Checkpoint & Resume](checkpoint.md) for the storage contract and
+> [Goal Mode](goal_mode.md) for Goal-specific lifecycle rules.
 
 ### 12.2 Heartbeat Mechanism & Crash Detection
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -15,6 +15,10 @@ _LAZY_EXPORTS = {
     "get_code_agent_config": ("src.lib.config", "get_code_agent_config"),
     "get_model_config": ("src.lib.config", "get_model_config"),
     "ApplicationRunError": ("src.application_run", "ApplicationRunError"),
+    "ApplicationRunBudgetLimited": (
+        "src.application_run",
+        "ApplicationRunBudgetLimited",
+    ),
     "ApplicationRunInterrupted": ("src.application_run", "ApplicationRunInterrupted"),
     "ApplicationRunResult": ("src.application_run", "ApplicationRunResult"),
     "RunEventSink": ("src.application_run", "RunEventSink"),
@@ -52,6 +56,7 @@ __all__ = [
     "get_code_agent_config",
     "get_model_config",
     "ApplicationRunError",
+    "ApplicationRunBudgetLimited",
     "ApplicationRunInterrupted",
     "ApplicationRunResult",
     "RunEventSink",

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager, nullcontext, redirect_stdout
 from datetime import UTC, datetime
 from typing import Any, TextIO
@@ -71,11 +71,20 @@ def _run_event_payload(event: Any) -> dict[str, object]:
         "occurred_at": occurred_at.isoformat(),
         "run": _run_info_payload(event.run),
     }
-    for field in ("output", "error", "phase"):
+    for field in ("output", "error", "phase", "goal"):
         value = getattr(event, field, None)
         if value is not None:
-            payload[field] = value
+            payload[field] = dict(value) if field == "goal" else value
     return payload
+
+
+def _goal_text(goal: Mapping[str, object]) -> str:
+    budget = goal.get("token_budget")
+    budget_text = "unlimited" if budget is None else str(budget)
+    return (
+        f"Goal: {goal.get('status')} | tokens: "
+        f"{goal.get('used_tokens', 0)}/{budget_text}"
+    )
 
 
 def _emit_jsonl_record(payload: dict[str, object], stream: TextIO) -> None:
@@ -87,7 +96,7 @@ def _emit_jsonl_record(payload: dict[str, object], stream: TextIO) -> None:
 
 
 @contextmanager
-def _isolated_jsonl_stdout() -> Iterator[TextIO]:
+def _isolated_machine_stdout() -> Iterator[TextIO]:
     """Reserve the original fd 1 for JSONL and route all other fd 1 writes to stderr."""
 
     protocol_stream = click.get_text_stream("stdout")
@@ -233,6 +242,7 @@ Examples:
   loom run applications/test_demo/workflows/test_agent.yaml --no-file-log
   loom run applications/test_demo/workflows/test_agent.yaml --resume task_xxx
   loom run applications/test_demo/workflows/test_agent.yaml --task "Inspect this repository"
+  loom run applications/test_demo/workflows/test_agent.yaml --output-format json
   loom run applications/test_demo/workflows/test_agent.yaml --output-format jsonl
 """
 
@@ -249,10 +259,10 @@ Examples:
 @click.option("--task", "task_override", default=None, help="Override the task from the application YAML.")
 @click.option(
     "--output-format",
-    type=click.Choice(("text", "jsonl"), case_sensitive=False),
+    type=click.Choice(("text", "json", "jsonl"), case_sensitive=False),
     default="text",
     show_default=True,
-    help="Choose human-readable output or lifecycle JSON Lines.",
+    help="Choose human-readable output, one JSON event, or lifecycle JSON Lines.",
 )
 def run(
     yaml_path: str,
@@ -282,16 +292,18 @@ def run(
             event_stream,
         )
 
-    output_context = _isolated_jsonl_stdout() if output_format == "jsonl" else nullcontext(None)
+    machine_output = output_format in {"json", "jsonl"}
+    output_context = _isolated_machine_stdout() if machine_output else nullcontext(None)
     with output_context as active_event_stream:
         event_stream = active_event_stream
         try:
-            if output_format == "jsonl":
+            if machine_output:
                 from src.runner import execute_app
 
                 def emit_event(event: Any) -> None:
                     assert event_stream is not None
-                    _emit_jsonl_record(_run_event_payload(event), event_stream)
+                    if output_format == "jsonl" or event.event != "run.started":
+                        _emit_jsonl_record(_run_event_payload(event), event_stream)
                     emitted_events.add(event.event)
 
                 execute_app(
@@ -304,13 +316,16 @@ def run(
             else:
                 from src.runner import execute_app
 
-                result = execute_app(
+                completed = execute_app(
                     yaml_path,
                     file_logging=False if no_file_log else None,
                     resume_task_id=resume_task_id,
                     task_override=task_override,
-                ).output
-                click.echo(result)
+                )
+                click.echo(completed.output)
+                completed_goal = getattr(completed, "goal", None)
+                if isinstance(completed_goal, Mapping):
+                    click.echo(_goal_text(completed_goal))
         except KeyboardInterrupt as exc:
             if not emitted_events:
                 emit_rejected(exc, message="interrupted before run started")
@@ -324,16 +339,29 @@ def run(
                     err=True,
                 )
             raise click.exceptions.Exit(130) from exc
-        except SystemExit as exc:
-            emit_rejected(exc, message="nested process exit")
-            click.echo("\n Execution failed: nested process exit", err=True)
-            raise click.exceptions.Exit(1) from exc
         except Exception as exc:
+            from src.application_run import ApplicationRunBudgetLimited
+
+            if isinstance(exc, ApplicationRunBudgetLimited):
+                if not emitted_events:
+                    emit_rejected(exc, message=str(exc))
+                goal = exc.goal
+                click.echo(
+                    "\nGoal budget limited: "
+                    f"{goal.get('used_tokens')}/{goal.get('token_budget')} tokens used. "
+                    f"Resume task {exc.run.task_id} after increasing or removing token_budget.",
+                    err=True,
+                )
+                raise click.exceptions.Exit(1) from exc
             retryable = _has_transient_provider_error(exc)
             if not emitted_events:
                 emit_rejected(exc, retryable=retryable)
             click.echo(f"\n Execution failed: {exc}", err=True)
             raise click.exceptions.Exit(_EX_TEMPFAIL if retryable else 1) from exc
+        except SystemExit as exc:
+            emit_rejected(exc, message="nested process exit")
+            click.echo("\n Execution failed: nested process exit", err=True)
+            raise click.exceptions.Exit(1) from exc
 
 
 # ─────────────────────────────────────────────

--- a/src/application_run.py
+++ b/src/application_run.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from types import MappingProxyType
 from typing import Literal, Protocol
 
 RunEventType = Literal[
     "run.started",
     "run.completed",
+    "run.budget_limited",
     "run.failed",
     "run.interrupted",
 ]
@@ -19,6 +22,29 @@ RunPhase = Literal[
     "finalization",
     "cleanup",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class GoalSnapshot(Mapping[str, object]):
+    """Immutable copy of one public Goal projection."""
+
+    _values: Mapping[str, object]
+
+    def __init__(self, value: Mapping[str, object]) -> None:
+        object.__setattr__(self, "_values", MappingProxyType(dict(value)))
+
+    def __getitem__(self, key: str) -> object:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+
+def _goal_snapshot(value: Mapping[str, object] | None) -> GoalSnapshot | None:
+    return None if value is None else GoalSnapshot(value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,6 +67,10 @@ class ApplicationRunResult:
     run: RunInfo
     started_at: datetime
     ended_at: datetime
+    goal: GoalSnapshot | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "goal", _goal_snapshot(self.goal))
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,7 +83,11 @@ class RunLifecycleEvent:
     output: str | None = None
     error: str | None = None
     phase: RunPhase | None = None
+    goal: GoalSnapshot | None = None
     schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "goal", _goal_snapshot(self.goal))
 
 
 @dataclass(frozen=True, slots=True)
@@ -119,3 +153,23 @@ class ApplicationRunInterrupted(KeyboardInterrupt):
         self.phase = phase
         self.original_error = original_error
         self.resumable = resumable
+
+
+class ApplicationRunBudgetLimited(RuntimeError):
+    """Soft Goal budget exhaustion carrying a resumable run receipt."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        run: RunInfo,
+        phase: RunPhase,
+        original_error: Exception,
+        goal: Mapping[str, object],
+    ) -> None:
+        super().__init__(message)
+        self.run = run
+        self.phase = phase
+        self.original_error = original_error
+        self.goal = GoalSnapshot(goal)
+        self.resumable = True

--- a/src/lib/checkpoint/checkpoint_manager.py
+++ b/src/lib/checkpoint/checkpoint_manager.py
@@ -425,6 +425,7 @@ class CheckpointManager:
 
         self._tree_lock = threading.Lock()
         self._todo_lock = threading.RLock()
+        self._goal_lock = threading.RLock()
         self._todo_corrupt_scopes: set[tuple[str, str]] = set()
         self._task_storages: dict[Path, SecureDirectory] = {}
         if self._checkpoint_dir is not None and self._checkpoint_dir.is_dir():
@@ -486,6 +487,9 @@ class CheckpointManager:
 
     def _todos_path(self, task_id: str) -> Path:
         return self._task_dir(task_id) / "todos.json"
+
+    def _goal_path(self, task_id: str) -> Path:
+        return self._task_dir(task_id) / "goal.json"
 
     def context_store_dir(self, task_id: str) -> Path:
         return self._task_dir(task_id) / "context_store"
@@ -721,6 +725,49 @@ class CheckpointManager:
             "items": [dict(item) for item in canonical],
             "corrupt": False,
         }
+
+    def load_goal(self, task_id: str) -> dict[str, Any] | None:
+        """Load strict Goal state; corruption is terminal rather than fail-open."""
+
+        from src.lib.goal import validate_goal_state
+
+        task_id = _require_safe_path_component(task_id, field="task_id")
+        with self._goal_lock:
+            storage = self.task_storage(task_id)
+            try:
+                with storage.advisory_file_lock("goal.lock", create=True):
+                    try:
+                        raw = storage.read_json("goal.json")
+                    except FileNotFoundError:
+                        return None
+                    except Exception as exc:
+                        raise ValueError(
+                            f"corrupt Goal state for task {task_id}: {exc}"
+                        ) from exc
+                    try:
+                        return validate_goal_state(raw).to_dict()
+                    except (TypeError, ValueError) as exc:
+                        raise ValueError(
+                            f"corrupt Goal state for task {task_id}: {exc}"
+                        ) from exc
+            finally:
+                storage.close()
+
+    def save_goal(self, task_id: str, state: Any) -> dict[str, Any]:
+        """Validate and atomically persist the canonical Goal state."""
+
+        from src.lib.goal import validate_goal_state
+
+        task_id = _require_safe_path_component(task_id, field="task_id")
+        canonical = validate_goal_state(state).to_dict()
+        with self._goal_lock:
+            storage = self.task_storage(task_id)
+            try:
+                with storage.advisory_file_lock("goal.lock", create=True):
+                    storage.atomic_write_json("goal.json", canonical)
+            finally:
+                storage.close()
+        return canonical
 
     def _read_task_events_from_path(self, path: Path) -> list[dict]:
         """Read append-only task events, skipping malformed crash-tail lines."""

--- a/src/lib/checkpoint/coordinator.py
+++ b/src/lib/checkpoint/coordinator.py
@@ -143,6 +143,16 @@ class CheckpointCoordinator:
 
         return self._cm.replace_todos(self._task_id, agent_path, items)
 
+    def load_goal(self) -> dict[str, Any] | None:
+        """Load the root task's durable Goal state."""
+
+        return self._cm.load_goal(self._task_id)
+
+    def save_goal(self, state: Any) -> dict[str, Any]:
+        """Atomically replace the root task's durable Goal state."""
+
+        return self._cm.save_goal(self._task_id, state)
+
     # ── ContextVar lifecycle ─────────────────────────────────────────
 
     @classmethod

--- a/src/lib/goal/__init__.py
+++ b/src/lib/goal/__init__.py
@@ -1,0 +1,35 @@
+"""Goal mode public contracts."""
+
+from .model import (
+    GOAL_SCHEMA_VERSION,
+    GoalConfig,
+    GoalState,
+    build_goal_objective,
+    goal_objective_fingerprint,
+    normalize_goal_config,
+    normalize_workflow_for_goal,
+    validate_goal_state,
+)
+from .provider import (
+    GoalBudgetLimitedError,
+    GoalCompleteError,
+    GoalStateProvider,
+    bind_goal_state_provider,
+    get_current_goal_provider,
+)
+
+__all__ = [
+    "GOAL_SCHEMA_VERSION",
+    "GoalConfig",
+    "GoalState",
+    "build_goal_objective",
+    "goal_objective_fingerprint",
+    "normalize_goal_config",
+    "normalize_workflow_for_goal",
+    "validate_goal_state",
+    "GoalBudgetLimitedError",
+    "GoalCompleteError",
+    "GoalStateProvider",
+    "bind_goal_state_provider",
+    "get_current_goal_provider",
+]

--- a/src/lib/goal/model.py
+++ b/src/lib/goal/model.py
@@ -1,0 +1,290 @@
+"""Strict Goal-mode configuration and durable state models."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime
+from typing import Any, Literal
+
+GOAL_SCHEMA_VERSION = 1
+GoalStatus = Literal["active", "budget_limited", "complete"]
+
+
+@dataclass(frozen=True, slots=True)
+class GoalConfig:
+    enabled: bool = False
+    token_budget: int | None = None
+
+
+def normalize_goal_config(config: dict[str, Any], *, source: str) -> GoalConfig:
+    """Return the strict Goal config accepted by Supervisor YAML."""
+
+    if "goal" not in config:
+        return GoalConfig()
+    raw = config["goal"]
+    if isinstance(raw, bool):
+        return GoalConfig(enabled=raw)
+    if not isinstance(raw, dict):
+        raise ValueError(f"{source}.goal must be a boolean or mapping")
+
+    unsupported = sorted(set(raw) - {"enabled", "token_budget"})
+    if unsupported:
+        raise ValueError(
+            f"{source}.goal has unsupported field(s): {', '.join(unsupported)}"
+        )
+    if "enabled" not in raw:
+        raise ValueError(f"{source}.goal.enabled is required when goal is a mapping")
+    enabled = raw["enabled"]
+    if not isinstance(enabled, bool):
+        raise ValueError(f"{source}.goal.enabled must be a boolean")
+
+    token_budget_present = "token_budget" in raw
+    token_budget = raw.get("token_budget")
+    if token_budget_present:
+        if (
+            isinstance(token_budget, bool)
+            or not isinstance(token_budget, int)
+            or token_budget <= 0
+        ):
+            raise ValueError(f"{source}.goal.token_budget must be a positive integer")
+        if not enabled:
+            raise ValueError(
+                f"{source}.goal.token_budget is only valid when goal.enabled is true"
+            )
+    return GoalConfig(enabled=enabled, token_budget=token_budget)
+
+
+def normalize_workflow_for_goal(workflow: str | list[str]) -> str:
+    if isinstance(workflow, str):
+        return workflow.strip()
+    return "\n".join(f"{index}. {item.strip()}" for index, item in enumerate(workflow, 1))
+
+
+def build_goal_objective(
+    *,
+    description: str,
+    workflow: str | list[str],
+    task: str,
+) -> str:
+    parts = [f"Description:\n{description.strip()}"]
+    parts.append(f"Workflow:\n{normalize_workflow_for_goal(workflow)}")
+    if task.strip():
+        parts.append(f"Runtime request:\n{task.strip()}")
+    return "\n\n".join(parts)
+
+
+def goal_objective_fingerprint(
+    *,
+    description: str,
+    workflow: str | list[str],
+    task: str,
+) -> str:
+    payload = {
+        "description": description.strip(),
+        "workflow": normalize_workflow_for_goal(workflow),
+        "task": task.strip(),
+    }
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now().astimezone().isoformat()
+
+
+@dataclass(frozen=True, slots=True)
+class GoalState:
+    goal_id: str
+    objective: str
+    objective_fingerprint: str
+    status: GoalStatus = "active"
+    token_budget: int | None = None
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    evidence: str | None = None
+    goal_started: bool = False
+    created_at: str = ""
+    updated_at: str = ""
+    completed_at: str | None = None
+    schema_version: int = GOAL_SCHEMA_VERSION
+
+    @property
+    def used_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        objective: str,
+        objective_fingerprint: str,
+        token_budget: int | None,
+    ) -> GoalState:
+        now = _now()
+        return cls(
+            goal_id=f"goal_{uuid.uuid4().hex}",
+            objective=objective,
+            objective_fingerprint=objective_fingerprint,
+            token_budget=token_budget,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def with_usage(self, prompt_tokens: int, completion_tokens: int) -> GoalState:
+        if prompt_tokens < 0 or completion_tokens < 0:
+            raise ValueError("Goal token usage cannot be negative")
+        next_prompt = self.prompt_tokens + prompt_tokens
+        next_completion = self.completion_tokens + completion_tokens
+        next_status: GoalStatus = self.status
+        if (
+            self.status != "complete"
+            and self.token_budget is not None
+            and next_prompt + next_completion >= self.token_budget
+        ):
+            next_status = "budget_limited"
+        return replace(
+            self,
+            prompt_tokens=next_prompt,
+            completion_tokens=next_completion,
+            status=next_status,
+            updated_at=_now(),
+        )
+
+    def with_started(self) -> GoalState:
+        if self.goal_started:
+            return self
+        return replace(self, goal_started=True, updated_at=_now())
+
+    def with_completion(self, evidence: str) -> GoalState:
+        evidence = evidence.strip()
+        if not evidence:
+            raise ValueError("Goal completion evidence must be non-empty")
+        if self.status == "complete":
+            return self
+        now = _now()
+        return replace(
+            self,
+            status="complete",
+            evidence=evidence,
+            completed_at=now,
+            updated_at=now,
+        )
+
+    def with_resumed_budget(self, token_budget: int | None) -> GoalState:
+        if self.token_budget is None and token_budget is not None:
+            raise ValueError("Goal token_budget cannot be decreased on resume")
+        if (
+            self.token_budget is not None
+            and token_budget is not None
+            and token_budget < self.token_budget
+        ):
+            raise ValueError("Goal token_budget cannot be decreased on resume")
+        status = self.status
+        if status != "complete":
+            status = (
+                "budget_limited"
+                if token_budget is not None and self.used_tokens >= token_budget
+                else "active"
+            )
+        return replace(self, token_budget=token_budget, status=status, updated_at=_now())
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["used_tokens"] = self.used_tokens
+        payload["remaining_tokens"] = (
+            None
+            if self.token_budget is None
+            else max(self.token_budget - self.used_tokens, 0)
+        )
+        return payload
+
+
+def validate_goal_state(raw: Any) -> GoalState:
+    if not isinstance(raw, dict):
+        raise ValueError("Goal state must be a JSON object")
+    allowed = {
+        "schema_version",
+        "goal_id",
+        "objective",
+        "objective_fingerprint",
+        "status",
+        "token_budget",
+        "prompt_tokens",
+        "completion_tokens",
+        "evidence",
+        "goal_started",
+        "created_at",
+        "updated_at",
+        "completed_at",
+        "used_tokens",
+        "remaining_tokens",
+    }
+    unexpected = sorted(set(raw) - allowed)
+    if unexpected:
+        raise ValueError(f"Goal state has unsupported field(s): {', '.join(unexpected)}")
+    if raw.get("schema_version") != GOAL_SCHEMA_VERSION:
+        raise ValueError("Goal state schema_version is unsupported")
+    for field in (
+        "goal_id",
+        "objective",
+        "objective_fingerprint",
+        "created_at",
+        "updated_at",
+    ):
+        if not isinstance(raw.get(field), str) or not raw[field].strip():
+            raise ValueError(f"Goal state {field} must be a non-empty string")
+    status = raw.get("status")
+    if status not in {"active", "budget_limited", "complete"}:
+        raise ValueError("Goal state status is invalid")
+    token_budget = raw.get("token_budget")
+    if token_budget is not None and (
+        isinstance(token_budget, bool)
+        or not isinstance(token_budget, int)
+        or token_budget <= 0
+    ):
+        raise ValueError("Goal state token_budget must be a positive integer")
+    numeric: dict[str, int] = {}
+    for field in ("prompt_tokens", "completion_tokens"):
+        value = raw.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"Goal state {field} must be a non-negative integer")
+        numeric[field] = value
+    if "used_tokens" in raw and raw["used_tokens"] != sum(numeric.values()):
+        raise ValueError("Goal state used_tokens does not match token totals")
+    expected_remaining = (
+        None
+        if token_budget is None
+        else max(token_budget - sum(numeric.values()), 0)
+    )
+    if "remaining_tokens" in raw and raw["remaining_tokens"] != expected_remaining:
+        raise ValueError("Goal state remaining_tokens does not match token totals")
+    if not isinstance(raw.get("goal_started"), bool):
+        raise ValueError("Goal state goal_started must be a boolean")
+    evidence = raw.get("evidence")
+    completed_at = raw.get("completed_at")
+    if evidence is not None and (not isinstance(evidence, str) or not evidence.strip()):
+        raise ValueError("Goal state evidence must be a non-empty string")
+    if completed_at is not None and (
+        not isinstance(completed_at, str) or not completed_at.strip()
+    ):
+        raise ValueError("Goal state completed_at must be a non-empty string")
+    if status == "complete" and (evidence is None or completed_at is None):
+        raise ValueError("Complete Goal state requires evidence and completed_at")
+    return GoalState(
+        schema_version=GOAL_SCHEMA_VERSION,
+        goal_id=raw["goal_id"],
+        objective=raw["objective"],
+        objective_fingerprint=raw["objective_fingerprint"],
+        status=status,
+        token_budget=token_budget,
+        prompt_tokens=numeric["prompt_tokens"],
+        completion_tokens=numeric["completion_tokens"],
+        evidence=evidence,
+        goal_started=raw["goal_started"],
+        created_at=raw["created_at"],
+        updated_at=raw["updated_at"],
+        completed_at=completed_at,
+    )

--- a/src/lib/goal/provider.py
+++ b/src/lib/goal/provider.py
@@ -1,0 +1,194 @@
+"""Run-scoped Goal state shared by a Supervisor and its Worker tree."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Literal, overload
+
+from .model import GoalConfig, GoalState, validate_goal_state
+
+
+class GoalBudgetLimitedError(RuntimeError):
+    """Raised by the pre-request fence after a Goal exhausts its soft budget."""
+
+    def __init__(self, state: GoalState) -> None:
+        super().__init__(
+            f"Goal token budget exhausted: used={state.used_tokens}, "
+            f"budget={state.token_budget}"
+        )
+        self.state = state
+
+
+class GoalCompleteError(RuntimeError):
+    """Stops further model calls after the Goal completion commit point."""
+
+    def __init__(self, state: GoalState) -> None:
+        super().__init__("Goal is already complete")
+        self.state = state
+
+
+class GoalStateProvider:
+    """Serialize Goal mutations and durably commit each state transition."""
+
+    def __init__(self, state: GoalState) -> None:
+        self._state = state
+        self._lock = threading.RLock()
+        # This allowance exists only in the current process. A completed Goal
+        # restored after a crash must not synthesize a missing final response.
+        self._completion_settlement_run_id: str | None = None
+        self._completion_settlement_available = False
+
+    @staticmethod
+    def _coordinator():
+        from src.lib.checkpoint.coordinator import CheckpointCoordinator
+
+        return CheckpointCoordinator.current()
+
+    @classmethod
+    def initialize(
+        cls,
+        *,
+        config: GoalConfig,
+        objective: str,
+        objective_fingerprint: str,
+        resume: bool,
+    ) -> GoalStateProvider:
+        if not config.enabled:
+            raise ValueError("Cannot initialize Goal state when Goal mode is disabled")
+        coordinator = cls._coordinator()
+        raw = coordinator.load_goal() if coordinator is not None else None
+
+        if resume:
+            if raw is None:
+                raise ValueError("Cannot resume Goal mode: checkpoint has no Goal state")
+            state = validate_goal_state(raw)
+            if state.objective_fingerprint != objective_fingerprint:
+                raise ValueError(
+                    "Cannot resume Goal mode because the objective changed; "
+                    "description, workflow, and runtime task must match"
+                )
+            state = state.with_resumed_budget(config.token_budget)
+        else:
+            if raw is not None:
+                raise ValueError("Cannot start Goal mode: Goal state already exists")
+            state = GoalState.create(
+                objective=objective,
+                objective_fingerprint=objective_fingerprint,
+                token_budget=config.token_budget,
+            )
+
+        provider = cls(state)
+        provider._persist_locked()
+        return provider
+
+    def _persist_locked(self) -> None:
+        coordinator = self._coordinator()
+        if coordinator is not None:
+            coordinator.save_goal(self._state.to_dict())
+
+    def snapshot(self) -> GoalState:
+        with self._lock:
+            return self._state
+
+    def assert_request_allowed(
+        self,
+        *,
+        local_run_id: str | None = None,
+        allow_completion_settlement: bool = False,
+    ) -> bool:
+        """Fence new work and claim the one ephemeral final-delivery request."""
+
+        with self._lock:
+            if self._state.status == "complete":
+                if (
+                    self._state.token_budget is not None
+                    and self._state.used_tokens >= self._state.token_budget
+                ):
+                    raise GoalBudgetLimitedError(self._state)
+                if (
+                    allow_completion_settlement
+                    and self._completion_settlement_available
+                    and local_run_id == self._completion_settlement_run_id
+                ):
+                    self._completion_settlement_available = False
+                    return True
+                raise GoalCompleteError(self._state)
+            if self._state.status == "budget_limited":
+                raise GoalBudgetLimitedError(self._state)
+            return False
+
+    def completion_settlement_pending(self, *, local_run_id: str | None) -> bool:
+        """Return whether this process still owes the root its final delivery."""
+
+        with self._lock:
+            return (
+                self._state.status == "complete"
+                and (
+                    self._state.token_budget is None
+                    or self._state.used_tokens < self._state.token_budget
+                )
+                and self._completion_settlement_available
+                and local_run_id == self._completion_settlement_run_id
+            )
+
+    def record_usage(self, *, prompt_tokens: int, completion_tokens: int) -> GoalState:
+        with self._lock:
+            self._state = self._state.with_usage(prompt_tokens, completion_tokens)
+            self._persist_locked()
+            return self._state
+
+    def mark_started(self) -> GoalState:
+        with self._lock:
+            self._state = self._state.with_started()
+            self._persist_locked()
+            return self._state
+
+    def complete(
+        self,
+        evidence: str,
+        *,
+        settlement_run_id: str | None = None,
+    ) -> GoalState:
+        with self._lock:
+            previous_status = self._state.status
+            self._state = self._state.with_completion(evidence)
+            if previous_status == "active" and settlement_run_id is not None:
+                self._completion_settlement_run_id = settlement_run_id
+                self._completion_settlement_available = True
+            self._persist_locked()
+            return self._state
+
+
+_CURRENT_GOAL_PROVIDER: ContextVar[GoalStateProvider | None] = ContextVar(
+    "_CURRENT_GOAL_PROVIDER",
+    default=None,
+)
+
+
+@overload
+def get_current_goal_provider(*, required: Literal[True]) -> GoalStateProvider: ...
+
+
+@overload
+def get_current_goal_provider(
+    *, required: Literal[False] = False
+) -> GoalStateProvider | None: ...
+
+
+def get_current_goal_provider(*, required: bool = False) -> GoalStateProvider | None:
+    provider = _CURRENT_GOAL_PROVIDER.get()
+    if provider is None and required:
+        raise RuntimeError("no GoalStateProvider is bound to the current root run")
+    return provider
+
+
+@contextmanager
+def bind_goal_state_provider(provider: GoalStateProvider) -> Iterator[GoalStateProvider]:
+    token = _CURRENT_GOAL_PROVIDER.set(provider)
+    try:
+        yield provider
+    finally:
+        _CURRENT_GOAL_PROVIDER.reset(token)

--- a/src/lib/smolagents/agent/agent_validation.py
+++ b/src/lib/smolagents/agent/agent_validation.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 import inspect
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from src.lib.config.config_validation import TODO_MODES, normalize_todo_mode_value
+from src.lib.goal import GoalConfig, normalize_goal_config
 from src.lib.logging import get_logger, validate_logging_config
 
 
 @dataclass
 class NormalizedAgentConfig:
     agent_function_schema: Optional[dict] = None
+    goal: GoalConfig = dataclass_field(default_factory=GoalConfig)
 
 
 _ALLOWED_EXECUTION_ENV_TYPES = {"local", "e2b", "docker", "wasm"}
@@ -635,9 +637,14 @@ class AgentConfigNormalizer:
         source_name: str,
     ) -> NormalizedAgentConfig:
         _ = agent_root
-        name = str(config.get("name", source_name))
+        if "goal" in config:
+            raise ValueError(
+                f"Worker Agent configuration {source_name} must not define goal; "
+                "Goal mode is Supervisor-only"
+            )
         return NormalizedAgentConfig(
             agent_function_schema=cls.validate_agent_function_schema(config),
+            goal=GoalConfig(),
         )
 
     @classmethod
@@ -652,4 +659,5 @@ class AgentConfigNormalizer:
         name = str(config.get("name", source_name))
         return NormalizedAgentConfig(
             agent_function_schema=None,
+            goal=normalize_goal_config(config, source=name),
         )

--- a/src/lib/smolagents/agent/base_agent.py
+++ b/src/lib/smolagents/agent/base_agent.py
@@ -114,12 +114,67 @@ def _normalize_tool_arguments_object(arguments: dict[str, Any] | str) -> dict[st
     return parsed if isinstance(parsed, dict) else arguments
 
 
+def _require_runtime_result(
+    run_result: Any,
+    *,
+    allowed_states: set[str],
+    error_prefix: str,
+) -> None:
+    run_state = str(getattr(run_result, "state", "") or "")
+    if run_state not in allowed_states:
+        state_label = run_state or "missing_run_state"
+        raise RuntimeError(f"{error_prefix}: {state_label}")
+
+
 def _require_successful_runtime_result(run_result: Any) -> None:
     """Reject structured runtime results that did not finish successfully."""
-    run_state = str(getattr(run_result, "state", "") or "")
-    if run_state != "success":
-        state_label = run_state or "missing_run_state"
-        raise RuntimeError(f"Agent run did not complete successfully: {state_label}")
+
+    _require_runtime_result(
+        run_result,
+        allowed_states={"success"},
+        error_prefix="Agent run did not complete successfully",
+    )
+
+
+def _require_goal_runtime_result(run_result: Any) -> None:
+    """Accept both ordinary finals and max-step segment boundaries in Goal mode."""
+
+    _require_runtime_result(
+        run_result,
+        allowed_states={"success", "max_steps_error"},
+        error_prefix="Agent Goal segment failed",
+    )
+
+
+def _goal_continuation_prompt(state: Any) -> str:
+    budget = "unlimited"
+    if state.token_budget is not None:
+        remaining = max(state.token_budget - state.used_tokens, 0)
+        budget = (
+            f"{state.used_tokens}/{state.token_budget} tokens used; "
+            f"{remaining} tokens remain before the next-request fence"
+        )
+    return (
+        "Continue working toward the active Goal using the existing conversation "
+        "and tool state. Do not restart or repeat completed work.\n\n"
+        f"Goal ID: {state.goal_id}\n"
+        "Objective: unchanged from the initial task context; call get_goal only "
+        "if you need to inspect the canonical objective again.\n"
+        f"Goal status: {state.status}\n"
+        f"Token budget: {budget}\n\n"
+        "A normal final answer does not complete the Goal. Only after the entire "
+        "objective is delivered and verified, call update_goal with status="
+        "'complete' and concise evidence."
+    )
+
+
+def _goal_completion_output(segment_output: Any, evidence: str | None) -> Any:
+    if (
+        isinstance(segment_output, str)
+        and segment_output.startswith("Error in generating final LLM output:")
+    ):
+        return evidence
+    return segment_output if segment_output is not None else evidence
 
 
 class _SuccessfulRunStateMixin:
@@ -1102,6 +1157,17 @@ class RoleDrivenAgent(BaseAgent):
 
     def _build_runtime_tools(self, profile: AgentRoleProfile) -> list:
         tools = self.get_all_tools(agent_type=profile.agent_type.value.lower())
+        if profile.agent_type is AgentType.SUPERVISOR:
+            from src.lib.goal import normalize_goal_config
+
+            goal = normalize_goal_config(
+                self._config,
+                source=self._config.get("name", "supervisor"),
+            )
+            if goal.enabled:
+                from src.tools.goal import get_goal, update_goal
+
+                tools = [*tools, get_goal, update_goal]
         todo_mode = self._resolve_todo_mode()
         if todo_mode == "off":
             return [
@@ -1389,6 +1455,12 @@ class RoleDrivenAgent(BaseAgent):
         owns_root_run: bool,
     ) -> str:
         from src.lib.checkpoint.coordinator import CheckpointCoordinator
+        from src.lib.goal import (
+            GoalStateProvider,
+            build_goal_objective,
+            goal_objective_fingerprint,
+            normalize_goal_config,
+        )
 
         # Transform task before passing it to the runtime agent.
         transformed_tasks = self._transform_tasks(task)
@@ -1396,6 +1468,25 @@ class RoleDrivenAgent(BaseAgent):
             raise ValueError("Agent task transformation produced no tasks")
         transformed_tasks = self._inject_memory_snapshot(transformed_tasks)
         transformed_task = "\n\n".join(transformed_tasks)
+        goal_config = normalize_goal_config(
+            self._config,
+            source=self._config.get("name", "agent"),
+        )
+        goal_objective = None
+        goal_fingerprint = None
+        if goal_config.enabled:
+            if not owns_root_run:
+                raise ValueError("Goal mode can only be configured by the root Supervisor Agent")
+            goal_objective = build_goal_objective(
+                description=str(self._config.get("description", "")),
+                workflow=self._config["workflow"],
+                task=task,
+            )
+            goal_fingerprint = goal_objective_fingerprint(
+                description=str(self._config.get("description", "")),
+                workflow=self._config["workflow"],
+                task=task,
+            )
         # Determine ID
         parent_execution_context = capture_explicit_execution_context()
         current_task_id = parent_execution_context.task_id
@@ -1418,6 +1509,21 @@ class RoleDrivenAgent(BaseAgent):
         else:
             coord = CheckpointCoordinator.current()
 
+        goal_provider = None
+        if goal_config.enabled:
+            assert goal_objective is not None and goal_fingerprint is not None
+            try:
+                goal_provider = GoalStateProvider.initialize(
+                    config=goal_config,
+                    objective=goal_objective,
+                    objective_fingerprint=goal_fingerprint,
+                    resume=resume,
+                )
+            except Exception:
+                if checkpoint_manager is not None and coord is not None:
+                    CheckpointCoordinator.deactivate(coord)
+                raise
+
         def _execute_agent():
             session_started = False
             session_result = None
@@ -1430,12 +1536,21 @@ class RoleDrivenAgent(BaseAgent):
                 self._model.agent_id = agent_id
 
             active_context = capture_explicit_execution_context()
+            hook_agent_config = self._effective_agent_config or self._config
+            if goal_config.enabled:
+                # Goal is an Agent-owned lifecycle field, not a system overlay.
+                # Preserve the raw validated value in the execution-time
+                # identity snapshot used by root-only Goal tool guards.
+                hook_agent_config = {
+                    **hook_agent_config,
+                    "goal": deepcopy(self._config["goal"]),
+                }
             hook_run = HookRun(
                 self._hook_plan,
                 local_run_id=active_context.local_run_id or "",
                 root_run_id=active_context.root_run_id or "",
                 parent=active_context.hook_run,
-                agent_config=self._effective_agent_config or self._config,
+                agent_config=hook_agent_config,
                 project_root=str(C.agent_root),
             )
             previous_runtime_path = active_context.runtime_agent_path
@@ -1455,8 +1570,15 @@ class RoleDrivenAgent(BaseAgent):
                 )
             )
             execution_binding.__enter__()
+            from src.lib.goal import bind_goal_state_provider
             from src.lib.todo import ensure_todo_state_provider
 
+            goal_provider_binding = (
+                bind_goal_state_provider(goal_provider)
+                if goal_provider is not None
+                else nullcontext(None)
+            )
+            goal_provider_binding.__enter__()
             todo_provider_binding = ensure_todo_state_provider()
             todo_provider_binding.__enter__()
 
@@ -1503,22 +1625,88 @@ class RoleDrivenAgent(BaseAgent):
                 # which is indistinguishable from a successful final answer and
                 # would incorrectly emit TaskCompleted and run memory review.
                 result = None
-                for task_index, current_task in enumerate(transformed_tasks):
-                    run_kwargs: dict = {
-                        "task": current_task,
-                        "return_full_result": True,
-                    }
-                    if additional_args:
-                        run_kwargs["additional_args"] = dict(additional_args)
-                    if resume or task_index > 0:
-                        run_kwargs["reset"] = False
-                    if task_index > 0 and getattr(
-                        runtime_agent, "_agent_loom_supports_reset_false_task_step_control", False
-                    ):
-                        run_kwargs["_skip_task_step_on_reset_false"] = False
-                    run_result = runtime_agent.run(**run_kwargs)
-                    _require_successful_runtime_result(run_result)
-                    result = getattr(run_result, "output", None)
+                if goal_provider is not None:
+                    initial_state = goal_provider.snapshot()
+                    segment_index = 0
+                    while True:
+                        state = goal_provider.snapshot()
+                        if state.status == "complete":
+                            result = state.evidence
+                            break
+                        goal_provider.assert_request_allowed()
+                        use_initial_context = segment_index == 0 and not initial_state.goal_started
+                        current_task = (
+                            transformed_tasks[0]
+                            if use_initial_context
+                            else _goal_continuation_prompt(state)
+                        )
+                        run_kwargs = {
+                            "task": current_task,
+                            "return_full_result": True,
+                        }
+                        if additional_args:
+                            run_kwargs["additional_args"] = dict(additional_args)
+                        if resume or segment_index > 0 or not use_initial_context:
+                            run_kwargs["reset"] = False
+                        if (
+                            not use_initial_context
+                            and getattr(
+                                runtime_agent,
+                                "_agent_loom_supports_reset_false_task_step_control",
+                                False,
+                            )
+                        ):
+                            run_kwargs["_skip_task_step_on_reset_false"] = False
+                        try:
+                            run_result = runtime_agent.run(**run_kwargs)
+                        except Exception as exc:
+                            from src.lib.goal import (
+                                GoalBudgetLimitedError,
+                                GoalCompleteError,
+                            )
+
+                            terminal_state = goal_provider.snapshot()
+                            if (
+                                isinstance(exc, GoalCompleteError)
+                                or terminal_state.status == "complete"
+                            ):
+                                result = terminal_state.evidence
+                                break
+                            if terminal_state.status == "budget_limited":
+                                raise GoalBudgetLimitedError(terminal_state) from exc
+                            raise
+                        _require_goal_runtime_result(run_result)
+                        segment_output = getattr(run_result, "output", None)
+                        segment_index += 1
+                        state = goal_provider.snapshot()
+                        if state.status == "complete":
+                            # A CodeAgent can commit completion and call
+                            # final_answer in the same model response. Preserve
+                            # that user-facing delivery; evidence is only the
+                            # durable fallback when no final output settled.
+                            result = _goal_completion_output(
+                                segment_output,
+                                state.evidence,
+                            )
+                            break
+                        goal_provider.assert_request_allowed()
+                else:
+                    for task_index, current_task in enumerate(transformed_tasks):
+                        run_kwargs: dict = {
+                            "task": current_task,
+                            "return_full_result": True,
+                        }
+                        if additional_args:
+                            run_kwargs["additional_args"] = dict(additional_args)
+                        if resume or task_index > 0:
+                            run_kwargs["reset"] = False
+                        if task_index > 0 and getattr(
+                            runtime_agent, "_agent_loom_supports_reset_false_task_step_control", False
+                        ):
+                            run_kwargs["_skip_task_step_on_reset_false"] = False
+                        run_result = runtime_agent.run(**run_kwargs)
+                        _require_successful_runtime_result(run_result)
+                        result = getattr(run_result, "output", None)
 
                 # Compatibility fallback for wrapper paths that cannot read
                 # memory directly from the runtime agent.
@@ -1544,7 +1732,17 @@ class RoleDrivenAgent(BaseAgent):
                     coord.save_supervisor(runtime_agent, "interrupted")
                 raise
             except Exception as exc:
+                from src.lib.goal import GoalBudgetLimitedError
+
                 session_error = exc
+                if isinstance(exc, GoalBudgetLimitedError):
+                    if coord is not None and checkpoint_manager is not None:
+                        coord.save_supervisor(
+                            runtime_agent,
+                            "budget_limited",
+                            error=str(exc),
+                        )
+                    raise
                 self._emit_task_lifecycle_event(
                     HookEvent.STOP_FAILURE,
                     transformed_task,
@@ -1554,6 +1752,8 @@ class RoleDrivenAgent(BaseAgent):
                     coord.save_supervisor(runtime_agent, "failed", error=str(exc))
                 raise
             finally:
+                if goal_provider is not None:
+                    self._last_goal_state = goal_provider.snapshot().to_dict()
                 if session_started:
                     self._emit_session_lifecycle_event(
                         HookEvent.SESSION_END,
@@ -1611,7 +1811,10 @@ class RoleDrivenAgent(BaseAgent):
                     try:
                         todo_provider_binding.__exit__(None, None, None)
                     finally:
-                        execution_binding.__exit__(None, None, None)
+                        try:
+                            goal_provider_binding.__exit__(None, None, None)
+                        finally:
+                            execution_binding.__exit__(None, None, None)
 
         if current_task_id:
             return _execute_agent()

--- a/src/lib/smolagents/agent/runtime_validation.py
+++ b/src/lib/smolagents/agent/runtime_validation.py
@@ -15,6 +15,7 @@ from src.lib.smolagents.agent.agent_validation import (
     validate_execution_config_payload,
     validate_todo_config,
 )
+from src.lib.goal import normalize_goal_config
 
 REQUIRED_YAML_FIELDS = ("name", "workflow", "description")
 
@@ -73,6 +74,7 @@ def validate_runtime_agent_config(
     AgentConfigNormalizer.validate_agent_function_schema(config)
     AgentConfigNormalizer.validate_worker_agents_config(config.get("worker_agents", []))
     validate_todo_config(config, source=str(yaml_path))
+    normalize_goal_config(config, source=str(yaml_path))
     normalized_execution = build_normalized_execution_config(
         config,
         source_name=str(yaml_path),
@@ -87,6 +89,11 @@ def validate_runtime_worker_config(
     *,
     agent_root: Path | str,
 ) -> None:
+    if "goal" in config:
+        raise ValueError(
+            f"Worker Agent configuration {yaml_path} must not define goal; "
+            "Goal mode is Supervisor-only"
+        )
     validate_runtime_agent_config(config, yaml_path, agent_root=agent_root)
     if AgentConfigNormalizer.validate_agent_function_schema(config) is None:
         raise ValueError(f"Worker Agent configuration {yaml_path} agent_function_schema is required")

--- a/src/lib/smolagents/agent/yaml_agent_factory.py
+++ b/src/lib/smolagents/agent/yaml_agent_factory.py
@@ -13,6 +13,7 @@ from src.lib.config.yaml_loader import load_unique_yaml
 from src.lib.logging import (
     get_logger,
 )
+from src.lib.goal import normalize_goal_config, normalize_workflow_for_goal
 from src.lib.smolagents import AgentLogger
 from src.lib.smolagents.agent.agent_validation import AgentConfigNormalizer, NormalizedAgentConfig
 from src.lib.smolagents.agent.base_agent import AgentRoleProfile, AgentType, RoleDrivenAgent
@@ -730,8 +731,12 @@ class YamlConfiguredSupervisorAgent(RoleDrivenAgent):
             inject_default_file_tools=False,
         )
 
-    def _transform_task(self, task: str) -> str:
-        workflow_content = _workflow_to_task_spec_source(self._config['workflow'])
+    def _transform_task(self, task: str, *, workflow_override: str | None = None) -> str:
+        workflow_content = (
+            workflow_override
+            if workflow_override is not None
+            else _workflow_to_task_spec_source(self._config['workflow'])
+        )
         description = self._config.get('description', '').strip()
         task_spec_source = workflow_content.strip()
         if description:
@@ -755,6 +760,10 @@ class YamlConfiguredSupervisorAgent(RoleDrivenAgent):
 
     def _transform_tasks(self, task: str) -> list[str]:
         workflow_content = self._config['workflow']
+        goal = normalize_goal_config(self._config, source=self._config.get("name", "supervisor"))
+        if goal.enabled:
+            merged_workflow = normalize_workflow_for_goal(workflow_content)
+            return [self._transform_task(task, workflow_override=merged_workflow)]
         if isinstance(workflow_content, list):
             # List workflows are executed sequentially: each item becomes a
             # separate runtime_agent.run() call with reset=False preserving

--- a/src/lib/smolagents/memory/context_compression.py
+++ b/src/lib/smolagents/memory/context_compression.py
@@ -1152,6 +1152,22 @@ def summarize_conversation(
     """
     log = get_logger(None, __name__)
 
+    # A completed Goal may owe the root exactly one final-delivery request.
+    # Smart summary runs under the same ContextVars but is only scaffolding;
+    # skip its model call so it cannot consume that ephemeral allowance.
+    from src.lib.goal import get_current_goal_provider
+    from src.trace import get_current_local_run_id
+
+    goal_provider = get_current_goal_provider()
+    if goal_provider is not None and goal_provider.completion_settlement_pending(
+        local_run_id=get_current_local_run_id(),
+    ):
+        return SummarizeResponse(
+            messages=messages,
+            summary="",
+            error="Goal completion settlement pending; smart summary skipped",
+        )
+
     messages_to_summarize = get_messages_since_last_summary(messages)
     summarizable_messages = [
         msg for msg in messages_to_summarize

--- a/src/lib/smolagents/models/litellm_model.py
+++ b/src/lib/smolagents/models/litellm_model.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from smolagents import AgentLogger, LiteLLMModel
 from smolagents.models import ChatMessage, ChatMessageToolCall, ChatMessageToolCallFunction, MessageRole
+from smolagents.monitoring import TokenUsage
 from src.lib.logging import get_logger
 from src.lib.smolagents.models.tool_call_parser import (
     ToolCallParseError,
@@ -145,6 +146,43 @@ class LiteLLMModelV2(LiteLLMModel):
         tools_to_call_from: list[Any] | None = None,
         **kwargs,
     ) -> ChatMessage:
+        from src.lib.goal import get_current_goal_provider
+        from src.trace import get_current_local_run_id
+
+        goal_provider = get_current_goal_provider()
+        completion_settlement = False
+        if goal_provider is not None:
+            # Soft fence: only committed usage from earlier responses can stop
+            # a request. The response currently in flight may overshoot.
+            final_answer_tools = [
+                tool
+                for tool in tools_to_call_from or []
+                if getattr(tool, "name", None) == "final_answer"
+            ]
+            local_run_id = get_current_local_run_id()
+            is_planning_request = "<end_plan>" in (stop_sequences or [])
+            if is_planning_request and goal_provider.completion_settlement_pending(
+                local_run_id=local_run_id,
+            ):
+                # Planning is host-side scaffolding, not final delivery. Skip
+                # it locally so the same action step can claim the allowance.
+                return ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content="Goal is complete. Skip planning and deliver the final answer now.",
+                    token_usage=TokenUsage(input_tokens=0, output_tokens=0),
+                )
+            completion_settlement = goal_provider.assert_request_allowed(
+                local_run_id=local_run_id,
+                allow_completion_settlement=not is_planning_request,
+            )
+            if completion_settlement:
+                # Completion may need one more ToolCallingAgent response to
+                # deliver final_answer. Do not expose substantive tools. The
+                # max-steps final fallback has no tool schema and remains a
+                # prose-only settlement request.
+                if tools_to_call_from is not None:
+                    tools_to_call_from = final_answer_tools
+            goal_provider.mark_started()
         current_tools = self._set_current_tools(tools_to_call_from)
         try:
             message = super().generate(
@@ -154,6 +192,25 @@ class LiteLLMModelV2(LiteLLMModel):
                 tools_to_call_from=tools_to_call_from,
                 **kwargs,
             )
+            if goal_provider is not None:
+                usage = getattr(message, "token_usage", None)
+                if usage is not None:
+                    prompt_tokens = getattr(usage, "input_tokens", 0)
+                    completion_tokens = getattr(usage, "output_tokens", 0)
+                    if (
+                        isinstance(prompt_tokens, int)
+                        and not isinstance(prompt_tokens, bool)
+                        and prompt_tokens >= 0
+                        and isinstance(completion_tokens, int)
+                        and not isinstance(completion_tokens, bool)
+                        and completion_tokens >= 0
+                    ):
+                        goal_provider.record_usage(
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=completion_tokens,
+                        )
+                    else:
+                        raise ValueError("Provider returned invalid Goal token usage")
             self._normalize_and_validate_tool_calls(message, list(current_tools))
             # ToolCallingAgent invokes parse_tool_calls(message) immediately
             # after generate() returns. Keep this call's schema in its Context

--- a/src/runner.py
+++ b/src/runner.py
@@ -17,12 +17,15 @@ Usage (CLI)::
 
 from __future__ import annotations
 
+import json
 import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from src.application_revision import application_revision
 from src.application_run import (
+    ApplicationRunBudgetLimited,
     ApplicationRunError,
     ApplicationRunInterrupted,
     ApplicationRunResult,
@@ -34,10 +37,10 @@ from src.application_run import (
     RunRejectedEvent,
     RunRejection,
 )
-from src.application_revision import application_revision
 from src.lib.checkpoint import CheckpointManager
 from src.lib.checkpoint.file_history import FileHistoryManager
 from src.lib.config import C, build_effective_agent_config
+from src.lib.goal import GoalBudgetLimitedError, normalize_goal_config
 from src.lib.heartbeat import SupervisorHeartbeat
 from src.lib.logging import (
     LoggingConfigBuilder,
@@ -191,6 +194,22 @@ def _persist_run_observability(
 
     if checkpoint_mgr is None:
         return manifest_updates
+
+    goal = checkpoint_mgr.load_goal(task_id)
+    if goal is not None:
+        runtime_context.atomic_write_run_file(
+            runtime_context.audit_dir / "goal.json",
+            json.dumps(
+                goal,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
+        manifest_updates.update(
+            goal=goal,
+            goal_artifact="audit/goal.json",
+        )
 
     try:
         runtime_context.atomic_write_run_file_chunks(
@@ -412,7 +431,13 @@ def execute_app(
         try:
             runtime_context.update_manifest(
                 **durable_manifest_updates,
-                status="interrupted" if isinstance(exc, KeyboardInterrupt) else "failed",
+                status=(
+                    "interrupted"
+                    if isinstance(exc, KeyboardInterrupt)
+                    else "budget_limited"
+                    if isinstance(exc, GoalBudgetLimitedError)
+                    else "failed"
+                ),
                 ended_at=datetime.now().astimezone().isoformat(),
                 error=str(exc),
             )
@@ -551,12 +576,31 @@ def execute_app(
                                     "Detected crashed task "
                                     "(process dead, heartbeat stale)"
                                 )
-                        resumable_statuses = {"interrupted", "failed", "crashed"}
+                        resumable_statuses = {
+                            "interrupted",
+                            "failed",
+                            "crashed",
+                            "budget_limited",
+                        }
                         if tree_status not in resumable_statuses:
                             raise ValueError(
                                 f"Checkpoint {task_id} is not resumable "
                                 f"(status={tree_status}); start a new task instead"
                             )
+                        persisted_goal = checkpoint_mgr.load_goal(task_id)
+                        current_goal = normalize_goal_config(
+                            config,
+                            source=str(resolved_path),
+                        )
+                        if persisted_goal is not None and not current_goal.enabled:
+                            raise ValueError(
+                                "Cannot resume: checkpoint contains an active Goal but "
+                                "Goal mode is disabled in YAML"
+                            )
+                        if task_override is None:
+                            persisted_task = tree.get("task_text")
+                            if isinstance(persisted_task, str) and persisted_task.strip():
+                                effective_task = persisted_task
                         checkpoint_mgr.record_run_resumed(task_id)
                         log.info(
                             "Resuming task %s (status=%s)",
@@ -642,19 +686,27 @@ def execute_app(
                     log.info("Task: %s", effective_task[:200])
                     log.info("=" * 70)
 
-                    result = supervisor.run(
+                    agent_result = supervisor.run(
                         effective_task,
                         task_id=task_id,
                         run_id=run_id,
                         checkpoint_manager=checkpoint_mgr,
                         resume=is_resume,
                     )
-                    result_str = "" if result is None else str(result)
+                    result_str = "" if agent_result is None else str(agent_result)
                     phase = "finalization"
                     outcome = "completed"
                     log.info("=" * 70)
                     log.info("Execution completed successfully.")
                     log.info("=" * 70)
+                except GoalBudgetLimitedError as exc:
+                    outcome = "budget_limited"
+                    outcome_error = str(exc)
+                    log.warning(
+                        "Goal token budget reached. Checkpoint preserved for task_id=%s",
+                        task_id,
+                    )
+                    raise
                 except KeyboardInterrupt as exc:
                     outcome = "interrupted"
                     outcome_error = str(exc)
@@ -732,6 +784,9 @@ def execute_app(
                             file_history.close()
                         except Exception:
                             pass
+                    goal_snapshot = getattr(supervisor, "_last_goal_state", None)
+                    if isinstance(goal_snapshot, dict):
+                        durable_manifest_updates["goal"] = dict(goal_snapshot)
                     try:
                         if outcome == "completed":
                             _persist_run_observability(
@@ -864,9 +919,32 @@ def execute_app(
                     occurred_at=ended_at,
                     error=str(interrupted),
                     phase=phase,
+                    goal=durable_manifest_updates.get("goal"),
                 ),
             )
             raise interrupted from terminal_error
+
+        if isinstance(terminal_error, GoalBudgetLimitedError):
+            goal = dict(terminal_error.state.to_dict())
+            limited = ApplicationRunBudgetLimited(
+                str(terminal_error),
+                run=public_run,
+                phase=phase,
+                original_error=terminal_error,
+                goal=goal,
+            )
+            _emit_lifecycle_event(
+                event_sink,
+                RunLifecycleEvent(
+                    event="run.budget_limited",
+                    run=public_run,
+                    occurred_at=ended_at,
+                    error=str(limited),
+                    phase=phase,
+                    goal=goal,
+                ),
+            )
+            raise limited from terminal_error
 
         if not isinstance(terminal_error, Exception):
             detail = str(terminal_error)
@@ -894,15 +972,17 @@ def execute_app(
                 occurred_at=ended_at,
                 error=message,
                 phase=phase,
+                goal=durable_manifest_updates.get("goal"),
             ),
         )
         raise failure from terminal_error
     ended_at = datetime.now().astimezone()
-    result = ApplicationRunResult(
+    application_result = ApplicationRunResult(
         output=result_str,
         run=public_run,
         started_at=started_at,
         ended_at=ended_at,
+        goal=durable_manifest_updates.get("goal"),
     )
     _emit_lifecycle_event(
         event_sink,
@@ -911,9 +991,10 @@ def execute_app(
             run=public_run,
             occurred_at=ended_at,
             output=result_str,
+            goal=durable_manifest_updates.get("goal"),
         ),
     )
-    return result
+    return application_result
 
 
 def run_app(
@@ -936,6 +1017,8 @@ def run_app(
             file_logging=file_logging,
         ).output
     except ApplicationRunInterrupted as exc:
+        raise exc.original_error from exc
+    except ApplicationRunBudgetLimited as exc:
         raise exc.original_error from exc
     except ApplicationRunError as exc:
         if exc.phase != "execution" or isinstance(

--- a/src/schedules/runner.py
+++ b/src/schedules/runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import socket
@@ -46,7 +47,34 @@ class ScheduleRunner:
             "src",
             "run",
             str(job["yaml_path"]),
+            "--output-format",
+            "jsonl",
         ]
+
+    def _goal_budget_event(self, execution_id: str) -> dict[str, Any] | None:
+        """Return a canonical budget event emitted by the isolated JSONL CLI."""
+
+        try:
+            stdout = self.store.read_execution_stdout(execution_id)
+        except (OSError, RuntimeError, ValueError):
+            return None
+        for line in reversed(stdout.splitlines()):
+            try:
+                payload = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(payload, dict) or payload.get("event") != "run.budget_limited":
+                continue
+            goal = payload.get("goal")
+            run = payload.get("run")
+            if (
+                isinstance(goal, dict)
+                and goal.get("status") == "budget_limited"
+                and isinstance(run, dict)
+                and isinstance(run.get("task_id"), str)
+            ):
+                return payload
+        return None
 
     @staticmethod
     def _process_group_exists(process_group_id: int) -> bool:
@@ -142,6 +170,8 @@ class ScheduleRunner:
         process: subprocess.Popen[bytes] | None = None
         exit_code: int | None = None
         error: str | None = None
+        terminal_status: str | None = None
+        goal: dict[str, Any] | None = None
         heartbeat_every = max(0.1, min(30.0, self.store.claim_lease_seconds / 3))
         last_heartbeat = time.monotonic()
 
@@ -185,6 +215,14 @@ class ScheduleRunner:
                     time.sleep(self.poll_seconds)
             if exit_code != 0:
                 error = f"process exited with status {exit_code}"
+                budget_event = self._goal_budget_event(execution_id)
+                if budget_event is not None:
+                    terminal_status = "budget_limited"
+                    goal = budget_event["goal"]
+                    error = str(
+                        budget_event.get("error")
+                        or "Goal token budget exhausted; increase or remove token_budget and resume"
+                    )
         except BaseException as exc:
             if process is not None:
                 self._terminate_process_tree(process)
@@ -200,6 +238,8 @@ class ScheduleRunner:
             stdout_path=stdout_relative,
             stderr_path=stderr_relative,
             error=error,
+            terminal_status=terminal_status,
+            goal=goal,
         )
         if progress is not None:
             progress()

--- a/src/schedules/store.py
+++ b/src/schedules/store.py
@@ -24,6 +24,7 @@ EXECUTION_COMMAND_MAX_BYTES = 4 * 1024
 EXECUTION_COMMAND_ITEM_MAX_BYTES = 1024
 EXECUTION_ERROR_MAX_BYTES = 4 * 1024
 EXECUTION_JOB_NAME_MAX_BYTES = 512
+EXECUTION_GOAL_TEXT_MAX_BYTES = 4 * 1024
 
 
 class ScheduleStoreError(RuntimeError):
@@ -312,6 +313,20 @@ class ScheduleStore:
                 exclusive=True,
             ) as stderr_handle:
                 yield stdout_handle, stderr_handle
+
+    def read_execution_stdout(self, execution_id: str, *, max_bytes: int = 256 * 1024) -> str:
+        """Read the bounded tail of one execution's stdout from anchored storage."""
+
+        self._execution_log_paths(execution_id)
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
+        stdout_name = f"{execution_id}.stdout.log"
+        with self._executions_storage.open_binary_reader(stdout_name) as stream:
+            stream.seek(0, 2)
+            size = stream.tell()
+            stream.seek(max(0, size - max_bytes))
+            payload = stream.read(max_bytes)
+        return payload.decode("utf-8", errors="replace")
 
     def close(self) -> None:
         self._executions_storage.close()
@@ -619,12 +634,44 @@ class ScheduleStore:
         stdout_path: str,
         stderr_path: str,
         error: str | None = None,
+        terminal_status: str | None = None,
+        goal: dict[str, Any] | None = None,
         now: datetime | None = None,
     ) -> dict[str, Any]:
         finished_at = _as_utc(now)
         expected_stdout, expected_stderr = self._execution_log_paths(execution_id)
         if (stdout_path, stderr_path) != (expected_stdout, expected_stderr):
             raise ValueError("stdout_path and stderr_path must be canonical execution log paths")
+        if terminal_status not in {None, "budget_limited"}:
+            raise ValueError(f"unsupported schedule terminal status: {terminal_status}")
+        bounded_goal: dict[str, Any] | None = None
+        if goal is not None:
+            if terminal_status != "budget_limited" or goal.get("status") != "budget_limited":
+                raise ValueError("schedule Goal diagnostics require budget_limited status")
+            bounded_goal = {
+                key: (
+                    self._bounded_text(value, EXECUTION_GOAL_TEXT_MAX_BYTES)
+                    if key in {"objective", "evidence"} and value is not None
+                    else value
+                )
+                for key, value in goal.items()
+                if key
+                in {
+                    "schema_version",
+                    "goal_id",
+                    "status",
+                    "objective",
+                    "token_budget",
+                    "prompt_tokens",
+                    "completion_tokens",
+                    "used_tokens",
+                    "remaining_tokens",
+                    "evidence",
+                    "created_at",
+                    "updated_at",
+                    "completed_at",
+                }
+            }
         with self._locked(exclusive=True):
             payload = self._read_unlocked()
             execution = self._find_execution(payload, execution_id)
@@ -637,9 +684,10 @@ class ScheduleStore:
             if error is not None:
                 error = self._bounded_text(error, EXECUTION_ERROR_MAX_BYTES)
             success = exit_code == 0 and error is None
+            status = terminal_status or ("succeeded" if success else "failed")
             execution.update(
                 {
-                    "status": "succeeded" if success else "failed",
+                    "status": status,
                     "finished_at": finished_at.isoformat(),
                     "exit_code": exit_code,
                     "stdout_path": expected_stdout,
@@ -647,6 +695,8 @@ class ScheduleStore:
                     "error": error,
                 }
             )
+            if bounded_goal is not None:
+                execution["goal"] = bounded_goal
             job["claim"] = None
             job["last_run_at"] = finished_at.isoformat()
             job["last_status"] = execution["status"]

--- a/src/tools/goal/__init__.py
+++ b/src/tools/goal/__init__.py
@@ -1,0 +1,5 @@
+"""Supervisor-only Goal tools."""
+
+from .goal_tools import get_goal, update_goal
+
+__all__ = ["get_goal", "update_goal"]

--- a/src/tools/goal/goal_tools.py
+++ b/src/tools/goal/goal_tools.py
@@ -1,0 +1,77 @@
+"""Model-facing tools for observing and completing the root Goal."""
+
+from __future__ import annotations
+
+import json
+
+from src.lib.smolagents.tools.tools import tool
+
+
+def _require_root_goal_provider():
+    from src.lib.goal import get_current_goal_provider, normalize_goal_config
+    from src.trace import (
+        get_current_hook_run,
+        require_local_run_id,
+        require_root_run_id,
+    )
+
+    if require_local_run_id() != require_root_run_id():
+        raise PermissionError("Goal tools are available only to the root Supervisor Agent")
+    hook_run = get_current_hook_run(required=True)
+    if hook_run.parent is not None:
+        raise PermissionError("Goal tools are available only to the root Supervisor Agent")
+    config = hook_run.agent_config
+    if not isinstance(config, dict) or not normalize_goal_config(
+        config,
+        source="active Supervisor",
+    ).enabled:
+        raise PermissionError("Goal mode is not enabled for the root Supervisor Agent")
+    return get_current_goal_provider(required=True)
+
+
+@tool
+def get_goal() -> str:
+    """Return the root task's canonical Goal status and cumulative token usage.
+
+    Use this to inspect the objective, completion state, and remaining soft
+    token budget. This tool is restricted to the root Supervisor Agent.
+
+    Returns:
+        JSON containing the complete canonical Goal snapshot.
+    """
+
+    provider = _require_root_goal_provider()
+    return json.dumps(
+        provider.snapshot().to_dict(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+@tool
+def update_goal(status: str, evidence: str) -> str:
+    """Mark the root Goal complete with durable, non-empty evidence.
+
+    Call this only after the full objective has been delivered and verified.
+    A normal final answer does not complete a Goal. The only accepted status is
+    complete. Completion is terminal and idempotent. This tool is restricted
+    to the root Supervisor Agent.
+
+    Args:
+        status: Must be exactly complete.
+        evidence: Concise evidence describing what was delivered and verified.
+
+    Returns:
+        JSON containing the committed canonical Goal snapshot.
+    """
+
+    if status != "complete":
+        raise ValueError("update_goal status must be 'complete'")
+    from src.trace import require_local_run_id
+
+    provider = _require_root_goal_provider()
+    state = provider.complete(
+        evidence,
+        settlement_run_id=require_local_run_id(),
+    )
+    return json.dumps(state.to_dict(), ensure_ascii=False, separators=(",", ":"))

--- a/src/tui_bridge/bridge.py
+++ b/src/tui_bridge/bridge.py
@@ -57,6 +57,7 @@ _TERMINAL_RUN_STATUS_ALIASES = {
     "cancelled": "interrupted",
     "canceled": "interrupted",
     "crashed": "crashed",
+    "budget_limited": "budget_limited",
     "unknown": "unknown",
 }
 
@@ -755,6 +756,12 @@ class TuiBridge:
             application_id=application_id,
             system_id=system_id,
         )
+        goal = self._goal_projection(
+            manifest,
+            runtime_root=runtime_root,
+            application_id=application_id,
+            task_id=task_id,
+        )
         summary = {
             "run_id": run_id,
             "system_id": linked_system_id,
@@ -765,6 +772,8 @@ class TuiBridge:
             "started_at": self._optional_string(manifest.get("started_at")),
             "ended_at": self._optional_string(manifest.get("ended_at")),
         }
+        if goal is not None:
+            summary["goal"] = goal
         return {
             "summary": summary,
             "manifest": manifest,
@@ -841,6 +850,8 @@ class TuiBridge:
         status = str(record["summary"].get("status") or "").strip().lower()
         if status == "interrupted":
             return "Execution was interrupted before completion."
+        if status == "budget_limited":
+            return "Goal token budget was reached; increase or remove token_budget before resume."
         if status == "crashed":
             return "Execution stopped unexpectedly before completion."
         if status == "unknown":
@@ -953,7 +964,13 @@ class TuiBridge:
                 worker = self._checkpoint_worker_summary(raw_worker)
                 parent_status = str(candidate_run.get("status") or "")
                 worker_status = str(worker.get("status") or "").strip().lower()
-                if parent_status in {"completed", "failed", "interrupted", "crashed"} and worker_status in {
+                if parent_status in {
+                    "completed",
+                    "failed",
+                    "interrupted",
+                    "crashed",
+                    "budget_limited",
+                } and worker_status in {
                     "running",
                     "claimed",
                     "in_progress",
@@ -1599,6 +1616,12 @@ class TuiBridge:
             systems_by_application=systems_by_application,
         )
         status = self._run_status(manifest, task=task, run_dir=run_dir)
+        goal = self._goal_projection(
+            manifest,
+            runtime_root=runtime_root,
+            application_id=application_id,
+            task_id=task_id,
+        )
         summary = {
             "run_id": run_id,
             "system_id": system_id,
@@ -1609,6 +1632,8 @@ class TuiBridge:
             "started_at": self._optional_string(manifest.get("started_at")),
             "ended_at": self._optional_string(manifest.get("ended_at")),
         }
+        if goal is not None:
+            summary["goal"] = goal
         return (
             (application_id, run_id),
             {
@@ -1948,6 +1973,26 @@ class TuiBridge:
         if status == "running":
             return "crashed"
         return "unknown"
+
+    def _goal_projection(
+        self,
+        manifest: dict[str, Any],
+        *,
+        runtime_root: Path,
+        application_id: str,
+        task_id: str,
+    ) -> dict[str, Any] | None:
+        goal = manifest.get("goal")
+        if isinstance(goal, dict):
+            return copy.deepcopy(goal)
+        return self._read_json_object_bounded_secure(
+            runtime_root,
+            Path("checkpoints")
+            / Path(*application_id.split("/"))
+            / task_id
+            / "goal.json",
+            max_bytes=RUN_MANIFEST_MAX_BYTES,
+        )
 
     def _task_events(
         self,

--- a/src/tui_bridge/domain_cli.py
+++ b/src/tui_bridge/domain_cli.py
@@ -328,7 +328,11 @@ def _run_application(
     if action == "run.resume" and not isinstance(resume_task_id, str):
         raise BridgeError("invalid_params", "run.resume requires task_id")
 
-    from src.application_run import ApplicationRunError, ApplicationRunInterrupted
+    from src.application_run import (
+        ApplicationRunBudgetLimited,
+        ApplicationRunError,
+        ApplicationRunInterrupted,
+    )
     from src.runner import execute_app
 
     events: list[dict[str, Any]] = []
@@ -357,6 +361,16 @@ def _run_application(
             "task_id": error.run.task_id,
             "run_id": error.run.run_id,
             "resumable": error.resumable,
+            "events": events[-8:],
+        }
+    except ApplicationRunBudgetLimited as error:
+        return {
+            "status": "budget_limited",
+            "application_id": error.run.application_id,
+            "task_id": error.run.task_id,
+            "run_id": error.run.run_id,
+            "resumable": True,
+            "goal": dict(error.goal),
             "events": events[-8:],
         }
     except ApplicationRunError as error:

--- a/tests/agent_test/llm_cfg_test/test_supervisor_task_spec_format.py
+++ b/tests/agent_test/llm_cfg_test/test_supervisor_task_spec_format.py
@@ -100,3 +100,26 @@ def test_transform_tasks_list_workflow_empty_task_returns_raw_items():
         "First workflow item.\nUse exactly this instruction.",
         "Second workflow item.\nContinue from previous memory.",
     ]
+
+
+def test_goal_mode_merges_list_workflow_into_one_goal_context():
+    supervisor = object.__new__(YamlConfiguredSupervisorAgent)
+    supervisor._config = {
+        "name": "goal_workflow",
+        "description": "Deliver the complete change.",
+        "workflow": [
+            "Inspect the implementation.",
+            "Implement and verify the change.",
+        ],
+        "goal": {"enabled": True},
+    }
+    supervisor._logger = None
+
+    transformed_tasks = supervisor._transform_tasks("Add Goal mode.")
+
+    assert len(transformed_tasks) == 1
+    prompt = transformed_tasks[0]
+    assert "1. Inspect the implementation." in prompt
+    assert "2. Implement and verify the change." in prompt
+    assert "Deliver the complete change." in prompt
+    assert "Add Goal mode." in prompt

--- a/tests/agent_test/runtime_builder_test/test_runtime_builder.py
+++ b/tests/agent_test/runtime_builder_test/test_runtime_builder.py
@@ -126,6 +126,14 @@ class DummyToolCallingAgent(base_agent_module.RoleDrivenAgent):
         return []
 
 
+class DummyGoalAgent(DummyAgent):
+    def _role_profile(self) -> base_agent_module.AgentRoleProfile:
+        return base_agent_module.AgentRoleProfile(
+            agent_type=base_agent_module.AgentType.SUPERVISOR,
+            tool_call_type="code_act",
+        )
+
+
 def _make_agent(*, logger=None) -> DummyAgent:
     agent = DummyAgent(
         config={"name": "runtime_dummy"},
@@ -1676,6 +1684,236 @@ def test_base_run_executes_transformed_tasks_sequentially_with_reset_false(tmp_p
             "reset": False,
         },
     ]
+
+
+def test_goal_mode_continues_after_normal_final_until_update_goal(monkeypatch):
+    from src.lib.goal import get_current_goal_provider
+
+    agent = DummyGoalAgent(
+        config={
+            "name": "goal-runtime",
+            "description": "Finish all work.",
+            "workflow": "Implement and verify.",
+            "goal": {"enabled": True},
+        },
+        model=object(),
+        logger=DummyLoggerBackend(),
+    )
+    runtime = DummyRuntimeRunner()
+
+    def _run(*, task, **kwargs):
+        runtime.calls.append({"task": task, **kwargs})
+        if len(runtime.calls) == 2:
+            get_current_goal_provider(required=True).complete("implemented; tests passed")
+        return DummyRunResult(f"segment-{len(runtime.calls)}", state="success")
+
+    runtime.run = _run
+    monkeypatch.setattr(agent, "build_runtime_agent", lambda: runtime)
+    monkeypatch.setattr(agent, "_inject_memory_snapshot", lambda tasks: tasks)
+
+    result = agent.run("Add Goal mode", task_id="goal-task")
+
+    assert result == "segment-2"
+    assert len(runtime.calls) == 2
+    assert runtime.calls[0]["task"] == "Add Goal mode"
+    assert "Continue working toward the active Goal" in runtime.calls[1]["task"]
+    assert "Implement and verify." not in runtime.calls[1]["task"]
+    assert "Goal ID: goal_" in runtime.calls[1]["task"]
+    assert runtime.calls[1]["reset"] is False
+
+
+def test_goal_mode_treats_max_steps_as_continuation_boundary(monkeypatch):
+    from src.lib.goal import get_current_goal_provider
+
+    agent = DummyGoalAgent(
+        config={
+            "name": "goal-runtime",
+            "description": "Finish all work.",
+            "workflow": "Implement and verify.",
+            "goal": True,
+        },
+        model=object(),
+        logger=DummyLoggerBackend(),
+    )
+    runtime = DummyRuntimeRunner()
+
+    def _run(*, task, **kwargs):
+        runtime.calls.append({"task": task, **kwargs})
+        if len(runtime.calls) == 2:
+            get_current_goal_provider(required=True).complete("done")
+        state = "max_steps_error" if len(runtime.calls) == 1 else "success"
+        output = "segment" if len(runtime.calls) == 1 else "done"
+        return DummyRunResult(output, state=state)
+
+    runtime.run = _run
+    monkeypatch.setattr(agent, "build_runtime_agent", lambda: runtime)
+    monkeypatch.setattr(agent, "_inject_memory_snapshot", lambda tasks: tasks)
+
+    assert agent.run("Add Goal mode", task_id="goal-task") == "done"
+    assert len(runtime.calls) == 2
+
+
+def test_goal_mode_uses_evidence_when_max_steps_final_delivery_failed(monkeypatch):
+    from src.lib.goal import get_current_goal_provider
+
+    agent = DummyGoalAgent(
+        config={
+            "name": "goal-runtime",
+            "description": "Finish all work.",
+            "workflow": "Implement and verify.",
+            "goal": True,
+        },
+        model=object(),
+        logger=DummyLoggerBackend(),
+    )
+    runtime = DummyRuntimeRunner()
+
+    def _run(*, task, **kwargs):
+        runtime.calls.append({"task": task, **kwargs})
+        get_current_goal_provider(required=True).complete("durable evidence")
+        return DummyRunResult(
+            "Error in generating final LLM output: Goal is already complete",
+            state="max_steps_error",
+        )
+
+    runtime.run = _run
+    monkeypatch.setattr(agent, "build_runtime_agent", lambda: runtime)
+    monkeypatch.setattr(agent, "_inject_memory_snapshot", lambda tasks: tasks)
+
+    assert agent.run("Add Goal mode", task_id="goal-task") == "durable evidence"
+
+
+def test_goal_mode_stops_before_next_segment_after_soft_budget_crossing(monkeypatch):
+    from src.lib.goal import GoalBudgetLimitedError, get_current_goal_provider
+
+    agent = DummyGoalAgent(
+        config={
+            "name": "goal-runtime",
+            "description": "Finish all work.",
+            "workflow": "Implement and verify.",
+            "goal": {"enabled": True, "token_budget": 100},
+        },
+        model=object(),
+        logger=DummyLoggerBackend(),
+    )
+    runtime = DummyRuntimeRunner()
+
+    def _run(*, task, **kwargs):
+        runtime.calls.append({"task": task, **kwargs})
+        get_current_goal_provider(required=True).record_usage(
+            prompt_tokens=90,
+            completion_tokens=20,
+        )
+        return DummyRunResult("ordinary final")
+
+    runtime.run = _run
+    monkeypatch.setattr(agent, "build_runtime_agent", lambda: runtime)
+    monkeypatch.setattr(agent, "_inject_memory_snapshot", lambda tasks: tasks)
+
+    with pytest.raises(GoalBudgetLimitedError):
+        agent.run("Add Goal mode", task_id="goal-task")
+    assert len(runtime.calls) == 1
+
+
+def test_goal_mode_resume_after_completion_commit_does_not_restart_work(
+    tmp_path,
+    monkeypatch,
+):
+    from src.lib.checkpoint import CheckpointManager
+    from src.lib.goal import get_current_goal_provider
+
+    config = {
+        "name": "goal-runtime",
+        "description": "Finish all work.",
+        "workflow": "Implement and verify.",
+        "goal": True,
+    }
+    manager = CheckpointManager("goal-runtime", checkpoints_root=tmp_path)
+    first_agent = DummyGoalAgent(
+        config=config,
+        model=object(),
+        logger=DummyLoggerBackend(),
+    )
+    first_runtime = DummyRuntimeRunner()
+
+    def _commit_then_interrupt(*, task, **kwargs):
+        first_runtime.calls.append({"task": task, **kwargs})
+        get_current_goal_provider(required=True).complete("delivered; tests passed")
+        raise KeyboardInterrupt("crash after completion commit")
+
+    first_runtime.run = _commit_then_interrupt
+    monkeypatch.setattr(first_agent, "build_runtime_agent", lambda: first_runtime)
+    monkeypatch.setattr(first_agent, "_inject_memory_snapshot", lambda tasks: tasks)
+
+    with pytest.raises(KeyboardInterrupt):
+        first_agent.run(
+            "Add Goal mode",
+            task_id="goal-complete-crash",
+            checkpoint_manager=manager,
+        )
+
+    persisted = manager.load_goal("goal-complete-crash")
+    assert persisted["status"] == "complete"
+    assert persisted["evidence"] == "delivered; tests passed"
+
+    resumed_agent = DummyGoalAgent(
+        config=config,
+        model=object(),
+        logger=DummyLoggerBackend(),
+    )
+    resumed_runtime = DummyRuntimeRunner()
+    monkeypatch.setattr(resumed_agent, "build_runtime_agent", lambda: resumed_runtime)
+    monkeypatch.setattr(resumed_agent, "_inject_memory_snapshot", lambda tasks: tasks)
+
+    result = resumed_agent.run(
+        "Add Goal mode",
+        task_id="goal-complete-crash",
+        checkpoint_manager=manager,
+        resume=True,
+    )
+
+    assert result == "delivered; tests passed"
+    assert resumed_runtime.calls == []
+    assert manager.load_goal("goal-complete-crash")["goal_id"] == persisted["goal_id"]
+
+
+@pytest.mark.parametrize("goal", [None, False, {"enabled": False}])
+def test_goal_tools_are_absent_when_goal_mode_is_disabled(monkeypatch, goal):
+    config = {
+        "name": "goal-runtime",
+        "description": "Finish all work.",
+        "workflow": "Implement and verify.",
+        "todo": {"mode": "off"},
+    }
+    if goal is not None:
+        config["goal"] = goal
+    agent = DummyGoalAgent(
+        config=config,
+        model=object(),
+        logger=DummyLoggerBackend(),
+    )
+    monkeypatch.setattr(agent, "get_all_tools", lambda agent_type: [])
+
+    assert agent._build_runtime_tools(agent._role_profile()) == []
+
+
+def test_goal_tools_are_added_only_for_enabled_root_supervisor(monkeypatch):
+    agent = DummyGoalAgent(
+        config={
+            "name": "goal-runtime",
+            "description": "Finish all work.",
+            "workflow": "Implement and verify.",
+            "goal": True,
+            "todo": {"mode": "off"},
+        },
+        model=object(),
+        logger=DummyLoggerBackend(),
+    )
+    monkeypatch.setattr(agent, "get_all_tools", lambda agent_type: [])
+
+    names = {tool.name for tool in agent._build_runtime_tools(agent._role_profile())}
+
+    assert names == {"get_goal", "update_goal"}
 
 
 def test_loom_runtime_can_keep_task_step_for_sequential_reset_false():

--- a/tests/goal_test/test_goal_config.py
+++ b/tests/goal_test/test_goal_config.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import pytest
+
+from src.lib.goal import GoalConfig, normalize_goal_config
+from src.lib.smolagents.agent.runtime_validation import (
+    validate_runtime_agent_config,
+    validate_runtime_worker_config,
+)
+
+
+def _config(**overrides):
+    return {
+        "name": "goal-test",
+        "description": "Finish the requested work.",
+        "workflow": "Inspect, implement, and verify.",
+        "tools": [],
+        **overrides,
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, GoalConfig(enabled=False, token_budget=None)),
+        (False, GoalConfig(enabled=False, token_budget=None)),
+        (True, GoalConfig(enabled=True, token_budget=None)),
+        ({"enabled": False}, GoalConfig(enabled=False, token_budget=None)),
+        ({"enabled": True}, GoalConfig(enabled=True, token_budget=None)),
+        (
+            {"enabled": True, "token_budget": 120_000},
+            GoalConfig(enabled=True, token_budget=120_000),
+        ),
+    ],
+)
+def test_normalize_goal_config_accepts_only_supported_forms(raw, expected):
+    config = {} if raw is None else {"goal": raw}
+    assert normalize_goal_config(config, source="agent.yaml") == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {},
+        {"token_budget": 10},
+        {"enabled": "true"},
+        {"enabled": True, "token_budget": None},
+        {"enabled": True, "token_budget": True},
+        {"enabled": True, "token_budget": "10"},
+        {"enabled": True, "token_budget": 0},
+        {"enabled": True, "token_budget": -1},
+        {"enabled": False, "token_budget": 10},
+        {"enabled": True, "unknown": 1},
+        [],
+        "true",
+    ],
+)
+def test_normalize_goal_config_rejects_ambiguous_or_invalid_forms(raw):
+    with pytest.raises(ValueError, match="goal"):
+        normalize_goal_config({"goal": raw}, source="agent.yaml")
+
+
+def test_runtime_supervisor_validation_accepts_goal(tmp_path: Path):
+    validate_runtime_agent_config(
+        _config(goal={"enabled": True, "token_budget": 100}),
+        tmp_path / "supervisor.yaml",
+        agent_root=tmp_path,
+    )
+
+
+@pytest.mark.parametrize("goal", [False, True, {"enabled": False}, {"enabled": True}])
+def test_runtime_worker_validation_rejects_any_goal_key(tmp_path: Path, goal):
+    config = _config(
+        goal=goal,
+        agent_function_schema={
+            "description": "worker",
+            "inputs": {"task": {"description": "task"}},
+            "output": {"description": "result"},
+        },
+    )
+    with pytest.raises(ValueError, match="Worker Agent.*goal"):
+        validate_runtime_worker_config(
+            config,
+            tmp_path / "worker.yaml",
+            agent_root=tmp_path,
+        )

--- a/tests/goal_test/test_goal_model_accounting.py
+++ b/tests/goal_test/test_goal_model_accounting.py
@@ -1,0 +1,209 @@
+from types import SimpleNamespace
+
+import pytest
+from smolagents import LiteLLMModel
+
+from src.lib.goal import GoalBudgetLimitedError, GoalCompleteError, GoalState
+from src.lib.goal.provider import GoalStateProvider, bind_goal_state_provider
+from src.lib.smolagents.memory.context_compression import (
+    InternalChatMessage,
+    summarize_conversation,
+)
+from src.lib.smolagents.models.litellm_model import LiteLLMModelV2
+from src.trace import bind_local_run
+
+
+def _model():
+    model = object.__new__(LiteLLMModelV2)
+    model._normalize_and_validate_tool_calls = lambda *_args: None
+    return model
+
+
+def _provider(budget=100):
+    return GoalStateProvider(
+        GoalState.create(
+            objective="Ship.",
+            objective_fingerprint="abc",
+            token_budget=budget,
+        )
+    )
+
+
+def test_model_response_usage_is_charged_once_and_next_request_is_fenced(monkeypatch):
+    calls = 0
+
+    def fake_generate(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(
+            token_usage=SimpleNamespace(input_tokens=80, output_tokens=25)
+        )
+
+    monkeypatch.setattr(LiteLLMModel, "generate", fake_generate)
+    provider = _provider()
+    model = _model()
+
+    with bind_goal_state_provider(provider):
+        model.generate([])
+        with pytest.raises(GoalBudgetLimitedError):
+            model.generate([])
+
+    assert calls == 1
+    assert provider.snapshot().used_tokens == 105
+    assert provider.snapshot().goal_started is True
+
+
+def test_worker_and_supervisor_responses_aggregate_through_shared_provider(monkeypatch):
+    def fake_generate(self, *args, **kwargs):
+        return SimpleNamespace(
+            token_usage=SimpleNamespace(input_tokens=10, output_tokens=5)
+        )
+
+    monkeypatch.setattr(LiteLLMModel, "generate", fake_generate)
+    provider = _provider(budget=None)
+
+    with bind_goal_state_provider(provider):
+        _model().generate([])
+        _model().generate([])
+
+    assert provider.snapshot().prompt_tokens == 20
+    assert provider.snapshot().completion_tokens == 10
+
+
+def test_completion_allows_one_root_final_answer_settlement_request(monkeypatch):
+    observed_tools: list[list[str]] = []
+
+    def fake_generate(self, *args, **kwargs):
+        observed_tools.append(
+            [tool.name for tool in kwargs.get("tools_to_call_from") or []]
+        )
+        return SimpleNamespace(
+            token_usage=SimpleNamespace(input_tokens=10, output_tokens=5)
+        )
+
+    monkeypatch.setattr(LiteLLMModel, "generate", fake_generate)
+    provider = _provider(budget=None)
+    provider.complete("Delivered.", settlement_run_id="root")
+    tools = [
+        SimpleNamespace(name="get_goal"),
+        SimpleNamespace(name="final_answer"),
+    ]
+
+    with bind_goal_state_provider(provider):
+        with bind_local_run("worker"):
+            with pytest.raises(GoalCompleteError):
+                _model().generate([], tools_to_call_from=tools)
+        with bind_local_run("root"):
+            _model().generate([], tools_to_call_from=tools)
+            with pytest.raises(GoalCompleteError):
+                _model().generate([], tools_to_call_from=tools)
+
+    assert observed_tools == [["final_answer"]]
+    assert provider.snapshot().status == "complete"
+    assert provider.snapshot().used_tokens == 15
+
+
+def test_completion_skips_planning_before_claiming_final_settlement(monkeypatch):
+    observed_tools: list[list[str]] = []
+
+    def fake_generate(self, *args, **kwargs):
+        observed_tools.append(
+            [tool.name for tool in kwargs.get("tools_to_call_from") or []]
+        )
+        return SimpleNamespace(
+            token_usage=SimpleNamespace(input_tokens=10, output_tokens=5)
+        )
+
+    monkeypatch.setattr(LiteLLMModel, "generate", fake_generate)
+    provider = _provider(budget=None)
+    provider.complete("Delivered.", settlement_run_id="root")
+    tools = [
+        SimpleNamespace(name="get_goal"),
+        SimpleNamespace(name="final_answer"),
+    ]
+
+    with bind_goal_state_provider(provider), bind_local_run("root"):
+        plan = _model().generate([], stop_sequences=["<end_plan>"])
+        _model().generate([], tools_to_call_from=tools)
+
+    assert plan.content == "Goal is complete. Skip planning and deliver the final answer now."
+    assert plan.token_usage.input_tokens == 0
+    assert observed_tools == [["final_answer"]]
+
+
+def test_max_steps_prose_fallback_can_claim_final_settlement(monkeypatch):
+    observed_tools: list[object] = []
+
+    def fake_generate(self, *args, **kwargs):
+        observed_tools.append(kwargs.get("tools_to_call_from"))
+        return SimpleNamespace(
+            token_usage=SimpleNamespace(input_tokens=10, output_tokens=5)
+        )
+
+    monkeypatch.setattr(LiteLLMModel, "generate", fake_generate)
+    provider = _provider(budget=None)
+    provider.complete("Delivered.", settlement_run_id="root")
+
+    with bind_goal_state_provider(provider), bind_local_run("root"):
+        _model().generate([])
+
+    assert observed_tools == [None]
+
+
+def test_budget_crossing_does_not_grant_completion_settlement(monkeypatch):
+    calls = 0
+
+    def fake_generate(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(token_usage=None)
+
+    monkeypatch.setattr(LiteLLMModel, "generate", fake_generate)
+    provider = _provider(budget=100)
+    provider.record_usage(prompt_tokens=90, completion_tokens=20)
+    provider.complete("Delivered.", settlement_run_id="root")
+
+    with bind_goal_state_provider(provider), bind_local_run("root"):
+        with pytest.raises(GoalBudgetLimitedError):
+            _model().generate(
+                [],
+                tools_to_call_from=[SimpleNamespace(name="final_answer")],
+            )
+
+    assert calls == 0
+
+
+def test_smart_summary_cannot_consume_completion_settlement(monkeypatch):
+    from smolagents.models import ChatMessage, MessageRole
+
+    from src.lib.smolagents.memory import context_compression
+
+    monkeypatch.setattr(
+        context_compression.model_manager,
+        "get_smolagents_model",
+        lambda *_args, **_kwargs: pytest.fail("summary model must not be called"),
+    )
+    provider = _provider(budget=None)
+    provider.complete("Delivered.", settlement_run_id="root")
+    messages = [
+        InternalChatMessage(ChatMessage(role=MessageRole.USER, content="task")),
+        InternalChatMessage(ChatMessage(role=MessageRole.ASSISTANT, content="done")),
+    ]
+
+    with bind_goal_state_provider(provider), bind_local_run("root"):
+        result = summarize_conversation(messages, "summary-model")
+
+    assert result.error == "Goal completion settlement pending; smart summary skipped"
+    assert provider.completion_settlement_pending(local_run_id="root") is True
+
+
+def test_restored_complete_goal_has_no_final_delivery_allowance():
+    completed = _provider(budget=None)
+    completed.complete("Delivered.", settlement_run_id="root")
+    restored = GoalStateProvider(completed.snapshot())
+
+    with pytest.raises(GoalCompleteError):
+        restored.assert_request_allowed(
+            local_run_id="root",
+            allow_completion_settlement=True,
+        )

--- a/tests/goal_test/test_goal_state.py
+++ b/tests/goal_test/test_goal_state.py
@@ -1,0 +1,150 @@
+import threading
+
+import pytest
+
+from src.lib.checkpoint import CheckpointManager
+from src.lib.checkpoint.coordinator import CheckpointCoordinator
+from src.lib.goal import GoalConfig, GoalState
+from src.lib.goal.provider import (
+    GoalBudgetLimitedError,
+    GoalStateProvider,
+    bind_goal_state_provider,
+    get_current_goal_provider,
+)
+
+
+def _state(*, budget=100) -> GoalState:
+    return GoalState.create(
+        objective="Ship Goal mode.",
+        objective_fingerprint="abc123",
+        token_budget=budget,
+    )
+
+
+def test_goal_state_soft_budget_counts_prompt_and_completion_tokens():
+    state = _state(budget=100).with_usage(80, 25)
+
+    assert state.used_tokens == 105
+    assert state.status == "budget_limited"
+
+
+def test_goal_state_exact_budget_boundary_is_limited():
+    state = _state(budget=100).with_usage(75, 25)
+
+    assert state.used_tokens == 100
+    assert state.to_dict()["remaining_tokens"] == 0
+    assert state.status == "budget_limited"
+
+
+def test_goal_state_unlimited_budget_never_limits():
+    state = _state(budget=None).with_usage(1_000_000, 500_000)
+
+    assert state.used_tokens == 1_500_000
+    assert state.status == "active"
+
+
+def test_goal_state_resume_budget_may_increase_or_be_removed_but_not_decrease():
+    state = _state(budget=100).with_usage(90, 20)
+
+    assert state.with_resumed_budget(200).status == "active"
+    assert state.with_resumed_budget(None).status == "active"
+    with pytest.raises(ValueError, match="cannot be decreased"):
+        state.with_resumed_budget(50)
+
+    with pytest.raises(ValueError, match="cannot be decreased"):
+        _state(budget=None).with_resumed_budget(200)
+
+
+def test_goal_provider_serializes_parallel_in_flight_usage_after_soft_crossing():
+    provider = GoalStateProvider(_state(budget=100))
+    barrier = threading.Barrier(4)
+    errors: list[BaseException] = []
+
+    def finish_in_flight_response() -> None:
+        try:
+            provider.assert_request_allowed()
+            barrier.wait(timeout=2)
+            provider.record_usage(prompt_tokens=25, completion_tokens=10)
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=finish_in_flight_response) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert errors == []
+    assert provider.snapshot().used_tokens == 140
+    assert provider.snapshot().status == "budget_limited"
+    with pytest.raises(GoalBudgetLimitedError):
+        provider.assert_request_allowed()
+
+
+def test_checkpoint_goal_state_roundtrip_and_corruption_is_fatal(tmp_path):
+    manager = CheckpointManager("supervisor", checkpoints_root=tmp_path)
+    state = _state()
+
+    manager.save_goal("task-1", state.to_dict())
+    assert manager.load_goal("task-1") == state.to_dict()
+
+    goal_path = tmp_path / "task-1" / "goal.json"
+    goal_path.write_text("{broken", encoding="utf-8")
+    with pytest.raises(ValueError, match="corrupt Goal state"):
+        manager.load_goal("task-1")
+
+
+def test_provider_persists_usage_and_fences_later_requests(tmp_path):
+    manager = CheckpointManager("supervisor", checkpoints_root=tmp_path)
+    coord = CheckpointCoordinator.activate(manager, "task-1", "task")
+    try:
+        provider = GoalStateProvider.initialize(
+            config=GoalConfig(enabled=True, token_budget=100),
+            objective="Ship Goal mode.",
+            objective_fingerprint="abc123",
+            resume=False,
+        )
+        provider.assert_request_allowed()
+        provider.record_usage(prompt_tokens=90, completion_tokens=20)
+
+        assert provider.snapshot().status == "budget_limited"
+        with pytest.raises(GoalBudgetLimitedError):
+            provider.assert_request_allowed()
+        assert manager.load_goal("task-1")["used_tokens"] == 110
+    finally:
+        CheckpointCoordinator.deactivate(coord)
+
+
+def test_provider_resume_rejects_changed_objective_and_reactivates_higher_budget(tmp_path):
+    manager = CheckpointManager("supervisor", checkpoints_root=tmp_path)
+    manager.save_goal("task-1", _state(budget=100).with_usage(90, 20).to_dict())
+    coord = CheckpointCoordinator.activate(manager, "task-1", "task", resume=True)
+    try:
+        with pytest.raises(ValueError, match="objective changed"):
+            GoalStateProvider.initialize(
+                config=GoalConfig(enabled=True, token_budget=200),
+                objective="Changed.",
+                objective_fingerprint="different",
+                resume=True,
+            )
+
+        provider = GoalStateProvider.initialize(
+            config=GoalConfig(enabled=True, token_budget=200),
+            objective="Ship Goal mode.",
+            objective_fingerprint="abc123",
+            resume=True,
+        )
+        assert provider.snapshot().status == "active"
+        assert provider.snapshot().used_tokens == 110
+    finally:
+        CheckpointCoordinator.deactivate(coord)
+
+
+def test_goal_provider_binding_is_run_scoped():
+    provider = GoalStateProvider(_state())
+    assert get_current_goal_provider() is None
+
+    with bind_goal_state_provider(provider):
+        assert get_current_goal_provider(required=True) is provider
+
+    assert get_current_goal_provider() is None

--- a/tests/goal_test/test_goal_tools.py
+++ b/tests/goal_test/test_goal_tools.py
@@ -1,0 +1,83 @@
+import json
+from dataclasses import replace
+
+import pytest
+
+from src.lib.goal import GoalState
+from src.lib.goal.provider import GoalStateProvider, bind_goal_state_provider
+from src.lib.smolagents.hooks.runtime import HookPlan, HookRun
+from src.tools.goal import get_goal, update_goal
+from src.trace import (
+    bind_explicit_execution_context,
+    bind_local_run,
+    bind_root_run,
+    capture_explicit_execution_context,
+)
+
+
+def _provider() -> GoalStateProvider:
+    return GoalStateProvider(
+        GoalState.create(
+            objective="Ship Goal mode.",
+            objective_fingerprint="abc123",
+            token_budget=None,
+        )
+    )
+
+
+def _hook(*, parent=None) -> HookRun:
+    return HookRun(
+        HookPlan(),
+        local_run_id="root" if parent is None else "worker",
+        root_run_id="root",
+        parent=parent,
+        agent_config={"goal": {"enabled": True}},
+    )
+
+
+def test_root_supervisor_can_read_and_complete_goal():
+    provider = _provider()
+    with bind_local_run("root"), bind_root_run("root"), bind_goal_state_provider(provider):
+        context = replace(
+            capture_explicit_execution_context(),
+            hook_run=_hook(),
+            agent_config={"goal": {"enabled": True}},
+        )
+        with bind_explicit_execution_context(context):
+            initial = json.loads(get_goal.forward())
+            completed = json.loads(
+                update_goal.forward(status="complete", evidence="Tests passed.")
+            )
+            assert provider.assert_request_allowed(
+                local_run_id="root",
+                allow_completion_settlement=True,
+            ) is True
+
+    assert initial["status"] == "active"
+    assert completed["status"] == "complete"
+    assert completed["evidence"] == "Tests passed."
+
+
+def test_update_goal_requires_complete_and_evidence():
+    provider = _provider()
+    with bind_local_run("root"), bind_root_run("root"), bind_goal_state_provider(provider):
+        context = replace(capture_explicit_execution_context(), hook_run=_hook())
+        with bind_explicit_execution_context(context):
+            with pytest.raises(ValueError, match="must be 'complete'"):
+                update_goal.forward(status="active", evidence="no")
+            with pytest.raises(ValueError, match="evidence"):
+                update_goal.forward(status="complete", evidence="  ")
+
+
+def test_worker_cannot_call_goal_tools_even_when_provider_is_inherited():
+    provider = _provider()
+    parent = _hook()
+    with bind_local_run("worker"), bind_root_run("root"), bind_goal_state_provider(provider):
+        context = replace(
+            capture_explicit_execution_context(),
+            hook_run=_hook(parent=parent),
+            agent_config={"goal": {"enabled": True}},
+        )
+        with bind_explicit_execution_context(context):
+            with pytest.raises(PermissionError, match="root Supervisor"):
+                get_goal.forward()

--- a/tests/goal_test/test_goal_validation_application.py
+++ b/tests/goal_test/test_goal_validation_application.py
@@ -1,0 +1,116 @@
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.lib.goal import GoalState, GoalStateProvider, bind_goal_state_provider
+
+_REPORT_TOOLS_PATH = (
+    Path(__file__).parents[2]
+    / "applications"
+    / "goal_mode_validation"
+    / "agent_tools"
+    / "report_tools.py"
+)
+_SPEC = importlib.util.spec_from_file_location("goal_validation_report_tools", _REPORT_TOOLS_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+report_tools = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(report_tools)
+
+
+def _provider() -> GoalStateProvider:
+    return GoalStateProvider(
+        GoalState.create(
+            objective="Validate Goal mode.",
+            objective_fingerprint="validation-app",
+            token_budget=50_000,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "topic", ["contract", "lifecycle", "observability", "documentation"]
+)
+def test_goal_validation_evidence_is_bounded_and_traceable(topic):
+    payload = json.loads(report_tools.load_goal_audit_evidence(topic))
+
+    assert payload["topic"] == topic
+    assert payload["files"]
+    for record in payload["files"]:
+        assert record["path"]
+        assert len(record["sha256"]) == 64
+        assert record["excerpts"]
+        assert len(record["excerpts"]) <= report_tools._EVIDENCE_LINES_PER_FILE
+
+
+def test_goal_validation_evidence_rejects_unknown_topic():
+    with pytest.raises(ValueError, match="topic must be"):
+        report_tools.load_goal_audit_evidence("unknown")
+
+
+def test_parallel_budget_probe_reuses_report_for_same_goal(tmp_path, monkeypatch):
+    provider = _provider()
+    goal_id = provider.snapshot().goal_id
+    monkeypatch.setattr(report_tools, "_OUTPUT_ROOT", tmp_path)
+    (tmp_path / "parallel_budget.md").write_text(
+        "\n".join(
+            [
+                "# Parallel Goal Budget",
+                "## Batch Results",
+                "## Accounting",
+                f"goal_id={goal_id}",
+                "## Resume Instructions",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def fail_if_rerun(*_args, **_kwargs):
+        raise AssertionError("resume must not rerun the completed Worker batch")
+
+    monkeypatch.setattr(report_tools, "run_goal_audit_batch", fail_if_rerun)
+    with bind_goal_state_provider(provider):
+        result = json.loads(
+            report_tools.run_parallel_goal_budget_probe(
+                '[{"task_id":"audit-1","query":"Inspect the Goal contract."}]'
+            )
+        )
+
+    assert result["status"] == "existing_report"
+    assert result["batch_rerun"] is False
+    assert result["report"]["matches_current_goal"] is True
+
+
+def test_goal_audit_batch_injects_evidence_into_tool_free_worker_query(monkeypatch):
+    from src.lib.smolagents.agent.yaml_agent_factory import YamlAgentFactory
+
+    captured = {}
+
+    def fake_parallel(_worker_path, tasks, *, max_workers):
+        captured["tasks"] = tasks
+        captured["max_workers"] = max_workers
+        return [
+            SimpleNamespace(
+                task_id="audit-1",
+                status="completed",
+                duration_seconds=0.1,
+                result="VERDICT: PASS",
+                error=None,
+            )
+        ]
+
+    monkeypatch.setattr(YamlAgentFactory, "run_agents_parallel", fake_parallel)
+    result = json.loads(
+        report_tools.run_goal_audit_batch(
+            "contract",
+            '[{"task_id":"audit-1","query":"Inspect the strict Goal contract."}]',
+        )
+    )
+
+    assert result[0]["status"] == "completed"
+    assert captured["max_workers"] == 1
+    query = captured["tasks"][0]["query"]
+    assert "EVIDENCE_BUNDLE=" in query
+    assert '"src/lib/goal/model.py"' in query

--- a/tests/schedules_test/test_schedule_runner_cli.py
+++ b/tests/schedules_test/test_schedule_runner_cli.py
@@ -44,7 +44,49 @@ def test_runner_uses_canonical_agentloom_command_by_default(tmp_path: Path) -> N
         "src",
         "run",
         "agent.yaml",
+        "--output-format",
+        "jsonl",
     ]
+
+
+def test_runner_persists_goal_budget_limit_as_resumable_terminal_status(
+    tmp_path: Path,
+) -> None:
+    store = ScheduleStore(tmp_path)
+    job = _job(store, tmp_path)
+    event = {
+        "schema_version": 1,
+        "event": "run.budget_limited",
+        "run": {"task_id": "task_goal", "run_id": "run_goal"},
+        "error": "Goal token budget exhausted",
+        "goal": {
+            "schema_version": 1,
+            "status": "budget_limited",
+            "objective": "finish the audit",
+            "token_budget": 100,
+            "prompt_tokens": 90,
+            "completion_tokens": 30,
+            "used_tokens": 120,
+            "remaining_tokens": 0,
+        },
+    }
+    command = [
+        sys.executable,
+        "-c",
+        f"import json, sys; print(json.dumps({event!r})); sys.exit(1)",
+    ]
+
+    execution = ScheduleRunner(
+        store,
+        command_factory=lambda _job: command,
+        poll_seconds=0.01,
+    ).run_now(job["id"], now=NOW)
+
+    assert execution["status"] == "budget_limited"
+    assert execution["exit_code"] == 1
+    assert execution["error"] == "Goal token budget exhausted"
+    assert execution["goal"]["used_tokens"] == 120
+    assert store.get_job(job["id"])["last_status"] == "budget_limited"
 
 
 def test_default_runner_isolated_mode_rejects_project_local_src_shadowing(tmp_path: Path) -> None:

--- a/tests/test_cli_run_observability.py
+++ b/tests/test_cli_run_observability.py
@@ -15,6 +15,7 @@ from litellm.exceptions import Timeout
 
 from src.__main__ import main
 from src.application_run import (
+    ApplicationRunBudgetLimited,
     ApplicationRunError,
     ApplicationRunInterrupted,
     RunInfo,
@@ -44,6 +45,7 @@ def _event(
     output: str | None = None,
     error: str | None = None,
     phase: str | None = None,
+    goal: dict | None = None,
 ) -> RunLifecycleEvent:
     return RunLifecycleEvent(
         event=event,
@@ -52,6 +54,7 @@ def _event(
         output=output,
         error=error,
         phase=phase,
+        goal=goal,
     )
 
 
@@ -74,6 +77,71 @@ def test_run_accepts_task_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert observed["task_override"] == "inspect this repository"
 
 
+def test_text_run_displays_goal_status_and_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    def succeed(*_args, **_kwargs):
+        return SimpleNamespace(
+            output="completed",
+            goal={
+                "status": "complete",
+                "used_tokens": 123,
+                "token_budget": None,
+            },
+        )
+
+    monkeypatch.setattr("src.runner.execute_app", succeed)
+
+    result = CliRunner().invoke(main, ["run", "unused.yaml"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "completed\nGoal: complete | tokens: 123/unlimited\n"
+
+
+def test_jsonl_budget_limited_event_contains_structured_goal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    goal = {
+        "status": "budget_limited",
+        "used_tokens": 105,
+        "token_budget": 100,
+        "remaining_tokens": 0,
+    }
+
+    def execute(*_args, event_sink=None, **_kwargs):
+        run = _run_info()
+        event_sink(_event("run.started"))
+        event_sink(
+            _event(
+                "run.budget_limited",
+                error="Goal token budget exhausted",
+                phase="execution",
+                goal=goal,
+            )
+        )
+        raise ApplicationRunBudgetLimited(
+            "Goal token budget exhausted",
+            run=run,
+            phase="execution",
+            original_error=RuntimeError("limited"),
+            goal=goal,
+        )
+
+    monkeypatch.setattr("src.runner.execute_app", execute, raising=False)
+
+    result = CliRunner().invoke(
+        main,
+        ["run", "unused.yaml", "--output-format", "jsonl"],
+    )
+
+    assert result.exit_code == 1
+    records = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [record["event"] for record in records] == [
+        "run.started",
+        "run.budget_limited",
+    ]
+    assert records[-1]["goal"] == goal
+    assert "Resume task task_123" in result.stderr
+
+
 def test_python_module_invocation_exposes_run_command() -> None:
     env = os.environ.copy()
     env["PYTHONPATH"] = str(_REPO_ROOT)
@@ -90,7 +158,47 @@ def test_python_module_invocation_exposes_run_command() -> None:
 
     assert completed.returncode == 0
     assert "Usage:" in completed.stdout
-    assert "--output-format [text|jsonl]" in completed.stdout
+    assert "--output-format [text|json|jsonl]" in completed.stdout
+
+
+def test_json_run_emits_one_terminal_object_with_structured_goal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    goal = {
+        "status": "complete",
+        "used_tokens": 123,
+        "token_budget": None,
+        "remaining_tokens": None,
+    }
+
+    def execute(*_args, event_sink=None, **_kwargs):
+        event_sink(_event("run.started"))
+        event_sink(_event("run.completed", output="final answer", goal=goal))
+        return SimpleNamespace(output="final answer", goal=goal)
+
+    monkeypatch.setattr("src.runner.execute_app", execute, raising=False)
+
+    result = CliRunner().invoke(
+        main,
+        ["run", "unused.yaml", "--output-format", "json"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "schema_version": 1,
+        "event": "run.completed",
+        "occurred_at": "2026-07-18T01:02:03+00:00",
+        "run": {
+            "application_id": "demo",
+            "task_id": "task_123",
+            "run_id": "run_123",
+            "run_dir": "/tmp/agentloom/runs/demo/run_123",
+            "manifest_path": "/tmp/agentloom/runs/demo/run_123/manifest.json",
+            "log_path": "/tmp/agentloom/runs/demo/run_123/logs/runtime.log",
+        },
+        "output": "final answer",
+        "goal": goal,
+    }
 
 
 def test_jsonl_run_emits_only_lifecycle_events_on_stdout(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1291,6 +1291,140 @@ def test_structured_run_api_is_publicly_exported():
 
 class TestExecuteApp:
     @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_resume_rejects_disabling_a_persisted_active_goal(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        from src.application_run import (
+            ApplicationRunBudgetLimited,
+            ApplicationRunError,
+        )
+        from src.lib.goal import GoalBudgetLimitedError, GoalState
+        from src.runner import execute_app
+
+        fake_yaml.write_text(_SAMPLE_YAML + "\ngoal:\n  enabled: true\n  token_budget: 100\n")
+        state = GoalState.create(
+            objective="Finish the application.",
+            objective_fingerprint="fingerprint",
+            token_budget=100,
+        ).with_usage(90, 20)
+
+        def _limit(_task, **kwargs):
+            manager = kwargs["checkpoint_manager"]
+            manager.save_goal(kwargs["task_id"], state.to_dict())
+            manager.record_task_status_changed(kwargs["task_id"], "budget_limited")
+            raise GoalBudgetLimitedError(state)
+
+        mock_cls.return_value.run.side_effect = _limit
+        with pytest.raises(ApplicationRunBudgetLimited) as limited:
+            execute_app(str(fake_yaml), file_logging=False)
+
+        fake_yaml.write_text(_SAMPLE_YAML + "\ngoal: false\n", encoding="utf-8")
+        with pytest.raises(ApplicationRunError) as rejected:
+            execute_app(
+                str(fake_yaml),
+                file_logging=False,
+                resume_task_id=limited.value.run.task_id,
+            )
+
+        assert isinstance(rejected.value.original_error, ValueError)
+        assert "Goal mode is disabled" in str(rejected.value.original_error)
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_budget_limited_is_structured_resumable_outcome(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        from src.application_run import ApplicationRunBudgetLimited
+        from src.lib.goal import GoalBudgetLimitedError, GoalState
+        from src.runner import execute_app
+
+        state = GoalState.create(
+            objective="Finish the application.",
+            objective_fingerprint="fingerprint",
+            token_budget=100,
+        ).with_usage(90, 20)
+
+        def _run(_task, **kwargs):
+            manager = kwargs["checkpoint_manager"]
+            manager.save_goal(kwargs["task_id"], state.to_dict())
+            manager.record_task_status_changed(kwargs["task_id"], "budget_limited")
+            raise GoalBudgetLimitedError(state)
+
+        mock_cls.return_value.run.side_effect = _run
+        events = []
+
+        with pytest.raises(ApplicationRunBudgetLimited) as caught:
+            execute_app(str(fake_yaml), file_logging=False, event_sink=events.append)
+
+        assert caught.value.resumable is True
+        assert caught.value.goal["used_tokens"] == 110
+        with pytest.raises(TypeError):
+            caught.value.goal["status"] = "active"
+        assert [event.event for event in events] == [
+            "run.started",
+            "run.budget_limited",
+        ]
+        assert events[-1].goal["status"] == "budget_limited"
+        with pytest.raises(TypeError):
+            events[-1].goal["status"] = "active"
+        manifest = json.loads(
+            caught.value.run.manifest_path.read_text(encoding="utf-8")
+        )
+        assert manifest["status"] == "budget_limited"
+        assert manifest["goal"]["used_tokens"] == 110
+        assert manifest["goal_artifact"] == "audit/goal.json"
+        assert (
+            caught.value.run.run_dir.parent.parent.parent
+            / "checkpoints"
+            / "test_app"
+            / caught.value.run.task_id
+            / "goal.json"
+        ).exists()
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_completed_goal_is_copied_before_checkpoint_cleanup(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        from src.lib.goal import GoalState
+        from src.runner import execute_app
+
+        state = GoalState.create(
+            objective="Finish the application.",
+            objective_fingerprint="fingerprint",
+            token_budget=None,
+        ).with_completion("Delivered and verified.")
+
+        def _run(_task, **kwargs):
+            manager = kwargs["checkpoint_manager"]
+            manager.save_goal(kwargs["task_id"], state.to_dict())
+            manager.record_task_status_changed(
+                kwargs["task_id"],
+                "completed",
+                result=state.evidence,
+            )
+            return state.evidence
+
+        mock_cls.return_value.run.side_effect = _run
+
+        result = execute_app(str(fake_yaml), file_logging=False)
+
+        manifest = json.loads(result.run.manifest_path.read_text(encoding="utf-8"))
+        assert result.goal["status"] == "complete"
+        with pytest.raises(TypeError):
+            result.goal["status"] = "active"
+        assert manifest["goal"]["evidence"] == "Delivered and verified."
+        assert json.loads(
+            (result.run.run_dir / manifest["goal_artifact"]).read_text(
+                encoding="utf-8"
+            )
+        )["status"] == "complete"
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
     def test_returns_canonical_receipt_after_durable_finalization(
         self,
         mock_cls,
@@ -1305,6 +1439,10 @@ class TestExecuteApp:
         result = execute_app(str(fake_yaml), file_logging=False)
 
         assert result.output == "structured-output"
+        assert result.goal is None
+        assert "goal" not in json.loads(
+            result.run.manifest_path.read_text(encoding="utf-8")
+        )
         assert result.started_at <= result.ended_at
         assert result.run.application_id == "test_app"
         assert result.run.run_dir.is_absolute()
@@ -1359,9 +1497,23 @@ class TestExecuteApp:
         import json
 
         from src.application_run import ApplicationRunError
+        from src.lib.goal import GoalState
         from src.runner import execute_app
 
-        mock_cls.return_value.run.side_effect = RuntimeError("boom")
+        fake_yaml.write_text(_SAMPLE_YAML + "\ngoal: true\n", encoding="utf-8")
+        state = GoalState.create(
+            objective="Finish the application.",
+            objective_fingerprint="fingerprint",
+            token_budget=None,
+        )
+
+        def _fail(_task, **kwargs):
+            kwargs["checkpoint_manager"].save_goal(
+                kwargs["task_id"], state.to_dict()
+            )
+            raise RuntimeError("boom")
+
+        mock_cls.return_value.run.side_effect = _fail
         events = []
 
         with pytest.raises(ApplicationRunError, match="Agent execution failed") as caught:
@@ -1374,6 +1526,7 @@ class TestExecuteApp:
         assert caught.value.phase == "execution"
         assert [event.event for event in events] == ["run.started", "run.failed"]
         assert events[0].run == events[1].run == caught.value.run
+        assert events[-1].goal["status"] == "active"
         manifest = json.loads(
             caught.value.run.manifest_path.read_text(encoding="utf-8")
         )
@@ -1386,9 +1539,23 @@ class TestExecuteApp:
         fake_yaml: Path,
     ) -> None:
         from src.application_run import ApplicationRunInterrupted
+        from src.lib.goal import GoalState
         from src.runner import execute_app
 
-        mock_cls.return_value.run.side_effect = KeyboardInterrupt()
+        fake_yaml.write_text(_SAMPLE_YAML + "\ngoal: true\n", encoding="utf-8")
+        state = GoalState.create(
+            objective="Finish the application.",
+            objective_fingerprint="fingerprint",
+            token_budget=None,
+        )
+
+        def _interrupt(_task, **kwargs):
+            kwargs["checkpoint_manager"].save_goal(
+                kwargs["task_id"], state.to_dict()
+            )
+            raise KeyboardInterrupt()
+
+        mock_cls.return_value.run.side_effect = _interrupt
         events = []
 
         with pytest.raises(ApplicationRunInterrupted) as caught:
@@ -1404,6 +1571,7 @@ class TestExecuteApp:
             "run.interrupted",
         ]
         assert events[-1].run == caught.value.run
+        assert events[-1].goal["status"] == "active"
 
     def test_preflight_failure_emits_rejected_without_allocating(
         self,

--- a/tests/tools_test/test_create_agent_loom_application_validator.py
+++ b/tests/tools_test/test_create_agent_loom_application_validator.py
@@ -136,6 +136,67 @@ def test_validator_rejects_invalid_list_workflow_item(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "goal",
+    [True, False, {"enabled": True}, {"enabled": False}, {"enabled": True, "token_budget": 1000}],
+)
+def test_validator_accepts_goal_supervisor_forms(tmp_path: Path, goal) -> None:
+    app_root = _create_min_project(tmp_path)
+    workflow_file = app_root / "workflows" / "demo_agent.yaml"
+    config = yaml.safe_load(workflow_file.read_text(encoding="utf-8"))
+    config["goal"] = goal
+    _write_yaml(workflow_file, config)
+
+    completed, payload = _run_validator(tmp_path)
+
+    assert completed.returncode == 0
+    assert payload["summary"]["valid"] is True
+
+
+@pytest.mark.parametrize(
+    "goal",
+    [None, {}, {"token_budget": 10}, {"enabled": True, "token_budget": "10"}, {"enabled": True, "extra": 1}],
+)
+def test_validator_rejects_invalid_goal_forms(tmp_path: Path, goal) -> None:
+    app_root = _create_min_project(tmp_path)
+    workflow_file = app_root / "workflows" / "demo_agent.yaml"
+    config = yaml.safe_load(workflow_file.read_text(encoding="utf-8"))
+    config["goal"] = goal
+    _write_yaml(workflow_file, config)
+
+    completed, payload = _run_validator(tmp_path)
+
+    assert completed.returncode == 1
+    assert any(error["field"] == "goal" for error in payload["errors"])
+
+
+def test_validator_rejects_goal_on_worker(tmp_path: Path) -> None:
+    app_root = _create_min_project(tmp_path)
+    worker_file = app_root / "workflows" / "worker_agents" / "worker.yaml"
+    _write_yaml(
+        worker_file,
+        {
+            "name": "worker",
+            "description": "worker",
+            "workflow": "work",
+            "goal": False,
+            "agent_function_schema": {
+                "description": "worker tool",
+                "inputs": {"task": {"description": "task"}},
+                "output": {"description": "result"},
+            },
+        },
+    )
+
+    completed, payload = _run_validator(tmp_path)
+
+    assert completed.returncode == 1
+    assert any(
+        error["field"] == "goal" and error["rule"] == "supervisor_only"
+        for error in payload["errors"]
+    )
+
+
 @pytest.mark.parametrize("mode", ["auto", "on", "off"])
 def test_validator_accepts_todo_modes(tmp_path: Path, mode: str) -> None:
     app_root = _create_min_project(tmp_path)

--- a/tests/tui_bridge_test/test_runtime_summary.py
+++ b/tests/tui_bridge_test/test_runtime_summary.py
@@ -89,6 +89,63 @@ def _completed_run(tmp_path: Path) -> None:
     )
 
 
+def test_goal_status_and_usage_are_visible_in_runtime_summary_and_detail(
+    tmp_path: Path,
+) -> None:
+    bridge = _project(tmp_path)
+    _completed_run(tmp_path)
+    run_dir = tmp_path / ".runtime-live/runs/demo/run-live"
+    manifest_path = run_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["status"] = "budget_limited"
+    manifest["goal"] = {
+        "status": "budget_limited",
+        "used_tokens": 105,
+        "token_budget": 100,
+        "remaining_tokens": 0,
+    }
+    _write(manifest_path, json.dumps(manifest))
+
+    bootstrap = bridge.bootstrap()
+    detail = bridge.dispatch(
+        "run.detail",
+        {"application_id": "demo", "run_id": "run-live"},
+    )
+
+    assert bootstrap["runs"][0]["status"] == "budget_limited"
+    assert bootstrap["runs"][0]["goal"]["used_tokens"] == 105
+    assert detail["summary"]["status"] == "budget_limited"
+    assert detail["summary"]["goal"] == manifest["goal"]
+
+
+def test_running_goal_is_loaded_from_checkpoint_for_tui_detail(tmp_path: Path) -> None:
+    bridge = _project(tmp_path)
+    _completed_run(tmp_path)
+    run_dir = tmp_path / ".runtime-live/runs/demo/run-live"
+    manifest_path = run_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["status"] = "running"
+    manifest.pop("ended_at", None)
+    _write(manifest_path, json.dumps(manifest))
+    goal = {
+        "status": "active",
+        "used_tokens": 50,
+        "token_budget": 1000,
+        "remaining_tokens": 950,
+    }
+    _write(
+        tmp_path / ".runtime-live/checkpoints/demo/task-live/goal.json",
+        json.dumps(goal),
+    )
+
+    detail = bridge.dispatch(
+        "run.detail",
+        {"application_id": "demo", "run_id": "run-live"},
+    )
+
+    assert detail["summary"]["goal"] == goal
+
+
 def _schedule_document(tmp_path: Path) -> None:
     _write(
         tmp_path / ".agentloom/schedules/jobs.json",


### PR DESCRIPTION
## Summary

- add Supervisor-only Goal Mode configured by YAML booleans or an explicit enabled/token_budget mapping
- merge Goal workflow lists into one objective and continue on the same runtime and memory until explicit completion
- aggregate root and Worker token usage, persist resumable budget_limited state, and expose Goal state through Python, CLI JSON/JSONL, TUI, and schedules
- add the root GOAL_MODE_SPEC.md, bilingual documentation, validation applications, and regression coverage
- preserve ordinary non-Goal workflow-list behavior

## Validation

- uv run pytest -q: 3605 passed, 2 skipped
- focused Goal/runtime/runner/CLI/context-compression suites passed
- agentloom-tui tests: 199 passed; TypeScript noEmit check passed
- real-model validation covered parallel budget exhaustion/resume, bounded merged-list completion, unlimited long continuation, and an ordinary non-Goal workflow
- final spec and standards fixed-point reviews: clean

## Notes

Goal completion settlement is process-local and single-use. It cannot be consumed by Workers, planning, or smart-summary calls; it is not recreated on resume, and an exhausted token budget still prevents it.