### PR TITLE
Centralize Application Run lifecycle ownership

### DIFF
--- a/docs/cn/checkpoint.md
+++ b/docs/cn/checkpoint.md
@@ -62,6 +62,25 @@ AgentLoom 将“一次执行尝试”和“需要恢复的逻辑任务”分开�
 - Agent 的持久 recall 使用 `.agentloom/workspaces/agents/<application_id>/<agent_path>/` 下、归 Application 所有的 `insights.md`。当前任务的 Todo 在启用 checkpoint 时随 `<application_id>/<task_id>/todos.json` 共同恢复和清理；未启用 checkpoint 时只保存在本次 run 的内存中。它既不是 run artifact，也不承担长期项目管理。
 - Goal Mode 使用 task-scoped `goal.json` 保存 objective 指纹、`goal_started`、状态、累计 token、预算和 evidence。`active`、`budget_limited`、`interrupted`、`failed`、`crashed` 都保留 checkpoint；只有显式完成后才进入现有成功清理流程。清理前状态会复制到 run manifest 和 `audit/goal.json`。
 
+### 终态 lifecycle ownership
+
+一个 Application Run owner 统一结算终态。Supervisor 只上报 output、memory
+snapshot、error 和可选 Goal projection，不再独立提交第二套 Application 终态。
+owner 按固定顺序完成一次事务：
+
+```text
+Supervisor report
+  -> terminal checkpoint/task event
+  -> result 与 audit evidence
+  -> terminal manifest
+  -> 可选的成功 checkpoint 删除
+  -> resource cleanup
+```
+
+如果 evidence 或 manifest finalization 在 checkpoint 删除前失败，同一个 owner 会把
+暂定成功改写为 `failed` 或 `interrupted` 并保留 checkpoint。如果删除已经开始后才被
+中断，run 会报告 `resumable: false`，且不会重建一个缺少真实进度的空 checkpoint。
+
 ## 配置
 
 在 `config/system.yaml` 中配置运行时存储、有界日志和 resume：

--- a/docs/en/checkpoint.md
+++ b/docs/en/checkpoint.md
@@ -62,6 +62,27 @@ Important boundaries:
 - Persistent Agent recall uses application-scoped `insights.md` under `.agentloom/workspaces/agents/<application_id>/<agent_path>/`. Current-task Todo state follows the checkpoint lifecycle in `<application_id>/<task_id>/todos.json` when checkpointing is enabled; otherwise it remains in run-scoped memory. It is neither a run artifact nor long-term project state.
 - Goal Mode stores the objective fingerprint, `goal_started`, state, cumulative tokens, budget, and evidence in task-scoped `goal.json`. `active`, `budget_limited`, interrupted, failed, and crashed work retains the checkpoint. Only explicit Goal completion enters normal success cleanup, after copying Goal state into the run manifest and `audit/goal.json`.
 
+### Terminal lifecycle ownership
+
+One Application Run owner settles the terminal outcome. The Supervisor reports
+its output, memory snapshot, error, and optional Goal projection; it does not
+independently commit a second Application-level terminal state. The owner then
+applies one ordered transaction:
+
+```text
+Supervisor report
+  -> terminal checkpoint/task event
+  -> result and audit evidence
+  -> terminal manifest
+  -> optional successful-checkpoint deletion
+  -> resource cleanup
+```
+
+If evidence or manifest finalization fails before checkpoint deletion, the same
+owner replaces provisional success with `failed` or `interrupted` and keeps the
+checkpoint. If interruption occurs after deletion has started, the run reports
+`resumable: false` and never recreates a skeletal checkpoint.
+
 ## Configuration
 
 Configure runtime storage, bounded logs, and resume behavior in `config/system.yaml`:

--- a/src/application_run_lifecycle.py
+++ b/src/application_run_lifecycle.py
@@ -1,0 +1,646 @@
+"""Single owner for one Application Run's terminal lifecycle.
+
+The runner allocates resources and the Supervisor performs model work, but
+neither owns terminal checkpoint state independently.  Both report into this
+module so checkpoint state, Goal projection, and the final Run outcome are
+settled by one lifecycle object.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+from src.application_run import RunPhase
+from src.lib.checkpoint import CheckpointManager
+from src.lib.goal import GoalBudgetLimitedError
+
+_RUN_ARTIFACT_COPY_CHUNK_BYTES = 1024 * 1024
+
+ApplicationRunOutcome = Literal[
+    "completed",
+    "budget_limited",
+    "interrupted",
+    "failed",
+]
+
+
+@dataclass(slots=True)
+class _AgentInvocation:
+    coordinator: Any | None
+    runtime_agent: Any | None
+    result: str | None
+    error: BaseException | None
+
+
+@dataclass(slots=True)
+class ApplicationRunFinalization:
+    """Durable collaborators for one ordered terminal transaction."""
+
+    runtime_context: Any
+    checkpoint_manager: CheckpointManager | None
+    task_id: str
+    event_start_offset: int | None
+    manifest_updates: dict[str, Any]
+    cleanup_on_success: bool
+    log: Any
+    task_tree_cleanup_max_bytes: int = 1024 * 1024
+
+
+@dataclass(slots=True)
+class ApplicationRunResources:
+    """Resources whose lifetimes end after terminal persistence."""
+
+    supervisor: Any | None
+    heartbeat: Any | None
+    file_history: Any | None
+    log: Any
+    task_lease: Any | None
+    checkpoint_manager: CheckpointManager | None
+
+
+class ApplicationRunLifecycle:
+    """Own terminal state for exactly one top-level Application Run.
+
+    Agent code reports the runtime snapshot here but does not persist a
+    terminal checkpoint itself.  The runner later commits the same outcome to
+    checkpoint evidence, Run artifacts, and the Run manifest. Public API events
+    remain an adapter concern after this object has settled the outcome.
+    """
+
+    def __init__(self) -> None:
+        self._invocation: _AgentInvocation | None = None
+        self._goal: dict[str, object] | None = None
+        self._checkpoint_outcome: ApplicationRunOutcome | None = None
+        self._phase: RunPhase = "initialization"
+        self._outcome: ApplicationRunOutcome | None = None
+        self._result = ""
+        self._error: BaseException | None = None
+        self._checkpoint_deletion_started = False
+        self._resumable = False
+
+    @property
+    def phase(self) -> RunPhase:
+        return self._phase
+
+    @property
+    def outcome(self) -> ApplicationRunOutcome:
+        if self._outcome is None:
+            raise RuntimeError("Application Run has no terminal outcome")
+        return self._outcome
+
+    @property
+    def result(self) -> str:
+        return self._result
+
+    @property
+    def error(self) -> BaseException | None:
+        return self._error
+
+    @property
+    def error_message(self) -> str | None:
+        if self._error is None:
+            return None
+        message = str(self._error)
+        if message:
+            return message
+        if isinstance(self._error, KeyboardInterrupt):
+            return "run interrupted"
+        return type(self._error).__name__
+
+    @property
+    def resumable(self) -> bool:
+        return self._resumable
+
+    @property
+    def goal(self) -> dict[str, object] | None:
+        return None if self._goal is None else dict(self._goal)
+
+    def report_agent_invocation(
+        self,
+        *,
+        coordinator: Any | None,
+        runtime_agent: Any | None,
+        result: object | None,
+        error: BaseException | None,
+        goal: Mapping[str, object] | None,
+    ) -> None:
+        """Capture the root Agent's final in-memory state without committing it."""
+
+        if self._invocation is not None:
+            raise RuntimeError("Application Run Agent invocation was already reported")
+        self._invocation = _AgentInvocation(
+            coordinator=coordinator,
+            runtime_agent=runtime_agent,
+            result=None if result is None else str(result),
+            error=error,
+        )
+        if goal is not None:
+            self._goal = dict(goal)
+
+    def settle_reported_agent_invocation(self) -> None:
+        """Settle a standalone Agent invocation from its captured return state."""
+
+        invocation = self._invocation
+        if invocation is None:
+            raise RuntimeError("Application Run Agent invocation was not reported")
+        if invocation.error is None:
+            self.complete_execution(invocation.result)
+        else:
+            self.fail_execution(invocation.error)
+
+    def enter_execution(self) -> None:
+        if self._phase != "initialization":
+            raise RuntimeError(f"Application Run cannot enter execution from {self._phase}")
+        self._phase = "execution"
+
+    def complete_execution(self, result: object | None) -> None:
+        if self._phase != "execution":
+            raise RuntimeError(f"Application Run cannot complete execution from {self._phase}")
+        self._result = "" if result is None else str(result)
+        self._error = None
+        self._outcome = "completed"
+        self._phase = "finalization"
+
+    def fail_execution(self, error: BaseException) -> None:
+        if self._phase not in {"initialization", "execution"}:
+            raise RuntimeError(f"Application Run cannot fail execution from {self._phase}")
+        self._error = error
+        self._outcome = self.outcome_for(error)
+
+    def fail_finalization(self, error: BaseException) -> None:
+        if self._phase not in {"execution", "finalization"}:
+            raise RuntimeError(f"Application Run cannot fail finalization from {self._phase}")
+        self._phase = "finalization"
+        self._error = error
+        self._outcome = self.outcome_for(error)
+
+    def enter_cleanup(self) -> None:
+        self._phase = "cleanup"
+
+    def fail_cleanup(self, error: BaseException) -> None:
+        self._phase = "cleanup"
+        self._error = error
+        self._outcome = self.outcome_for(error)
+
+    @staticmethod
+    def outcome_for(error: BaseException | None) -> ApplicationRunOutcome:
+        if error is None:
+            return "completed"
+        if isinstance(error, GoalBudgetLimitedError):
+            return "budget_limited"
+        if isinstance(error, KeyboardInterrupt):
+            return "interrupted"
+        return "failed"
+
+    def commit_checkpoint(
+        self,
+        *,
+        checkpoint_manager: CheckpointManager | None,
+        task_id: str,
+    ) -> None:
+        """Commit a terminal Agent checkpoint once for each settled outcome.
+
+        A real RoleDrivenAgent reports its coordinator and runtime memory.  A
+        different Supervisor implementation may only return or raise; in that
+        case the Run still owns and records the task-tree terminal state.
+        """
+
+        outcome = self.outcome
+        error_message = self.error_message
+        result = self._result if outcome == "completed" else None
+        if self._checkpoint_outcome == outcome or checkpoint_manager is None:
+            return
+
+        invocation = self._invocation
+        if invocation is not None and invocation.coordinator is not None and invocation.runtime_agent is not None:
+            invocation.coordinator.save_supervisor(
+                invocation.runtime_agent,
+                outcome,
+                result=result if outcome == "completed" else None,
+                error=error_message,
+            )
+        else:
+            checkpoint_manager.record_task_status_changed(
+                task_id,
+                outcome,
+                result=result if outcome == "completed" else None,
+                error=error_message,
+            )
+        self._checkpoint_outcome = outcome
+
+    def finalize_run(self, finalization: ApplicationRunFinalization) -> None:
+        """Commit checkpoint, evidence, manifest, and optional success cleanup."""
+
+        try:
+            goal_snapshot = self.goal
+            if goal_snapshot is not None:
+                finalization.manifest_updates["goal"] = goal_snapshot
+            self.commit_checkpoint(
+                checkpoint_manager=finalization.checkpoint_manager,
+                task_id=finalization.task_id,
+            )
+            if self.outcome == "interrupted":
+                self._validate_resumable_checkpoint(finalization)
+
+            if self.outcome == "completed":
+                _persist_run_observability(
+                    finalization.runtime_context,
+                    finalization.checkpoint_manager,
+                    finalization.task_id,
+                    result=self.result,
+                    event_start_offset=finalization.event_start_offset,
+                    manifest_updates=finalization.manifest_updates,
+                )
+            else:
+                try:
+                    _persist_run_observability(
+                        finalization.runtime_context,
+                        finalization.checkpoint_manager,
+                        finalization.task_id,
+                        result=None,
+                        event_start_offset=finalization.event_start_offset,
+                        manifest_updates=finalization.manifest_updates,
+                    )
+                except Exception as exc:
+                    finalization.log.warning(
+                        "Failed to persist Run observability: %s",
+                        exc,
+                    )
+
+            manifest_updates = {
+                "status": self.outcome,
+                "ended_at": datetime.now().astimezone().isoformat(),
+                **finalization.manifest_updates,
+            }
+            if self.error_message:
+                manifest_updates["error"] = self.error_message
+            try:
+                finalization.runtime_context.update_manifest(**manifest_updates)
+            except Exception as exc:
+                if self.outcome == "completed":
+                    raise
+                finalization.log.warning(
+                    "Failed to persist terminal manifest: %s",
+                    exc,
+                )
+
+            if (
+                self.outcome == "completed"
+                and finalization.cleanup_on_success
+                and finalization.checkpoint_manager is not None
+            ):
+                try:
+                    tree = finalization.checkpoint_manager.load_task_tree_projection(
+                        finalization.task_id,
+                        max_bytes=finalization.task_tree_cleanup_max_bytes,
+                    )
+                    if tree and tree.get("status") == "completed":
+                        self._checkpoint_deletion_started = True
+                        if finalization.checkpoint_manager.delete_task(
+                            finalization.task_id
+                        ):
+                            finalization.log.info(
+                                "Cleaned up checkpoint for completed task %s",
+                                finalization.task_id,
+                            )
+                except Exception:
+                    pass
+        except BaseException as exc:
+            self.fail_finalization(exc)
+            if (
+                finalization.checkpoint_manager is not None
+                and not self._checkpoint_deletion_started
+            ):
+                if isinstance(exc, KeyboardInterrupt):
+                    try:
+                        finalization.runtime_context.validate_checkpoint_path(
+                            require_exists=True,
+                        )
+                        self.commit_checkpoint(
+                            checkpoint_manager=finalization.checkpoint_manager,
+                            task_id=finalization.task_id,
+                        )
+                        self._resumable = True
+                    except Exception as checkpoint_exc:
+                        finalization.log.warning(
+                            "Failed to reopen checkpoint after finalization interruption: %s",
+                            checkpoint_exc,
+                        )
+                else:
+                    self.commit_checkpoint(
+                        checkpoint_manager=finalization.checkpoint_manager,
+                        task_id=finalization.task_id,
+                    )
+            raise
+
+    def persist_uncaught_failure(
+        self,
+        *,
+        runtime_context: Any,
+        manifest_initialized: bool,
+        manifest_updates: Mapping[str, Any],
+        error: BaseException,
+    ) -> None:
+        """Best-effort terminal manifest for failures outside finalization."""
+
+        if self._phase == "cleanup":
+            self.fail_cleanup(error)
+        elif self._phase == "finalization":
+            if self._error is not error:
+                self.fail_finalization(error)
+        else:
+            self.fail_execution(error)
+        if not manifest_initialized:
+            return
+        try:
+            runtime_context.update_manifest(
+                **manifest_updates,
+                status=self.outcome,
+                ended_at=datetime.now().astimezone().isoformat(),
+                error=self.error_message,
+            )
+        except Exception:
+            return
+
+    def _validate_resumable_checkpoint(
+        self,
+        finalization: ApplicationRunFinalization,
+    ) -> None:
+        if finalization.checkpoint_manager is None:
+            return
+        try:
+            finalization.runtime_context.validate_checkpoint_path(
+                require_exists=True,
+            )
+            self._resumable = True
+        except Exception as checkpoint_exc:
+            finalization.log.warning(
+                "Failed to persist resumable checkpoint: %s",
+                checkpoint_exc,
+            )
+
+    def close_execution_resources(
+        self,
+        *,
+        supervisor: Any | None,
+        heartbeat: Any | None,
+        file_history: Any | None,
+        log: Any,
+    ) -> None:
+        """Close all resources scoped to active Agent execution."""
+
+        try:
+            from src.tools.shell.background_task import BackgroundTaskRegistry
+
+            BackgroundTaskRegistry.get_instance().terminate_current_run()
+        except Exception as exc:
+            log.debug("Background task teardown skipped: %s", exc)
+        try:
+            from src.tools.shell.process import ShellProcessRegistry
+
+            ShellProcessRegistry.get_instance().release_current_run()
+        except Exception as exc:
+            log.debug("Shell session teardown skipped: %s", exc)
+        if heartbeat is not None:
+            try:
+                heartbeat.stop()
+            except Exception:
+                pass
+            try:
+                heartbeat.close()
+            except Exception:
+                pass
+        try:
+            mcp_manager = getattr(supervisor, "_mcp_manager", None)
+            if mcp_manager is not None:
+                mcp_manager.disconnect_all()
+        except Exception:
+            pass
+        if file_history is not None:
+            try:
+                file_history.close()
+            except Exception:
+                pass
+        invocation = self._invocation
+        if invocation is not None and invocation.coordinator is not None:
+            self.close_agent_coordinator(invocation.coordinator)
+
+    def close_agent_coordinator(self, coordinator: Any | None = None) -> None:
+        """Deactivate the reported coordinator through one teardown path."""
+
+        target = coordinator
+        if target is None and self._invocation is not None:
+            target = self._invocation.coordinator
+        if target is None:
+            return
+        from src.lib.checkpoint.coordinator import CheckpointCoordinator
+
+        try:
+            CheckpointCoordinator.deactivate(target)
+        except BaseException as exc:
+            self.fail_cleanup(exc)
+            raise
+
+    def close_resources(self, resources: ApplicationRunResources) -> None:
+        """Close execution and checkpoint resources without leaking either side."""
+
+        execution_cleanup_error: BaseException | None = None
+        try:
+            self.close_execution_resources(
+                supervisor=resources.supervisor,
+                heartbeat=resources.heartbeat,
+                file_history=resources.file_history,
+                log=resources.log,
+            )
+        except BaseException as exc:
+            execution_cleanup_error = exc
+        try:
+            self.close_checkpoint_resources(
+                task_lease=resources.task_lease,
+                checkpoint_manager=resources.checkpoint_manager,
+            )
+        except BaseException as exc:
+            if execution_cleanup_error is None:
+                raise
+            execution_cleanup_error.add_note(
+                f"Checkpoint resource cleanup also failed: {exc}"
+            )
+        if execution_cleanup_error is not None:
+            raise execution_cleanup_error
+
+    def close_checkpoint_resources(
+        self,
+        *,
+        task_lease: Any | None,
+        checkpoint_manager: CheckpointManager | None,
+    ) -> None:
+        """Release checkpoint resources while preserving the primary error."""
+
+        task_lease_error: BaseException | None = None
+        if task_lease is not None:
+            try:
+                task_lease.release()
+            except BaseException as exc:
+                self.enter_cleanup()
+                task_lease_error = exc
+        if checkpoint_manager is not None:
+            try:
+                checkpoint_manager.close()
+            except BaseException as exc:
+                self.enter_cleanup()
+                if task_lease_error is None:
+                    raise
+                task_lease_error.add_note(f"Checkpoint manager close also failed: {exc}")
+        if task_lease_error is not None:
+            raise task_lease_error
+
+    def release_run_lease(self, run_lease: Any | None) -> None:
+        if run_lease is None:
+            return
+        try:
+            run_lease.release()
+        except BaseException:
+            self.enter_cleanup()
+            raise
+
+
+def _persist_run_observability(
+    runtime_context: Any,
+    checkpoint_manager: CheckpointManager | None,
+    task_id: str,
+    *,
+    result: str | None,
+    event_start_offset: int | None,
+    manifest_updates: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Copy terminal task evidence into the immutable Run directory."""
+
+    if manifest_updates is None:
+        manifest_updates = {}
+    if result is not None:
+        result_artifact = runtime_context.artifacts_dir / "result.txt"
+        runtime_context.atomic_write_run_file(result_artifact, result)
+        manifest_updates.update(
+            result_artifact="artifacts/result.txt",
+            result_size=len(result.encode("utf-8")),
+        )
+
+    if checkpoint_manager is None:
+        return manifest_updates
+
+    goal = checkpoint_manager.load_goal(task_id)
+    if goal is not None:
+        runtime_context.atomic_write_run_file(
+            runtime_context.audit_dir / "goal.json",
+            json.dumps(
+                goal,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
+        manifest_updates.update(
+            goal=goal,
+            goal_artifact="audit/goal.json",
+        )
+
+    try:
+        runtime_context.atomic_write_run_file_chunks(
+            runtime_context.audit_dir / "task_tree.json",
+            _checkpoint_file_chunks(
+                checkpoint_manager,
+                task_id,
+                relative_path="task_tree.json",
+            ),
+        )
+    except FileNotFoundError:
+        pass
+    else:
+        manifest_updates["task_tree_artifact"] = "audit/task_tree.json"
+
+    if event_start_offset is not None:
+        event_stats = {"count": 0, "complete": True}
+        event_size = runtime_context.atomic_write_run_file_chunks(
+            runtime_context.audit_dir / "task_events.jsonl",
+            _run_event_chunks(
+                checkpoint_manager,
+                task_id,
+                start_offset=event_start_offset,
+                stats=event_stats,
+            ),
+        )
+        manifest_updates.update(
+            task_events_artifact="audit/task_events.jsonl",
+            task_events_run_id=runtime_context.run_id,
+            task_events_count=event_stats["count"],
+            task_events_size=event_size,
+            task_events_complete=event_stats["complete"],
+        )
+    return manifest_updates
+
+
+def _task_events_size(
+    checkpoint_manager: CheckpointManager,
+    task_id: str,
+) -> int:
+    try:
+        with checkpoint_manager.task_storage(task_id) as storage:
+            return storage.stat_file("task_events.jsonl").st_size
+    except (FileNotFoundError, OSError, RuntimeError):
+        return 0
+
+
+def _run_event_chunks(
+    checkpoint_manager: CheckpointManager,
+    task_id: str,
+    *,
+    start_offset: int,
+    stats: dict[str, Any],
+):
+    with checkpoint_manager.task_storage(task_id) as storage:
+        try:
+            with storage.open_binary_reader("task_events.jsonl") as stream:
+                size = os.fstat(stream.fileno()).st_size
+                if start_offset > size:
+                    stats["complete"] = False
+                    return
+                stream.seek(start_offset)
+                line_has_content = False
+                while True:
+                    chunk = stream.read(_RUN_ARTIFACT_COPY_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    segments = chunk.split(b"\n")
+                    for segment in segments[:-1]:
+                        if line_has_content or segment.strip():
+                            stats["count"] += 1
+                        line_has_content = False
+                    if segments[-1].strip():
+                        line_has_content = True
+                    yield chunk
+                if line_has_content:
+                    stats["count"] += 1
+        except FileNotFoundError:
+            stats["complete"] = False
+
+
+def _checkpoint_file_chunks(
+    checkpoint_manager: CheckpointManager,
+    task_id: str,
+    *,
+    relative_path: str,
+):
+    """Stream one maintained checkpoint projection without replaying events."""
+
+    with checkpoint_manager.task_storage(task_id) as storage:
+        with storage.open_binary_reader(relative_path) as stream:
+            while True:
+                chunk = stream.read(_RUN_ARTIFACT_COPY_CHUNK_BYTES)
+                if not chunk:
+                    return
+                yield chunk

--- a/src/lib/smolagents/agent/base_agent.py
+++ b/src/lib/smolagents/agent/base_agent.py
@@ -18,7 +18,10 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
 from threading import RLock
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.application_run_lifecycle import ApplicationRunLifecycle
 
 from smolagents import (
     AgentGenerationError,
@@ -1410,6 +1413,7 @@ class RoleDrivenAgent(BaseAgent):
         task_id: str | None = None,
         run_id: str | None = None,
         checkpoint_manager: Any | None = None,
+        application_lifecycle: "ApplicationRunLifecycle | None" = None,
         resume: bool = False,
         additional_args: dict[str, Any] | None = None,
     ) -> str:
@@ -1430,6 +1434,7 @@ class RoleDrivenAgent(BaseAgent):
                         task,
                         task_id=task_id,
                         checkpoint_manager=checkpoint_manager,
+                        application_lifecycle=application_lifecycle,
                         resume=resume,
                         additional_args=additional_args,
                         owns_root_run=owns_root_run,
@@ -1449,6 +1454,7 @@ class RoleDrivenAgent(BaseAgent):
         task: str,
         task_id: str | None = None,
         checkpoint_manager: Any | None = None,
+        application_lifecycle: "ApplicationRunLifecycle | None" = None,
         resume: bool = False,
         additional_args: dict[str, Any] | None = None,
         *,
@@ -1508,6 +1514,14 @@ class RoleDrivenAgent(BaseAgent):
             )
         else:
             coord = CheckpointCoordinator.current()
+
+        owns_application_lifecycle = False
+        if application_lifecycle is None and checkpoint_manager is not None:
+            from src.application_run_lifecycle import ApplicationRunLifecycle
+
+            application_lifecycle = ApplicationRunLifecycle()
+            application_lifecycle.enter_execution()
+            owns_application_lifecycle = True
 
         goal_provider = None
         if goal_config.enabled:
@@ -1722,99 +1736,113 @@ class RoleDrivenAgent(BaseAgent):
                 )
                 session_result = result
 
-                if coord is not None and checkpoint_manager is not None:
-                    coord.save_supervisor(runtime_agent, "completed", result=str(result) if result else None)
-
                 return result
-            except KeyboardInterrupt:
-                session_error = KeyboardInterrupt()
-                if coord is not None and checkpoint_manager is not None:
-                    coord.save_supervisor(runtime_agent, "interrupted")
-                raise
-            except Exception as exc:
+            except BaseException as exc:
                 from src.lib.goal import GoalBudgetLimitedError
 
                 session_error = exc
                 if isinstance(exc, GoalBudgetLimitedError):
-                    if coord is not None and checkpoint_manager is not None:
-                        coord.save_supervisor(
-                            runtime_agent,
-                            "budget_limited",
-                            error=str(exc),
-                        )
                     raise
-                self._emit_task_lifecycle_event(
-                    HookEvent.STOP_FAILURE,
-                    transformed_task,
-                    error=exc,
-                )
-                if coord is not None and checkpoint_manager is not None:
-                    coord.save_supervisor(runtime_agent, "failed", error=str(exc))
+                if isinstance(exc, Exception):
+                    self._emit_task_lifecycle_event(
+                        HookEvent.STOP_FAILURE,
+                        transformed_task,
+                        error=exc,
+                    )
                 raise
             finally:
-                if goal_provider is not None:
-                    self._last_goal_state = goal_provider.snapshot().to_dict()
-                if session_started:
-                    self._emit_session_lifecycle_event(
-                        HookEvent.SESSION_END,
-                        transformed_task,
-                        result=session_result,
-                        error=session_error,
-                    )
-                    if session_error is None:
-                        # SessionEnd owns only the short, deterministic ledger
-                        # write. Once a successful run is recorded, the root
-                        # owner may perform the optional synchronous review
-                        # while its trusted binding is still alive. Workers do
-                        # not enter this block, and review failure cannot change
-                        # the successful task result.
-                        try:
-                            from src.extensions.self_learning.paths import (
-                                review_config,
-                                self_learning_enabled,
-                            )
-
-                            effective_config = (
-                                self._effective_agent_config or self._config
-                            )
-                            review_policies = (
-                                review_config(effective_config, scope="application"),
-                                review_config(effective_config, scope="project"),
-                            )
-                            if (
-                                self_learning_enabled(effective_config)
-                                and any(
-                                    policy.get("enabled")
-                                    and str((policy.get("trigger") or {}).get("mode") or "manual")
-                                    != "manual"
-                                    for policy in review_policies
-                                )
-                            ):
-                                from src.extensions.self_learning.reviewer import (
-                                    review_finished_run,
-                                )
-
-                                review_finished_run(
-                                    root_run_id=require_root_run_id(),
-                                    agent_config=effective_config,
-                                )
-                        except Exception:
-                            if self._logger:
-                                self._logger.warning("Completed-run memory review failed unexpectedly")
-                if previous_model_agent_id is not ...:
-                    self._model.agent_id = previous_model_agent_id
-
+                application_lifecycle_error: BaseException | None = None
                 try:
-                    if checkpoint_manager is not None and coord is not None:
-                        CheckpointCoordinator.deactivate(coord)
+                    goal_snapshot = (
+                        goal_provider.snapshot().to_dict()
+                        if goal_provider is not None
+                        else None
+                    )
+                    if application_lifecycle is not None:
+                        try:
+                            application_lifecycle.report_agent_invocation(
+                                coordinator=coord,
+                                runtime_agent=runtime_agent,
+                                result=session_result,
+                                error=session_error,
+                                goal=goal_snapshot,
+                            )
+                            if owns_application_lifecycle:
+                                application_lifecycle.settle_reported_agent_invocation()
+                                application_lifecycle.commit_checkpoint(
+                                    checkpoint_manager=checkpoint_manager,
+                                    task_id=final_task_id,
+                                )
+                        except BaseException as exc:
+                            application_lifecycle_error = exc
+                    if session_started:
+                        self._emit_session_lifecycle_event(
+                            HookEvent.SESSION_END,
+                            transformed_task,
+                            result=session_result,
+                            error=session_error,
+                        )
+                        if session_error is None:
+                            # SessionEnd owns only the short, deterministic ledger
+                            # write. Once a successful run is recorded, the root
+                            # owner may perform the optional synchronous review
+                            # while its trusted binding is still alive. Workers do
+                            # not enter this block, and review failure cannot change
+                            # the successful task result.
+                            try:
+                                from src.extensions.self_learning.paths import (
+                                    review_config,
+                                    self_learning_enabled,
+                                )
+
+                                effective_config = (
+                                    self._effective_agent_config or self._config
+                                )
+                                review_policies = (
+                                    review_config(effective_config, scope="application"),
+                                    review_config(effective_config, scope="project"),
+                                )
+                                if (
+                                    self_learning_enabled(effective_config)
+                                    and any(
+                                        policy.get("enabled")
+                                        and str((policy.get("trigger") or {}).get("mode") or "manual")
+                                        != "manual"
+                                        for policy in review_policies
+                                    )
+                                ):
+                                    from src.extensions.self_learning.reviewer import (
+                                        review_finished_run,
+                                    )
+
+                                    review_finished_run(
+                                        root_run_id=require_root_run_id(),
+                                        agent_config=effective_config,
+                                    )
+                            except Exception:
+                                if self._logger:
+                                    self._logger.warning("Completed-run memory review failed unexpectedly")
+                    if previous_model_agent_id is not ...:
+                        self._model.agent_id = previous_model_agent_id
                 finally:
                     try:
-                        todo_provider_binding.__exit__(None, None, None)
+                        if (
+                            owns_application_lifecycle
+                            and checkpoint_manager is not None
+                            and coord is not None
+                        ):
+                            assert application_lifecycle is not None
+                            application_lifecycle.close_agent_coordinator(coord)
                     finally:
                         try:
-                            goal_provider_binding.__exit__(None, None, None)
+                            todo_provider_binding.__exit__(None, None, None)
                         finally:
-                            execution_binding.__exit__(None, None, None)
+                            try:
+                                goal_provider_binding.__exit__(None, None, None)
+                            finally:
+                                execution_binding.__exit__(None, None, None)
+                if application_lifecycle_error is not None:
+                    raise application_lifecycle_error
 
         if current_task_id:
             return _execute_agent()

--- a/src/runner.py
+++ b/src/runner.py
@@ -17,8 +17,6 @@ Usage (CLI)::
 
 from __future__ import annotations
 
-import json
-import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -33,9 +31,15 @@ from src.application_run import (
     RunEventSink,
     RunInfo,
     RunLifecycleEvent,
-    RunPhase,
     RunRejectedEvent,
     RunRejection,
+)
+from src.application_run_lifecycle import (
+    ApplicationRunFinalization,
+    ApplicationRunLifecycle,
+    ApplicationRunResources,
+    _run_event_chunks,  # noqa: F401 - public compatibility re-export
+    _task_events_size,
 )
 from src.lib.checkpoint import CheckpointManager
 from src.lib.checkpoint.file_history import FileHistoryManager
@@ -63,7 +67,6 @@ from src.lib.smolagents.agent.yaml_agent_factory import (
     YamlConfiguredSupervisorAgent,
 )
 
-_RUN_ARTIFACT_COPY_CHUNK_BYTES = 1024 * 1024
 _TASK_TREE_CLEANUP_MAX_BYTES = 1024 * 1024
 
 
@@ -165,144 +168,6 @@ def _events_for_run(events: list[dict[str, Any]], run_id: str) -> list[dict[str,
             elif explicit_run_id is None:
                 preamble.append(event)
     return projected
-
-
-def _persist_run_observability(
-    runtime_context: Any,
-    checkpoint_mgr: CheckpointManager | None,
-    task_id: str,
-    *,
-    result: str | None,
-    event_start_offset: int | None,
-    manifest_updates: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Copy durable evidence and retain references to every completed write.
-
-    ``manifest_updates`` is caller-owned so a later finalization failure can
-    still publish artifacts that were already committed to the Run directory.
-    """
-
-    if manifest_updates is None:
-        manifest_updates = {}
-    if result is not None:
-        result_artifact = runtime_context.artifacts_dir / "result.txt"
-        runtime_context.atomic_write_run_file(result_artifact, result)
-        manifest_updates.update(
-            result_artifact="artifacts/result.txt",
-            result_size=len(result.encode("utf-8")),
-        )
-
-    if checkpoint_mgr is None:
-        return manifest_updates
-
-    goal = checkpoint_mgr.load_goal(task_id)
-    if goal is not None:
-        runtime_context.atomic_write_run_file(
-            runtime_context.audit_dir / "goal.json",
-            json.dumps(
-                goal,
-                ensure_ascii=False,
-                sort_keys=True,
-                separators=(",", ":"),
-            ),
-        )
-        manifest_updates.update(
-            goal=goal,
-            goal_artifact="audit/goal.json",
-        )
-
-    try:
-        runtime_context.atomic_write_run_file_chunks(
-            runtime_context.audit_dir / "task_tree.json",
-            _checkpoint_file_chunks(
-                checkpoint_mgr,
-                task_id,
-                relative_path="task_tree.json",
-            ),
-        )
-    except FileNotFoundError:
-        pass
-    else:
-        manifest_updates["task_tree_artifact"] = "audit/task_tree.json"
-
-    if event_start_offset is not None:
-        event_stats = {"count": 0, "complete": True}
-        event_size = runtime_context.atomic_write_run_file_chunks(
-            runtime_context.audit_dir / "task_events.jsonl",
-            _run_event_chunks(
-                checkpoint_mgr,
-                task_id,
-                start_offset=event_start_offset,
-                stats=event_stats,
-            ),
-        )
-        manifest_updates.update(
-            task_events_artifact="audit/task_events.jsonl",
-            task_events_run_id=runtime_context.run_id,
-            task_events_count=event_stats["count"],
-            task_events_size=event_size,
-            task_events_complete=event_stats["complete"],
-        )
-    return manifest_updates
-
-
-def _task_events_size(checkpoint_mgr: CheckpointManager, task_id: str) -> int:
-    try:
-        with checkpoint_mgr.task_storage(task_id) as storage:
-            return storage.stat_file("task_events.jsonl").st_size
-    except (FileNotFoundError, OSError, RuntimeError):
-        return 0
-
-
-def _run_event_chunks(
-    checkpoint_mgr: CheckpointManager,
-    task_id: str,
-    *,
-    start_offset: int,
-    stats: dict[str, Any],
-):
-    with checkpoint_mgr.task_storage(task_id) as storage:
-        try:
-            with storage.open_binary_reader("task_events.jsonl") as stream:
-                size = os.fstat(stream.fileno()).st_size
-                if start_offset > size:
-                    stats["complete"] = False
-                    return
-                stream.seek(start_offset)
-                line_has_content = False
-                while True:
-                    chunk = stream.read(_RUN_ARTIFACT_COPY_CHUNK_BYTES)
-                    if not chunk:
-                        break
-                    segments = chunk.split(b"\n")
-                    for segment in segments[:-1]:
-                        if line_has_content or segment.strip():
-                            stats["count"] += 1
-                        line_has_content = False
-                    if segments[-1].strip():
-                        line_has_content = True
-                    yield chunk
-                if line_has_content:
-                    stats["count"] += 1
-        except FileNotFoundError:
-            stats["complete"] = False
-
-
-def _checkpoint_file_chunks(
-    checkpoint_mgr: CheckpointManager,
-    task_id: str,
-    *,
-    relative_path: str,
-):
-    """Stream one maintained checkpoint projection without replaying events."""
-
-    with checkpoint_mgr.task_storage(task_id) as storage:
-        with storage.open_binary_reader(relative_path) as stream:
-            while True:
-                chunk = stream.read(_RUN_ARTIFACT_COPY_CHUNK_BYTES)
-                if not chunk:
-                    return
-                yield chunk
 
 
 def _checkpoint_age_seconds(created_at: Any) -> float:
@@ -407,7 +272,7 @@ def execute_app(
         raise
     started_emitted = False
     manifest_initialized = False
-    phase: RunPhase = "initialization"
+    lifecycle = ApplicationRunLifecycle()
     log = None
     durable_manifest_updates: dict[str, Any] = {}
 
@@ -425,35 +290,13 @@ def execute_app(
             ),
         )
 
-    def update_failed_manifest(exc: BaseException) -> None:
-        if not manifest_initialized:
-            return
-        try:
-            runtime_context.update_manifest(
-                **durable_manifest_updates,
-                status=(
-                    "interrupted"
-                    if isinstance(exc, KeyboardInterrupt)
-                    else "budget_limited"
-                    if isinstance(exc, GoalBudgetLimitedError)
-                    else "failed"
-                ),
-                ended_at=datetime.now().astimezone().isoformat(),
-                error=str(exc),
-            )
-        except Exception:
-            return
-
     run_attempt_lease = None
     checkpoint_mgr: CheckpointManager | None = None
     task_lease: Any | None = None
     heartbeat: SupervisorHeartbeat | None = None
     file_history: FileHistoryManager | None = None
     supervisor: YamlConfiguredSupervisorAgent | None = None
-    result_str = ""
-    interrupt_resumable = False
     event_start_offset: int | None = None
-    checkpoint_deletion_started = False
 
     try:
         runtime_context.prepare_run()
@@ -494,10 +337,8 @@ def execute_app(
 
             with bind_logger_backend(logger_backend, context=runtime_context):
                 log = get_logger(logger_backend, __name__)
-                outcome = "failed"
-                outcome_error: str | None = None
                 try:
-                    phase = "execution"
+                    lifecycle.enter_execution()
                     log.info("Loading supervisor config: %s", resolved_path)
 
                     try:
@@ -691,225 +532,94 @@ def execute_app(
                         task_id=task_id,
                         run_id=run_id,
                         checkpoint_manager=checkpoint_mgr,
+                        application_lifecycle=lifecycle,
                         resume=is_resume,
                     )
-                    result_str = "" if agent_result is None else str(agent_result)
-                    phase = "finalization"
-                    outcome = "completed"
                     log.info("=" * 70)
                     log.info("Execution completed successfully.")
                     log.info("=" * 70)
+                    lifecycle.complete_execution(agent_result)
                 except GoalBudgetLimitedError as exc:
-                    outcome = "budget_limited"
-                    outcome_error = str(exc)
+                    lifecycle.fail_execution(exc)
                     log.warning(
                         "Goal token budget reached. Checkpoint preserved for task_id=%s",
                         task_id,
                     )
                     raise
                 except KeyboardInterrupt as exc:
-                    outcome = "interrupted"
-                    outcome_error = str(exc)
-                    if checkpoint_mgr is not None:
-                        try:
-                            runtime_context.validate_checkpoint_path(
-                                require_exists=True,
-                            )
-                            checkpoint_mgr.record_task_status_changed(
-                                task_id,
-                                "interrupted",
-                                error=outcome_error or "run interrupted",
-                            )
-                            interrupt_resumable = True
-                        except Exception as checkpoint_exc:
-                            log.warning(
-                                "Failed to persist resumable checkpoint: %s",
-                                checkpoint_exc,
-                            )
-                    if interrupt_resumable:
-                        log.warning(
-                            "Interrupted by user. Checkpoint saved for task_id=%s",
-                            task_id,
-                        )
-                        log.warning(
-                            "Resume with: loom run %s --resume %s",
-                            yaml_path,
-                            task_id,
-                        )
-                    else:
-                        log.warning(
-                            "Interrupted by user; no resumable checkpoint is available"
-                        )
+                    lifecycle.fail_execution(exc)
                     raise
                 except BaseException as exc:
-                    outcome_error = str(exc)
+                    lifecycle.fail_execution(exc)
                     if isinstance(exc, Exception):
                         log.error("Execution failed: %s", exc)
                     raise
                 finally:
                     try:
-                        from src.tools.shell.background_task import (
-                            BackgroundTaskRegistry,
-                        )
-
-                        BackgroundTaskRegistry.get_instance().terminate_current_run()
-                    except Exception as exc:
-                        log.debug(
-                            "Background task teardown skipped: %s",
-                            exc,
-                        )
-                    try:
-                        from src.tools.shell.process import ShellProcessRegistry
-
-                        ShellProcessRegistry.get_instance().release_current_run()
-                    except Exception as exc:
-                        log.debug("Shell session teardown skipped: %s", exc)
-                    if heartbeat is not None:
-                        try:
-                            heartbeat.stop()
-                        except Exception:
-                            pass
-                        try:
-                            heartbeat.close()
-                        except Exception:
-                            pass
-                    try:
-                        mcp_manager = getattr(supervisor, "_mcp_manager", None)
-                        if mcp_manager is not None:
-                            mcp_manager.disconnect_all()
-                    except Exception:
-                        pass
-                    if file_history is not None:
-                        try:
-                            file_history.close()
-                        except Exception:
-                            pass
-                    goal_snapshot = getattr(supervisor, "_last_goal_state", None)
-                    if isinstance(goal_snapshot, dict):
-                        durable_manifest_updates["goal"] = dict(goal_snapshot)
-                    try:
-                        if outcome == "completed":
-                            _persist_run_observability(
-                                runtime_context,
-                                checkpoint_mgr,
-                                task_id,
-                                result=result_str,
+                        lifecycle.finalize_run(
+                            ApplicationRunFinalization(
+                                runtime_context=runtime_context,
+                                checkpoint_manager=checkpoint_mgr,
+                                task_id=task_id,
                                 event_start_offset=event_start_offset,
                                 manifest_updates=durable_manifest_updates,
+                                cleanup_on_success=cleanup_on_success,
+                                log=log,
+                                task_tree_cleanup_max_bytes=_TASK_TREE_CLEANUP_MAX_BYTES,
                             )
-                        else:
-                            try:
-                                _persist_run_observability(
-                                    runtime_context,
-                                    checkpoint_mgr,
-                                    task_id,
-                                    result=None,
-                                    event_start_offset=event_start_offset,
-                                    manifest_updates=durable_manifest_updates,
-                                )
-                            except Exception as exc:
-                                log.warning(
-                                    "Failed to persist Run observability: %s",
-                                    exc,
-                                )
-                        manifest_updates = {
-                            "status": outcome,
-                            "ended_at": datetime.now().astimezone().isoformat(),
-                            **durable_manifest_updates,
-                        }
-                        if outcome_error:
-                            manifest_updates["error"] = outcome_error
-                        try:
-                            runtime_context.update_manifest(**manifest_updates)
-                        except Exception as exc:
-                            if outcome == "completed":
-                                raise
-                            log.warning(
-                                "Failed to persist terminal manifest: %s",
-                                exc,
-                            )
-                        if outcome == "completed" and cleanup_on_success and checkpoint_mgr is not None:
-                            try:
-                                tree = checkpoint_mgr.load_task_tree_projection(
-                                    task_id,
-                                    max_bytes=_TASK_TREE_CLEANUP_MAX_BYTES,
-                                )
-                                if tree and tree.get("status") == "completed":
-                                    # Deletion is an irreversible commit point. If
-                                    # it is interrupted, never recreate a skeletal
-                                    # checkpoint and advertise it as resumable.
-                                    checkpoint_deletion_started = True
-                                    if checkpoint_mgr.delete_task(task_id):
-                                        log.info(
-                                            "Cleaned up checkpoint for completed task %s",
-                                            task_id,
-                                        )
-                            except Exception:
-                                pass
-                    except KeyboardInterrupt as exc:
-                        outcome = "interrupted"
-                        outcome_error = str(exc)
-                        if checkpoint_mgr is not None and not checkpoint_deletion_started:
-                            try:
-                                runtime_context.validate_checkpoint_path(
-                                    require_exists=True,
-                                )
-                                checkpoint_mgr.record_task_status_changed(
-                                    task_id,
-                                    "interrupted",
-                                    error=outcome_error or "run interrupted",
-                                )
-                                interrupt_resumable = True
-                            except Exception as checkpoint_exc:
-                                log.warning(
-                                    "Failed to reopen checkpoint after finalization interruption: %s",
-                                    checkpoint_exc,
-                                )
-                        raise
+                        )
                     finally:
-                        task_lease_error: BaseException | None = None
-                        if task_lease is not None:
-                            try:
-                                task_lease.release()
-                            except BaseException as exc:
-                                phase = "cleanup"
-                                task_lease_error = exc
-                        if checkpoint_mgr is not None:
-                            try:
-                                checkpoint_mgr.close()
-                            except BaseException as exc:
-                                phase = "cleanup"
-                                if task_lease_error is None:
-                                    raise
-                                task_lease_error.add_note(f"Checkpoint manager close also failed: {exc}")
-                        if task_lease_error is not None:
-                            raise task_lease_error
+                        lifecycle.close_resources(
+                            ApplicationRunResources(
+                                supervisor=supervisor,
+                                heartbeat=heartbeat,
+                                file_history=file_history,
+                                log=log,
+                                task_lease=task_lease,
+                                checkpoint_manager=checkpoint_mgr,
+                            )
+                        )
         if run_attempt_lease is not None:
-            try:
-                run_attempt_lease.release()
-            except BaseException:
-                phase = "cleanup"
-                raise
+            lifecycle.release_run_lease(run_attempt_lease)
             run_attempt_lease = None
     except BaseException as caught:
         terminal_error = caught
         if run_attempt_lease is not None:
             try:
-                run_attempt_lease.release()
+                lifecycle.release_run_lease(run_attempt_lease)
             except BaseException as cleanup_exc:
                 terminal_error = cleanup_exc
-                phase = "cleanup"
             run_attempt_lease = None
         emit_started()
-        update_failed_manifest(terminal_error)
+        lifecycle.persist_uncaught_failure(
+            runtime_context=runtime_context,
+            manifest_initialized=manifest_initialized,
+            manifest_updates=durable_manifest_updates,
+            error=terminal_error,
+        )
         ended_at = datetime.now().astimezone()
         if isinstance(terminal_error, KeyboardInterrupt):
+            if log is not None:
+                if lifecycle.resumable:
+                    log.warning(
+                        "Interrupted by user. Checkpoint saved for task_id=%s",
+                        task_id,
+                    )
+                    log.warning(
+                        "Resume with: loom run %s --resume %s",
+                        yaml_path,
+                        task_id,
+                    )
+                else:
+                    log.warning(
+                        "Interrupted by user; no resumable checkpoint is available"
+                    )
             interrupted = ApplicationRunInterrupted(
                 "Application run interrupted",
                 run=public_run,
-                phase=phase,
+                phase=lifecycle.phase,
                 original_error=terminal_error,
-                resumable=interrupt_resumable,
+                resumable=lifecycle.resumable,
             )
             _emit_lifecycle_event(
                 event_sink,
@@ -918,7 +628,7 @@ def execute_app(
                     run=public_run,
                     occurred_at=ended_at,
                     error=str(interrupted),
-                    phase=phase,
+                    phase=lifecycle.phase,
                     goal=durable_manifest_updates.get("goal"),
                 ),
             )
@@ -929,7 +639,7 @@ def execute_app(
             limited = ApplicationRunBudgetLimited(
                 str(terminal_error),
                 run=public_run,
-                phase=phase,
+                phase=lifecycle.phase,
                 original_error=terminal_error,
                 goal=goal,
             )
@@ -940,7 +650,7 @@ def execute_app(
                     run=public_run,
                     occurred_at=ended_at,
                     error=str(limited),
-                    phase=phase,
+                    phase=lifecycle.phase,
                     goal=goal,
                 ),
             )
@@ -951,7 +661,7 @@ def execute_app(
             message = type(terminal_error).__name__
             if detail:
                 message = f"{message}: {detail}"
-        elif phase != "execution" or isinstance(
+        elif lifecycle.phase != "execution" or isinstance(
             terminal_error,
             (FileNotFoundError, ValueError),
         ):
@@ -961,7 +671,7 @@ def execute_app(
         failure = ApplicationRunError(
             message,
             run=public_run,
-            phase=phase,
+            phase=lifecycle.phase,
             original_error=terminal_error,
         )
         _emit_lifecycle_event(
@@ -971,14 +681,14 @@ def execute_app(
                 run=public_run,
                 occurred_at=ended_at,
                 error=message,
-                phase=phase,
+                phase=lifecycle.phase,
                 goal=durable_manifest_updates.get("goal"),
             ),
         )
         raise failure from terminal_error
     ended_at = datetime.now().astimezone()
     application_result = ApplicationRunResult(
-        output=result_str,
+        output=lifecycle.result,
         run=public_run,
         started_at=started_at,
         ended_at=ended_at,
@@ -990,7 +700,7 @@ def execute_app(
             event="run.completed",
             run=public_run,
             occurred_at=ended_at,
-            output=result_str,
+            output=lifecycle.result,
             goal=durable_manifest_updates.get("goal"),
         ),
     )

--- a/tests/agent_test/runtime_builder_test/test_runtime_builder.py
+++ b/tests/agent_test/runtime_builder_test/test_runtime_builder.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
@@ -160,6 +161,87 @@ def _make_review_agent(*, logger=None) -> DummyAgent:
         model=object(),
         logger=logger,
     )
+
+
+def test_role_driven_agent_reports_to_application_lifecycle(monkeypatch):
+    agent = _make_agent(logger=DummyLoggerBackend())
+    runtime = DummyRuntimeRunner("reported-result")
+    lifecycle = MagicMock()
+    monkeypatch.setattr(agent, "build_runtime_agent", lambda: runtime)
+    monkeypatch.setattr(agent, "_inject_memory_snapshot", lambda tasks: tasks)
+
+    result = agent.run(
+        "application task",
+        task_id="task-1",
+        application_lifecycle=lifecycle,
+    )
+
+    assert result == "reported-result"
+    lifecycle.report_agent_invocation.assert_called_once_with(
+        coordinator=None,
+        runtime_agent=runtime,
+        result="reported-result",
+        error=None,
+        goal=None,
+    )
+
+
+def test_standalone_checkpoint_failure_still_deactivates_coordinator(
+    tmp_path,
+    monkeypatch,
+):
+    from src.lib.checkpoint import CheckpointManager
+    from src.lib.checkpoint.coordinator import CheckpointCoordinator
+
+    agent = _make_agent(logger=DummyLoggerBackend())
+    runtime = DummyRuntimeRunner("reported-result")
+    manager = CheckpointManager("runtime-dummy", checkpoints_root=tmp_path)
+    monkeypatch.setattr(agent, "build_runtime_agent", lambda: runtime)
+    monkeypatch.setattr(agent, "_inject_memory_snapshot", lambda tasks: tasks)
+    monkeypatch.setattr(
+        CheckpointCoordinator,
+        "save_supervisor",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError("checkpoint write failed")
+        ),
+    )
+
+    with pytest.raises(OSError, match="checkpoint write failed"):
+        agent.run(
+            "standalone task",
+            task_id="task-checkpoint-failure",
+            checkpoint_manager=manager,
+        )
+
+    assert CheckpointCoordinator.current() is None
+
+
+def test_standalone_base_exception_is_persisted_as_failure(tmp_path, monkeypatch):
+    from src.lib.checkpoint import CheckpointManager
+
+    agent = _make_agent(logger=DummyLoggerBackend())
+    runtime = DummyRuntimeRunner()
+    runtime.memory = MagicMock(steps=[])
+    manager = CheckpointManager("runtime-dummy", checkpoints_root=tmp_path)
+
+    def _exit(*, task, **kwargs):
+        raise SystemExit("runtime exited")
+
+    runtime.run = _exit
+    monkeypatch.setattr(agent, "build_runtime_agent", lambda: runtime)
+    monkeypatch.setattr(agent, "_inject_memory_snapshot", lambda tasks: tasks)
+
+    with pytest.raises(SystemExit, match="runtime exited"):
+        agent.run(
+            "standalone task",
+            task_id="task-system-exit",
+            checkpoint_manager=manager,
+        )
+
+    tree = manager.load_task_tree("task-system-exit")
+    assert tree is not None
+    assert tree["status"] == "failed"
+    assert tree["error"] == "runtime exited"
 
 
 def test_manual_review_policy_never_enters_run_end_reviewer(monkeypatch):

--- a/tests/test_application_run_lifecycle.py
+++ b/tests/test_application_run_lifecycle.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from src.application_run_lifecycle import (
+    ApplicationRunFinalization,
+    ApplicationRunLifecycle,
+    ApplicationRunResources,
+)
+
+
+def test_lifecycle_defers_agent_checkpoint_until_run_owner_commits() -> None:
+    lifecycle = ApplicationRunLifecycle()
+    coordinator = MagicMock()
+    runtime_agent = SimpleNamespace(memory=SimpleNamespace(steps=[]))
+    manager = MagicMock()
+
+    lifecycle.enter_execution()
+    lifecycle.report_agent_invocation(
+        coordinator=coordinator,
+        runtime_agent=runtime_agent,
+        result="done",
+        error=None,
+        goal={"status": "complete"},
+    )
+    lifecycle.settle_reported_agent_invocation()
+
+    coordinator.save_supervisor.assert_not_called()
+    manager.record_task_status_changed.assert_not_called()
+
+    lifecycle.commit_checkpoint(
+        checkpoint_manager=manager,
+        task_id="task-1",
+    )
+
+    coordinator.save_supervisor.assert_called_once_with(
+        runtime_agent,
+        "completed",
+        result="done",
+        error=None,
+    )
+    assert lifecycle.goal == {"status": "complete"}
+
+
+def test_finalization_failure_replaces_provisional_success_checkpoint() -> None:
+    lifecycle = ApplicationRunLifecycle()
+    coordinator = MagicMock()
+    runtime_agent = SimpleNamespace(memory=SimpleNamespace(steps=[]))
+    manager = MagicMock()
+
+    lifecycle.enter_execution()
+    lifecycle.report_agent_invocation(
+        coordinator=coordinator,
+        runtime_agent=runtime_agent,
+        result="done",
+        error=None,
+        goal=None,
+    )
+    lifecycle.complete_execution("done")
+    lifecycle.commit_checkpoint(
+        checkpoint_manager=manager,
+        task_id="task-1",
+    )
+
+    failure = OSError("manifest commit failed")
+    lifecycle.fail_finalization(failure)
+    lifecycle.commit_checkpoint(
+        checkpoint_manager=manager,
+        task_id="task-1",
+    )
+
+    assert coordinator.save_supervisor.call_args_list == [
+        call(runtime_agent, "completed", result="done", error=None),
+        call(
+            runtime_agent,
+            "failed",
+            result=None,
+            error="manifest commit failed",
+        ),
+    ]
+
+
+def test_finalize_run_owns_evidence_manifest_and_success_cleanup(
+    monkeypatch,
+) -> None:
+    lifecycle = ApplicationRunLifecycle()
+    runtime_context = MagicMock()
+    manager = MagicMock()
+    manager.load_task_tree_projection.return_value = {"status": "completed"}
+    manager.delete_task.return_value = True
+    persist_observability = MagicMock()
+    manifest_updates: dict[str, object] = {}
+    monkeypatch.setattr(
+        "src.application_run_lifecycle._persist_run_observability",
+        persist_observability,
+    )
+
+    lifecycle.enter_execution()
+    lifecycle.complete_execution("done")
+    lifecycle.finalize_run(
+        ApplicationRunFinalization(
+            runtime_context=runtime_context,
+            checkpoint_manager=manager,
+            task_id="task-1",
+            event_start_offset=10,
+            manifest_updates=manifest_updates,
+            cleanup_on_success=True,
+            log=MagicMock(),
+        )
+    )
+
+    manager.record_task_status_changed.assert_called_once_with(
+        "task-1",
+        "completed",
+        result="done",
+        error=None,
+    )
+    persist_observability.assert_called_once_with(
+        runtime_context,
+        manager,
+        "task-1",
+        result="done",
+        event_start_offset=10,
+        manifest_updates=manifest_updates,
+    )
+    runtime_context.update_manifest.assert_called_once()
+    assert runtime_context.update_manifest.call_args.kwargs["status"] == "completed"
+    manager.delete_task.assert_called_once_with("task-1")
+
+
+def test_finalization_failure_can_replace_an_execution_failure() -> None:
+    lifecycle = ApplicationRunLifecycle()
+
+    lifecycle.enter_execution()
+    lifecycle.fail_execution(RuntimeError("agent failed"))
+    lifecycle.fail_finalization(OSError("checkpoint commit failed"))
+
+    assert lifecycle.phase == "finalization"
+    assert lifecycle.outcome == "failed"
+    assert lifecycle.error_message == "checkpoint commit failed"
+
+
+def test_terminal_checkpoint_precedes_coordinator_deactivation(monkeypatch) -> None:
+    from src.lib.checkpoint.coordinator import CheckpointCoordinator
+
+    lifecycle = ApplicationRunLifecycle()
+    coordinator = MagicMock()
+    runtime_agent = SimpleNamespace(memory=SimpleNamespace(steps=[]))
+    manager = MagicMock()
+    observed: list[str] = []
+    coordinator.save_supervisor.side_effect = lambda *_args, **_kwargs: observed.append("checkpoint")
+    monkeypatch.setattr(
+        CheckpointCoordinator,
+        "deactivate",
+        lambda current: observed.append("deactivate"),
+    )
+
+    lifecycle.enter_execution()
+    lifecycle.report_agent_invocation(
+        coordinator=coordinator,
+        runtime_agent=runtime_agent,
+        result="done",
+        error=None,
+        goal=None,
+    )
+    lifecycle.complete_execution("done")
+    lifecycle.commit_checkpoint(
+        checkpoint_manager=manager,
+        task_id="task-1",
+    )
+    lifecycle.close_execution_resources(
+        supervisor=None,
+        heartbeat=None,
+        file_history=None,
+        log=MagicMock(),
+    )
+
+    assert observed == ["checkpoint", "deactivate"]
+
+
+def test_checkpoint_resources_close_when_coordinator_deactivation_fails(
+    monkeypatch,
+) -> None:
+    from src.lib.checkpoint.coordinator import CheckpointCoordinator
+
+    lifecycle = ApplicationRunLifecycle()
+    coordinator = MagicMock()
+    task_lease = MagicMock()
+    manager = MagicMock()
+    lifecycle.enter_execution()
+    lifecycle.report_agent_invocation(
+        coordinator=coordinator,
+        runtime_agent=MagicMock(),
+        result=None,
+        error=RuntimeError("agent failed"),
+        goal=None,
+    )
+    lifecycle.settle_reported_agent_invocation()
+    monkeypatch.setattr(
+        CheckpointCoordinator,
+        "deactivate",
+        lambda _current: (_ for _ in ()).throw(OSError("context close failed")),
+    )
+
+    with pytest.raises(OSError, match="context close failed"):
+        lifecycle.close_resources(
+            ApplicationRunResources(
+                supervisor=None,
+                heartbeat=None,
+                file_history=None,
+                log=MagicMock(),
+                task_lease=task_lease,
+                checkpoint_manager=manager,
+            )
+        )
+
+    task_lease.release.assert_called_once_with()
+    manager.close.assert_called_once_with()
+    assert lifecycle.phase == "cleanup"
+
+
+def test_lifecycle_rejects_invalid_phase_transition() -> None:
+    lifecycle = ApplicationRunLifecycle()
+
+    with pytest.raises(RuntimeError, match="cannot complete execution"):
+        lifecycle.complete_execution("too early")
+
+
+def test_uncaught_cleanup_failure_replaces_completed_internal_state() -> None:
+    lifecycle = ApplicationRunLifecycle()
+    runtime_context = MagicMock()
+    failure = OSError("lease release failed")
+
+    lifecycle.enter_execution()
+    lifecycle.complete_execution("done")
+    lifecycle.enter_cleanup()
+    lifecycle.persist_uncaught_failure(
+        runtime_context=runtime_context,
+        manifest_initialized=True,
+        manifest_updates={},
+        error=failure,
+    )
+
+    assert lifecycle.phase == "cleanup"
+    assert lifecycle.outcome == "failed"
+    assert lifecycle.error is failure
+    runtime_context.update_manifest.assert_called_once()
+    assert runtime_context.update_manifest.call_args.kwargs["status"] == "failed"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -234,6 +234,7 @@ class TestRunApp:
             observed["context"] = context
             observed["kwargs"] = kwargs
             observed["manifest_exists"] = context.manifest_path.exists()
+            observed["task_tree_exists"] = context.task_tree_path.exists()
             return "ok"
 
         mock_agent.run.side_effect = _run
@@ -248,7 +249,8 @@ class TestRunApp:
         assert observed["kwargs"]["run_id"] == context.run_id
         assert context.manifest_path.parent == context.run_dir
         assert not context.log_path.exists()
-        assert context.task_tree_path.exists()
+        assert observed["task_tree_exists"] is True
+        assert not context.task_tree_path.exists()
         assert not (fake_yaml.parents[3] / ".logs").exists()
 
     @patch("src.runner.YamlConfiguredSupervisorAgent")
@@ -482,6 +484,11 @@ class TestRunApp:
         assert "result persistence failed" in manifest["error"]
         assert observed["manifest_updates"] == 1
         assert context.checkpoint_dir.exists()
+        checkpoint = json.loads(
+            context.task_tree_path.read_text(encoding="utf-8")
+        )
+        assert checkpoint["status"] == "failed"
+        assert checkpoint["error"] == "result persistence failed"
         with CheckpointTaskLease(context.checkpoint_dir, require_exists=True):
             pass
 
@@ -772,6 +779,8 @@ class TestRunApp:
 
         def _run(_task, **kwargs):
             attempts.append((get_current_run_context(required=True), kwargs))
+            if len(attempts) == 1:
+                raise RuntimeError("preserve the first attempt for resume")
             return "ok"
 
         mock_agent.run.side_effect = _run
@@ -786,7 +795,8 @@ class TestRunApp:
             reject_cumulative_event_load,
         )
 
-        run_app(str(fake_yaml), file_logging=False)
+        with pytest.raises(RuntimeError, match="preserve the first attempt"):
+            run_app(str(fake_yaml), file_logging=False)
         first_context, first_kwargs = attempts[0]
         run_app(
             str(fake_yaml),
@@ -911,9 +921,10 @@ class TestRunApp:
         from src.runner import run_app
 
         mock_agent = MagicMock()
-        mock_agent.run.return_value = "initial"
+        mock_agent.run.side_effect = RuntimeError("preserve for concurrent resume")
         mock_cls.return_value = mock_agent
-        run_app(str(fake_yaml), file_logging=False)
+        with pytest.raises(RuntimeError, match="preserve for concurrent resume"):
+            run_app(str(fake_yaml), file_logging=False)
         checkpoint_root = fake_yaml.parents[3] / ".agentloom" / "checkpoints" / "test_app"
         logical_task_id = next(checkpoint_root.iterdir()).name
 
@@ -1290,6 +1301,66 @@ def test_structured_run_api_is_publicly_exported():
 
 
 class TestExecuteApp:
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_application_run_owns_successful_checkpoint_terminal_state(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        """A Supervisor reports output; the Application Run commits success."""
+
+        from src.runner import execute_app
+
+        mock_cls.return_value.run.return_value = "owner-settled-output"
+
+        result = execute_app(str(fake_yaml), file_logging=False)
+
+        manifest = json.loads(result.run.manifest_path.read_text(encoding="utf-8"))
+        task_tree = json.loads(
+            (result.run.run_dir / manifest["task_tree_artifact"]).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert task_tree["status"] == "completed"
+        assert task_tree["result"] == "owner-settled-output"
+        assert not result.run.run_dir.parents[2].joinpath(
+            "checkpoints",
+            result.run.application_id,
+            result.run.task_id,
+        ).exists()
+
+    @patch("src.runner.YamlConfiguredSupervisorAgent")
+    def test_application_run_owns_failed_checkpoint_terminal_state(
+        self,
+        mock_cls,
+        fake_yaml: Path,
+    ) -> None:
+        """A Supervisor reports failure; the Application Run commits failure."""
+
+        from src.application_run import ApplicationRunError
+        from src.runner import execute_app
+
+        mock_cls.return_value.run.side_effect = RuntimeError("owner-settled-failure")
+
+        with pytest.raises(ApplicationRunError) as caught:
+            execute_app(str(fake_yaml), file_logging=False)
+
+        manifest = json.loads(
+            caught.value.run.manifest_path.read_text(encoding="utf-8")
+        )
+        task_tree = json.loads(
+            (caught.value.run.run_dir / manifest["task_tree_artifact"]).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert task_tree["status"] == "failed"
+        assert task_tree["error"] == "owner-settled-failure"
+        assert caught.value.run.run_dir.parents[2].joinpath(
+            "checkpoints",
+            caught.value.run.application_id,
+            caught.value.run.task_id,
+        ).is_dir()
+
     @patch("src.runner.YamlConfiguredSupervisorAgent")
     def test_resume_rejects_disabling_a_persisted_active_goal(
         self,
@@ -1676,7 +1747,12 @@ class TestExecuteApp:
             raise marker
 
         def record_close(manager):
-            closed_managers.append(manager)
+            checkpoint_dir = manager.checkpoint_dir
+            if (
+                checkpoint_dir is not None
+                and fake_yaml.parents[3] in checkpoint_dir.parents
+            ):
+                closed_managers.append(manager)
             original_close(manager)
 
         monkeypatch.setattr(CheckpointTaskLease, "release", release_then_fail)


### PR DESCRIPTION
## Summary

- introduce one deep `ApplicationRunLifecycle` owner for terminal outcome, checkpoint state, Run evidence, manifest finalization, resumability, successful-checkpoint deletion, and cleanup ordering
- make `RoleDrivenAgent` report its runtime snapshot to the top-level owner while preserving standalone checkpoint behavior through the same lifecycle implementation
- remove the private `_last_goal_state` handoff and prevent checkpoint/finalization/cleanup failures from producing contradictory terminal state
- document the ordered terminal transaction in English and Chinese

## Lifecycle invariants

1. Supervisor execution reports its runtime snapshot without independently committing an Application terminal state.
2. Terminal checkpoint is committed before ContextEngine/Coordinator teardown, so context-store statistics are complete.
3. Result and audit evidence are durable before the terminal manifest and optional successful checkpoint deletion.
4. A pre-deletion finalization failure replaces provisional success with failed/interrupted and preserves resume evidence.
5. Standalone checkpoint errors cannot skip coordinator/provider/context teardown; all `BaseException` paths settle as failures.

## Verification

- `uv run pytest -q`: **3618 passed, 2 skipped**
- targeted lifecycle/runner/checkpoint suite: **151 passed**
- Ruff: passed
- mypy (`--follow-imports=skip` on lifecycle and runner): passed
- two-axis code review: no remaining spec findings; no documented-standard violations

## Real LLM acceptance

Executed 17 real-model attempts across 12 repository Applications, covering `completed`, `failed`, `interrupted`, `budget_limited`, and resume transitions. Representative results:

- trivial Todo and tool-resolution Applications completed after the final architecture move
- ContextEngine text, JSON, and multi-Worker retrieval passed; terminal checkpoint snapshots retained 1/1/2 context refs respectively
- a JSON max-steps failure resumed under the same task ID and completed with a new run ID
- multi-Agent checkpoint Supervisor completed Worker file processing and cleanup
- parallel Goal workload crossed its 50k soft budget, emitted `run.budget_limited`, and preserved Goal/checkpoint state
- an interrupted real provider run emitted `run.interrupted` and retained resume state

No unrelated working-tree changes are included.