### PR TITLE
Improve README, Recall safety, and TUI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,80 @@ English | <a href="docs/cn/README.md">简体中文</a>
 <h1 align="center">AgentLoom</h1>
 
 <p align="center">
-  <strong>Create, run, and inspect YAML-defined multi-agent applications.</strong>
+  <strong>Build multi-agent applications from YAML. Operate them from an evidence-aware terminal Studio.</strong>
 </p>
 
 <p align="center">
-  Use Application Studio to create, modify, validate, run, and inspect AgentLoom Applications from one terminal.
+  Typed Workers, permissioned edits, resumable Runs, explicit Goal budgets, and review-gated memory share one runtime truth.
 </p>
 
 <p align="center">
   <a href="https://github.com/linora-u/AgentLoom/actions/workflows/tests.yml"><img alt="tests" src="https://github.com/linora-u/AgentLoom/actions/workflows/tests.yml/badge.svg"></a>
   <a href="https://www.python.org/downloads/"><img alt="python >=3.12" src="https://img.shields.io/badge/python-%3E%3D3.12-3776AB?logo=python&logoColor=white"></a>
-  <a href="https://github.com/linora-u/AgentLoom/releases/tag/v1.0.1"><img alt="release v1.0.1" src="https://img.shields.io/badge/release-v1.0.1-007EC6"></a>
+  <img alt="version 1.0.1" src="https://img.shields.io/badge/version-1.0.1-007EC6">
 </p>
 
 <p align="center">
-  <img alt="AgentLoom application flow" src="docs/assets/agentloom-application-flow.svg">
+  <img alt="AgentLoom Application Studio running in a real terminal" src="docs/assets/agentloom-studio.svg">
 </p>
 
-## Install
+<p align="center"><sub>Real reduced-motion terminal session using the current Chinese UI. The Studio indexes Applications, Skills, validation state, Runs, and commands from the project.</sub></p>
 
-The source installer is the recommended starting point. It prepares the TUI, the Python runtime, and their dependencies together, so you do not need to build environments by hand.
+AgentLoom treats a multi-agent system as an **Application with an execution
+contract**. YAML defines the Supervisor, typed Workers, models, tools, Skills,
+Hooks, permissions, and runtime policy. Application Studio can change that
+contract, show the Diff, request permission for side effects, run it, read
+structured evidence, and continue repairing failures.
+
+## Why AgentLoom
+
+### Workers become typed tools
+
+A Worker declares `agent_function_schema`; the runtime turns it into a validated
+callable tool for its Supervisor. Workers can use different models and tools,
+run concurrently, and expose stable input/output contracts instead of relying on
+prompt conventions.
+
+### Runs produce evidence, not terminal guesses
+
+Every allocated Run receives an immutable `run_id`, manifest, and versioned
+lifecycle events, with bounded file logs when enabled plus audit records and
+artifacts. A logical `task_id` survives resume. The TUI, CLI JSON/JSONL, and
+Python API read the same canonical state. Preflight rejection occurs before a
+Run or its storage is allocated.
+
+### Long-running work has an explicit owner
+
+Goal Mode keeps one root Supervisor objective active across continuation
+segments and Worker delegation. Only that Supervisor can mark the Goal complete
+with evidence. An optional token budget covers the whole Agent tree. When
+checkpointing is enabled, `budget_limited` preserves recovery state for a later
+resume.
+
+### Memory has review boundaries
+
+AgentLoom separates two jobs:
+
+- [`agent-recall-with-files`](skills/agent-recall-with-files/SKILL.md) keeps
+  lightweight task recovery notes and Agent-local experience in canonical
+  workspace files. Its optional Hook Bundle injects recent notes and uses
+  freshness-based reminders.
+- [Self-Learning v6](docs/en/self_learning.md) stores searchable history and
+  evidence-gated memory separately. Fact and experience candidates pass
+  evidence gates and the configured scope-approval policy; promotion to Project
+  scope is always initiated by a person.
+
+### Extensions do not silently gain authority
+
+Skills are model-context packages loaded on demand. Hooks are separately and
+explicitly authorized runtime code. Built-in tool metadata is discoverable
+without importing implementations, while actual tool, file, Shell, and MCP
+access remains governed by Agent configuration and permissions.
+
+## Quick start
+
+The source installer builds the TUI and prepares a locked Python environment for
+the current checkout:
 
 ```bash
 git clone https://github.com/linora-u/AgentLoom.git
@@ -32,49 +86,20 @@ cd AgentLoom
 ./install
 ```
 
-Open a new terminal after installation, then verify the command from the repository root:
+It currently supports macOS and Linux shells and requires Git and Bash. It
+installs missing `uv` and Bun through their official installers, then places the
+compatible unit under `~/.agentloom`. Open a new terminal and verify it:
 
 ```bash
 agentloom --version
 agentloom --snapshot
 ```
 
-The installer:
-
-- installs missing `uv` and Bun with their official installers;
-- creates a locked Python environment under `~/.agentloom/venv`;
-- builds the current-platform TypeScript/OpenTUI binary;
-- installs `agentloom` and `agentloom-tui` under `~/.agentloom/bin`;
-- adds that directory to your shell `PATH` when a writable shell config exists.
-
-The source installer currently targets macOS and Linux shells. It requires Git and Bash; `curl` is required only when `uv` or Bun must be installed.
-
-Rerun `./install` to update from source. Once installed, `agentloom update`
-rebuilds from the recorded trusted checkout. `--no-modify-path` is only an
-optional switch that leaves shell configuration unchanged; it is not an update
-requirement.
-
-The installed TUI checks that trusted checkout in the background. If relevant
-source files are newer than the installed compatible unit, `Ctrl+X` offers an
-explicit whole-product update and safe restart. It never pulls Git or replaces
-an active Session silently.
-
-Use a custom install location or leave `PATH` unchanged when needed:
-
-```bash
-AGENTLOOM_INSTALL_DIR="$HOME/tools/agentloom" ./install
-./install --no-modify-path
-```
-
-### Configure Application models
-
-Copy the model template before using TUI chat or running an Agent:
+Create the local model configuration:
 
 ```bash
 cp config/llm.example.yaml config/llm.yaml
 ```
-
-Edit `config/llm.yaml` and replace the placeholders. Do not commit this file; it is ignored because it contains credentials.
 
 ```yaml
 model:
@@ -84,36 +109,24 @@ model:
     api_key: "<api-key>"
     base_url: "https://<openai-compatible-endpoint>"  # optional for OpenAI
     tool_choice: "auto"
+  fast:
+    model: "openai/<fast-model-id>"
+    api_key: "<api-key>"
+    base_url: "https://<openai-compatible-endpoint>"
+    tool_choice: "auto"
 ```
 
-This file is the single model configuration source for both runtimes.
-Application Agents resolve it through Python and their YAML `model_type`; the
-TypeScript Studio adapter maps the same profiles, endpoints, credentials, and
-compatible request options into the bundled Studio runtime. `/models` and
-`Ctrl+X` select a Studio profile from `config/llm.yaml` without changing any
-Application's `model_type`. Studio startup fails clearly instead of falling
-back to an unconfigured ambient model when this configuration is missing or invalid.
-
-## Start with the TUI
-
-Run `agentloom` inside the project you want to inspect, or pass the project explicitly:
+`config/llm.yaml` is ignored by Git and is the only model catalog used by both
+Studio and Application Agents. Start the Studio from any AgentLoom project:
 
 ```bash
-cd /path/to/AgentLoom
 agentloom
 
-# Inspect another AgentLoom project
+# Or inspect another checkout
 agentloom --project /path/to/project
 ```
 
-The TUI is an Applications-first control plane. Its independent Studio Agent
-can inspect the whole project, directly edit the selected Application, show
-Tool and Diff blocks, validate configuration, request permission to
-run it, inspect structured evidence, and continue repairing failures.
-
-### 1. Create or select an Application
-
-Press `Enter` to send a request. A useful first prompt states the application, roles, inputs, outputs, and acceptance criteria:
+Try a request with explicit roles and acceptance criteria:
 
 ```text
 Create an Application named release_review.
@@ -122,158 +135,55 @@ Choose model types from config/llm.yaml.
 Validate it and ask before the first real Run.
 ```
 
-The Studio edits files directly in the selected scope and shows the resulting
-Diff. It loops through Effective Config, YAML/reference validation, an approved
-smoke Run, and structured Run evidence. If real execution is not approved it
-must report “configuration validated, not run” rather than claiming completion.
-Large model-facing Application detail is deduplicated and paginated at ten
-Agents per call. Studio persists Session status, retry, permission,
-question, and Task sub-session events; quiet model latency is not treated as a
-cancellation signal. `Esc` remains the explicit manual interrupt.
+Studio edits the selected Application directly and shows each Diff. Its loop is:
 
-### 2. Understand the workspace numbers
+```text
+inspect → edit → validate → request Run permission → execute → inspect evidence → repair
+```
 
-The homepage counts directories under `applications/`, not every expanded
-Supervisor and Worker YAML. `Global Skills` counts root runtime Skills; an
-Application's private Skills appear when that Application or Agent is opened.
-Use `Ctrl+X` to search Applications, main Supervisor Agents, Skills,
-Schedules, Runs, permissions, models, and commands.
-Worker Agents remain inside their Application and main-Agent details instead
-of appearing as independent global-search entries.
+If execution is not approved, Studio reports “configuration validated, not
+run.” It does not turn static validation into a success claim.
 
-Application detail shows Effective Config and source attribution for Agent
-topology, model type, Tools, Skills, permissions, Hooks, MCP, workflow files,
-validation, Working Revision, and Running Revision. Run detail defaults to an
-actionable summary rather than raw Events.
+## Application Studio
 
-### 3. Permissions and revisions
+The TUI is an Applications-first control plane, not a thin log viewer.
 
-`Application Only` is the default. Reads are project-wide, direct writes are
-limited to the current Application, and Studio asks for Shell, global, other
-Application, or new-path access. Choose `1` once, `2` for this Session, or `3`
-reject. `Full Access` is one on/off toggle in `Ctrl+X`: it can be preset before
-selecting an Application and remains active while switching Applications; it
-resets on exit. Switching Applications keeps the current Studio memory, while
-`/new` starts a fresh Session. `/compact` compresses the current Session with
-the selected Studio model while preserving task continuity, durable history,
-and completed file changes; the Runtime also reports automatic compaction when
-the context approaches its limit. Switching is blocked during an active Agent Loop;
-wait or press `Esc` first. Sub-agent execution text remains visible until the
-next turn; select TUI text and press `Ctrl+Y` to copy it.
-When the Agent needs a business decision, choose a visible option or type an
-answer; separate multiple answers with `|`.
+- **Application workspace:** browse Effective Config, Supervisor/Worker
+  topology, source attribution, models, Tools, Skills, Hooks, MCP, permissions,
+  and validation.
+- **Agent Loop:** inspect the project, modify the selected Application, display
+  Tool and Diff cards, ask business questions, run smoke checks, and diagnose
+  failed Runs.
+- **Permission boundary:** `Application Only` permits project reads and writes
+  inside the selected Application. Shell, global files, other Applications, and
+  unknown new paths require a visible decision. `Full Access` is an explicit
+  Session toggle and resets on exit.
+- **Session continuity:** switching Applications keeps Studio conversation
+  memory; `/new` starts fresh and `/compact` compresses the active context while
+  preserving completed file changes and durable history.
+- **Revision safety:** each Run pins its Application content hash. Later edits
+  change the Working Revision but never hot-switch an active Running Revision.
+- **Run diagnostics:** summaries expose terminal state, Goal progress, token
+  usage, completion evidence, and recovery actions without dumping raw events.
 
-Each Run pins an `application_revision` in its manifest. Later edits change the
-Working Revision but do not hot-switch a running Agent.
-
-| Action | Command / key |
+| Action | Key / command |
 |---|---|
-| Send chat | `Enter` |
-| Start a fresh Studio conversation | `/new` |
-| Compact the current conversation without starting over | `/compact` |
-| Copy selected TUI text | `Ctrl+Y` |
-| Browse commands and global entities | `Ctrl+X` |
-| Select a Studio model from `config/llm.yaml` | `/models` or `Ctrl+X` |
-| Refresh the full index | `/refresh` or `r` in details |
-| Analyze the selected failed Run | `a` |
-| Close detail, reject permission/question, or interrupt the loop | `Esc` |
+| Send a Studio message | `Enter` |
+| Search Applications, Agents, Skills, Runs, models, permissions, and commands | `Ctrl+X` |
+| Start a fresh conversation | `/new` |
+| Compact the current conversation | `/compact` |
+| Select a Studio model | `/models` |
+| Refresh the project index | `/refresh` |
+| Diagnose the selected failed Run | `a` |
+| Close detail, reject a decision, or interrupt the Agent Loop | `Esc` |
 
-See [agentloom-tui/README.md](agentloom-tui/README.md) for TUI architecture and contributor details.
+See [Application Studio](agentloom-tui/README.md) for screen behavior,
+architecture, updates, schedules, and contributor commands.
 
-### 5. Run schedules explicitly
+## Define an Application
 
-The TUI can create and manage durable schedules. Automatic firing is a separate foreground service, so closing the TUI never leaves a hidden daemon behind.
-
-```bash
-agentloom schedules --project /path/to/project serve
-```
-
-Scheduled YAML can enable Goal Mode, but unattended Goals should set a
-`token_budget`; an omitted budget is intentionally unlimited. Budget exhaustion
-is recorded as the resumable `budget_limited` schedule status, not as an ordinary
-execution failure.
-
-## Run an existing Agent
-
-To verify the framework without creating a new application, run the included code review example:
-
-```bash
-uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
-```
-
-One run creates a receipt under `.agentloom/runs/<application_id>/<run_id>/`. When checkpointing is enabled, resumable task state lives under `.agentloom/checkpoints/<application_id>/<task_id>/`.
-
-`run_id` identifies one attempt and changes after resume. `task_id` identifies the logical task and remains stable.
-
-For work that must continue beyond one final answer or `max_steps` segment, a
-top-level Supervisor can enable Goal Mode. Only the root Supervisor can complete
-the Goal; Worker token usage is included in the same optional soft budget:
-
-```yaml
-goal:
-  enabled: true
-  token_budget: 120000  # omit for unlimited
-```
-
-An active Goal continues on the same runtime and memory. `budget_limited` keeps
-its checkpoint and can resume after the budget is raised or removed. See
-[Goal Mode](docs/en/goal_mode.md).
-
-## How AgentLoom works
-
-AgentLoom treats a multi-agent system as an application, not a loose collection of prompts.
-
-| Concept | Responsibility |
-|---|---|
-| Supervisor | Decomposes the application task and coordinates Workers and tools. |
-| Worker | Owns one specialized role and exposes a typed callable contract. |
-| Agent YAML | Defines role, workflow, model type, tools, Skills, Workers, and runtime policy. |
-| Goal Mode | Keeps one Supervisor objective active across continuation segments, Worker delegation, and resume. |
-| Python runtime | Handles model routing, generated Worker tools, concurrency, logs, checkpoints, and artifacts. |
-
-This keeps orchestration reusable while leaving deterministic preprocessing, validation, caching, and output writing in normal Python code.
-
-### Core capabilities
-
-| Need | AgentLoom provides |
-|---|---|
-| Build an application from configuration | Direct YAML execution with `loom run` and optional Python entrypoint generation. |
-| Route roles to different models | Per-Agent `model_type` with credentials isolated in `config/llm.yaml`. |
-| Call an Agent like a tool | Worker `agent_function_schema` becomes a validated callable function. |
-| Process repeated inputs | Fixed or automatic Worker concurrency with `.batch(tasks)`. |
-| Extend an Agent | Built-in tools, local Python functions, MCP servers, Claude-style Skills, and explicit Hooks. |
-| Track complex execution | Agent-owned Todo snapshots with `auto`, strongly prompted `on`, and authoritative `off` modes. |
-| Recover and inspect work | Run receipts, bounded logs, Shell audit, checkpoint resume, structured events, Web UI, dashboard, and TUI. |
-
-### Task-scoped Todo tracking
-
-Todo is execution state for the current task and Agent, not long-term project
-management. Configure it globally, per Application, or per Agent; the most
-specific layer wins:
-
-```yaml
-todo:
-  mode: "auto"  # auto | on | off
-```
-
-- `auto` is the default: the tool is available and the model decides whether a
-  meaningful multi-step task benefits from tracking.
-- `on` strongly instructs a non-trivial Agent to establish a full Todo snapshot
-  before substantive work. The runtime does not add a hidden planning turn or
-  block the final answer.
-- `off` removes the tool, policy, and state from model context, even if a generic
-  tool list would otherwise include `todo_write`.
-
-Each `todo_write` call atomically replaces the complete ordered list. With
-checkpointing enabled, the canonical Agent-scoped snapshot is `todos.json` in
-the current task checkpoint and follows its resume, locking, retention, and
-cleanup lifecycle. Without checkpointing it exists only in run memory.
-`planning_interval` remains available for periodic replanning but no longer
-controls Todo. See the [Agent Configuration Reference](docs/en/agent_config.md#311-todomode--task-tracking).
-
-## Create an application manually
-
-An application keeps its Supervisor, Workers, prompts, optional tools, and outputs together:
+An Application keeps its Supervisor, Workers, prompts, optional tools, and
+outputs together:
 
 ```text
 applications/release_review/
@@ -282,12 +192,12 @@ applications/release_review/
 │   └── worker_agents/
 │       ├── api_reviewer.yaml
 │       └── test_reviewer.yaml
-├── config/system.yaml          # optional application overlay
-├── sysprompt/                  # optional prompt templates
-└── README.md
+├── config/system.yaml          # optional Application overlay
+├── skills/                     # optional private Skills
+└── sysprompt/                  # optional prompt templates
 ```
 
-A minimal Supervisor references Worker YAML files:
+A Supervisor references Worker definitions:
 
 ```yaml
 name: "release_review"
@@ -309,11 +219,7 @@ goal:
   token_budget: 120000
 ```
 
-In Goal Mode a workflow list is merged and numbered into one objective context.
-With Goal disabled, a Supervisor workflow list retains its sequential multi-run
-behavior. Worker YAML must never define `goal`.
-
-Each Worker defines the contract that the Supervisor sees:
+Each Worker exposes the contract seen by its Supervisor:
 
 ```yaml
 name: "api_reviewer"
@@ -338,114 +244,119 @@ worker_agents: []
 max_steps: 8
 ```
 
-Validate the real model types against `config/llm.yaml`, then run the Supervisor:
+Run the Supervisor directly:
 
 ```bash
 uv run loom run applications/release_review/workflows/release_review_agent.yaml
 ```
 
-For the complete schema, use the [Agent Configuration Reference](docs/en/agent_config.md).
+Or ask a Skill-aware coding assistant to read
+[`agentloom-framework-skill/SKILL.md`](agentloom-framework-skill/SKILL.md), create
+the files, validate them, run the Application, and inspect `.agentloom` evidence.
 
-## Create an application with a coding assistant
-
-The repository includes `agentloom-framework-skill/` for Codex, Claude Code, and other Skill-aware coding assistants.
-
-Ask the assistant to read the Skill before creating files:
-
-```text
-Read agentloom-framework-skill/SKILL.md first.
-
-Create an AgentLoom application named <app_name> for this goal:
-<task, inputs, outputs, and acceptance criteria>
-
-Create one Supervisor and the necessary Workers under applications/<app_name>/.
-Use only model types from config/llm.yaml.
-Define every Worker input/output with agent_function_schema.
-Validate the YAML, run the application, inspect .agentloom evidence,
-and report what passed, failed, or remains limited.
-```
-
-The Framework Skill is development guidance for coding assistants. It is not a runtime Skill and is not auto-loaded by Agent applications.
-
-## Architecture
+## Runtime model
 
 <p align="center">
   <img alt="AgentLoom runtime architecture" src="docs/assets/agentloom-runtime-architecture.svg">
 </p>
 
-Worker Agents become generated tools. The Supervisor calls them together with normal Python, MCP, file, Shell, search, Git, Codex, or Skill tools.
+The Python runtime owns model routing, Worker-tool generation, concurrency,
+permissions, Hooks, checkpoints, and evidence. Deterministic preprocessing,
+validation, caching, and output writing remain ordinary Python code.
 
-The runtime owns execution identity and evidence. TUI and other observers read that canonical state instead of guessing status from process output.
+Runtime storage separates attempts from recoverable tasks:
 
-## Example applications
+```text
+.agentloom/
+├── runs/<application_id>/<run_id>/
+│   ├── manifest.json
+│   ├── logs/runtime.log
+│   ├── audit/
+│   └── artifacts/
+├── checkpoints/<application_id>/<task_id>/
+│   ├── checkpoint.json
+│   ├── workers/<worker>/calls/<index>/checkpoint.json
+│   ├── todos.json
+│   ├── goal.json
+│   ├── context_store/
+│   └── file-history/
+└── workspaces/agents/<application_id>/<agent_path>/
+    ├── insights.md
+    └── tasks/<task_id>/{context.md,trace.md}
+```
+
+Goal, Todo, context-store, file-history, and Recall files appear only when the
+corresponding feature is configured or used.
+
+## Run and integrate
+
+Run the included code-review Application without creating a new Application:
+
+```bash
+uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
+```
+
+Use machine-readable lifecycle events when another program owns execution:
+
+```bash
+uv run loom run <workflow> --output-format json
+uv run loom run <workflow> --output-format jsonl
+```
+
+For programmatic execution, `execute_app()` returns an `ApplicationRunResult`
+with output, timestamps, structured Goal state, and a `RunInfo` receipt:
+
+```python
+from src.runner import execute_app
+
+result = execute_app("applications/release_review/workflows/release_review_agent.yaml")
+print(result.output, result.run.run_id)
+```
+
+Post-allocation failures carry the same receipt; preflight rejection emits
+`run.rejected` before storage exists. See
+[Structured Run API](docs/en/run_observability.md).
+
+Durable schedules use the same Application contract and Run lifecycle. Their
+automatic firing is a separate foreground service, so closing the TUI does not
+leave a hidden daemon:
+
+```bash
+agentloom schedules --project /path/to/project serve
+```
+
+## Example Applications
 
 | Application | Demonstrates |
 |---|---|
-| `ai_quality_analysis` | Twelve specialized Workers coordinated into a staged code review. |
-| `unit_test_studio` | A strict pytest generation pipeline with a custom Python entrypoint. |
-| `repo_map` | Deterministic preprocessing, bottom-up Agent analysis, batching, and progress persistence. |
-| `codex_exec_demo` | Local `codex exec` registered as normal Agent tools with fixed arguments. |
-
-```bash
-# Repository architecture map
-uv run python applications/repo_map/repo_map_app.py /path/to/project \
-  --output_dir /tmp/repo-map-output
-
-# Pytest generation for selected functions
-uv run python applications/unit_test_studio/studio_runner.py \
-  /path/to/project "src/utils.py:parse_config" \
-  --output_dir tests/generated
-
-# Local Codex tool example
-uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
-```
-
-## CLI reference
-
-| Command | Purpose |
-|---|---|
-| `uv run loom run <workflow>` | Run an application. |
-| `uv run loom run <workflow> --output-format json` | Emit one versioned terminal lifecycle event. |
-| `uv run loom run <workflow> --output-format jsonl` | Stream versioned lifecycle events. |
-| `uv run loom create <workflow>` | Generate a Python entrypoint. |
-| `uv run loom list-tasks` | List resumable tasks. |
-| `uv run loom dashboard` | Open the terminal task dashboard. |
-| `uv run loom ui` | Open the Web visualization panel. |
-| `uv run loom schedules ...` | Manage durable schedules. |
-| `uv run loom sessions ...` | Search and maintain execution history. |
-| `uv run loom learn review ...` | Trigger Application or Project review. |
-| `uv run loom reviews ...` | Inspect, apply, or roll back review decisions. |
-| `uv run loom memory ...` | Administer curated memory. |
-| `uv run loom feedback submit <run_id> ...` | Attach outcome feedback to a Run. |
-| `uv run loom clean-tasks` | Remove retained checkpoint tasks. |
-| `uv run loom clean-runtime` | Apply configured Run and artifact retention. |
-| `uv run loom migrate-runtime --dry-run\|--apply` | Preview or apply legacy runtime migration. |
-
-Run `uv run loom <command> --help` for the full command contract.
+| `ai_quality_analysis` | Twelve specialized Workers coordinated into staged code review |
+| `unit_test_studio` | Strict pytest generation with a deterministic Python entrypoint |
+| `repo_map` | Deterministic preprocessing, bottom-up Agent analysis, batching, and progress persistence |
+| `codex_exec_demo` | Local `codex exec` exposed as normal Agent tools with fixed arguments |
+| `goal_mode_validation` | Explicit Goal completion, budget accounting, and resumable terminal states |
+| `self_learning_smoke` | Session history, memory proposals, evidence, and review boundaries |
 
 ## Documentation
 
 | Document | Covers |
 |---|---|
-| [Configuration Overview](docs/en/config-overview.md) | Configuration layers, merging, and isolation. |
-| [Agent Configuration](docs/en/agent_config.md) | Supervisor and Worker YAML fields. |
-| [LLM Configuration](docs/en/llm_config.md) | Model types, providers, retries, and caching. |
-| [System Configuration](docs/en/system_config.md) | Runtime, permissions, execution environments, and tools. |
-| [Built-in Tool Catalog](docs/en/tool_catalog.md) | Toolsets, metadata/loading architecture, extension rules, and real validation. |
-| [Skills Configuration](docs/en/skills_config.md) | Skill packages, loading, and policy. |
-| [Hooks Reference](docs/en/hooks.md) | Direct Hooks, Bundles, events, and execution. |
-| [Goal Mode](docs/en/goal_mode.md) | Supervisor-owned continuation, explicit completion, budgets, resume, schedules, CLI, and TUI. |
-| [Checkpoint Resume](docs/en/checkpoint.md) | Run evidence, checkpoint layout, and recovery. |
-| [Self-Learning v6](docs/en/self_learning.md) | History, candidates, review, approval, and promotion. |
-| [Structured Run API](docs/en/run_observability.md) | Python receipts, typed errors, event sinks, JSON, and JSONL. |
+| [Configuration Overview](docs/en/config-overview.md) | Configuration layers, merging, and isolation |
+| [Agent Configuration](docs/en/agent_config.md) | Supervisor and Worker YAML fields |
+| [Tool Catalog](docs/en/tool_catalog.md) | Lazy implementation loading, toolsets, metadata, and extension rules |
+| [Skills](docs/en/skills_config.md) | Discovery, on-demand activation, and permission boundaries |
+| [Hooks](docs/en/hooks.md) | Explicit authorization, events, transforms, and failure semantics |
+| [Goal Mode](docs/en/goal_mode.md) | Continuation, completion ownership, budgets, resume, and schedules |
+| [Checkpoint and Runtime Storage](docs/en/checkpoint.md) | Run/task identity, evidence, recovery, and retention |
+| [Self-Learning v6](docs/en/self_learning.md) | History, candidates, review, approval, and promotion |
+| [Structured Run API](docs/en/run_observability.md) | Python receipts, typed failures, JSON, and JSONL |
 
 ## Development and support
 
 ```bash
-# Framework tests
+# Framework
 uv run pytest tests -q
 
-# TUI tests
+# TUI
 cd agentloom-tui
 bun test
 bun run typecheck
@@ -453,6 +364,7 @@ bun run typecheck
 
 - Issues: [github.com/linora-u/AgentLoom/issues](https://github.com/linora-u/AgentLoom/issues)
 - Contact: [raine_walker@163.com](mailto:raine_walker@163.com?subject=AgentLoom%20Collaboration)
-- TUI upstream provenance and license: [agentloom-tui/upstream/README.md](agentloom-tui/upstream/README.md)
+- TUI provenance and notices: [agentloom-tui/upstream/README.md](agentloom-tui/upstream/README.md)
 
-If AgentLoom helps your project, consider starring the repository or contributing a focused example, fix, or documentation improvement.
+If AgentLoom helps your project, consider starring the repository or
+contributing a focused Application, fix, or validation case.

--- a/agentloom-tui/README.md
+++ b/agentloom-tui/README.md
@@ -1,124 +1,190 @@
 # AgentLoom Application Studio
 
-`agentloom` is an Applications-first terminal control plane. It embeds a fixed
-Studio runtime for the Agent Loop and uses AgentLoom's Python runtime
-only for domain truth: configuration, validation, Effective Config, topology,
-Run lifecycle, and evidence.
+`agentloom` is an Applications-first terminal control plane. A dedicated Studio
+Agent can inspect and edit an Application, while AgentLoom's Python runtime
+remains authoritative for Effective Config, topology, validation, Run lifecycle,
+Goal state, and evidence.
 
-## Install, update, and run
+![AgentLoom Application Studio in a real terminal](../docs/assets/agentloom-studio.svg)
+
+The image above comes from a real reduced-motion terminal session. The Studio
+indexed the checkout and rendered its Applications, global Skills, validation
+state, Runs, and command input. It is not a static product mockup.
+
+## Install and open
 
 ```bash
 cd /path/to/AgentLoom
 ./install
+cp config/llm.example.yaml config/llm.yaml
+# Edit config/llm.yaml with at least one working model profile.
 agentloom --project /path/to/AgentLoom
 ```
 
-Rerun `./install` to update a source installation. After the first install,
-`agentloom update` performs the same update from the recorded trusted checkout.
-`./install --no-modify-path` is optional and only prevents the installer from
-editing shell PATH configuration; it is not required for updates.
+The installer creates one compatible unit under `~/.agentloom`: the
+TypeScript/OpenTUI binary, bundled Studio runtime, and locked Python environment.
+Use the non-interactive commands to verify that unit without opening the UI:
 
-The TUI checks the recorded trusted source checkout after first render. When
-relevant sources are newer than the installed compatible unit, `Ctrl+X` offers
-an explicit update of TUI + Studio runtime + Python followed by a safe restart. It
-does not fetch Git or silently replace an active Session.
+```bash
+agentloom --version
+agentloom --snapshot --project /path/to/AgentLoom
+```
 
-The installer builds and installs one compatible unit under `~/.agentloom`:
-the TypeScript/OpenTUI binary, bundled Studio runtime, and a locked Python
-environment. `agentloom --snapshot` is the non-interactive health check.
+Rerun `./install` to update from the current source checkout. After installation,
+`agentloom update` rebuilds from the recorded trusted checkout. The TUI checks
+that checkout after first render; when relevant source files are newer, `Ctrl+X`
+offers an explicit whole-product update and safe restart. It does not fetch Git
+or replace an active Session silently.
 
-## Product model
+## Read the workspace
 
-- The first entry is `+ New Application`, followed by every directory under
-  `applications/`. Choosing another Application retargets the current Studio
-  Session and keeps its conversation memory; only `/new` starts a fresh Session.
-  `/compact` summarizes the active context in place, retaining Session identity,
-  durable history, and completed file changes.
-  A target switch is blocked while an Agent Loop is active; wait or press `Esc`
-  before switching so an old turn cannot finish against the new Application.
-- The workspace summary counts Applications, not expanded Supervisor/Worker
-  YAML definitions. Main Supervisor Agents are searchable through `Ctrl+X`;
-  Worker Agents remain inspectable inside Application and main-Agent details.
-- `Global Skills` counts runtime-global Skill manifests from the root `skills/`
-  directory and explicit global configuration. Application-private Skills are
-  shown only inside that Application and its Agent details. The framework Skill
-  used by Studio is development context and is not counted as an Application Skill.
-- The right panel shows Effective Config, Working Revision, Running Revision,
-  Supervisor/Workers, model sources, Tools, Skills, permissions, Hooks, MCP,
-  workflow source files, and validation. It does not expose model credentials.
-- Recent Runs are secondary navigation. Their default detail is a compact,
-  actionable summary; raw event objects and full log bodies are not dumped.
-- Goal-aware Runs expose `active`, `complete`, and `budget_limited` state in the
-  same list/detail projection. Run detail shows cumulative/remaining tokens,
-  objective, and completion evidence. While a Run is active the bridge reads
-  canonical checkpoint `goal.json`; terminal Runs use the manifest/audit copy.
+The main screen has three working areas:
+
+1. **Conversation and Agent Loop** occupy the left pane. Tool calls, Diffs,
+   permissions, questions, sub-Agent progress, and the final response remain in
+   the same task history.
+2. **Workspace index** occupies the right pane. It lists Applications, global
+   Skills, Run counts, schedule service state, and recent executions.
+3. **Composer and status footer** show current model, permission scope, loop
+   state, copy/interrupt actions, and discoverable commands.
+
+Selecting an Application opens details sourced from Effective Config:
+
+- Supervisor and Worker topology;
+- model type and configuration source;
+- Tools and Skills with their loading source;
+- permissions, Hooks, and MCP configuration;
+- workflow source files and validation errors;
+- Working Revision and Running Revision;
+- recent Runs and available recovery actions.
+
+The homepage counts directories under `applications/`, not every expanded Agent
+YAML. Main Supervisors are searchable through `Ctrl+X`; Workers stay nested in
+Application and Supervisor details so one large Application does not flood the
+global index.
 
 ## Studio Agent Loop
 
-The Studio Agent can read the project, edit the selected Application directly,
-show Tool and Diff blocks, validate, request permission to run, inspect
-structured Run evidence, and continue fixing until the acceptance criteria are
-met. There is no separate draft-write command in the normal workflow.
+The normal workflow does not use a separate draft command:
 
-`Application Only` is the default: project reads and writes inside the selected
-Application are allowed; Shell, global files, other Applications, and unknown
-new-Application paths require explicit permission. Permission cards support
-`1` once, `2` for this Session, and `3` reject. `Full Access` is available from
-`Ctrl+X` as one on/off toggle. It can be preset before selecting an Application,
-remains active while switching Applications, and resets when the TUI exits.
-Task sub-agent text and Tool cards are visible in the parent Studio; completed
-sub-agent text remains until the next turn. Select it and press `Ctrl+Y` to copy
-through OSC52.
+```text
+inspect project and Effective Config
+  → edit the selected Application
+  → show the Diff
+  → validate YAML and references
+  → request permission for a real Run
+  → inspect structured Run evidence
+  → repair until acceptance criteria pass
+```
 
-Agent question requests are shown as decision cards. A user can click one
-choice or type an answer; multiple answers are separated with `|`, and `Esc`
-rejects the request. Set `AGENTLOOM_REDUCED_MOTION=1` to use static status
-symbols; dumb and CI terminals select this mode automatically.
+Studio must distinguish static validation from execution. If Run permission is
+rejected, the result is “configuration validated, not run.” A process exit or a
+plausible final answer is also insufficient proof; Studio reads the manifest,
+terminal state, Goal projection, and available audit evidence.
 
-Model-facing Application detail is deduplicated and paginated instead of
-placing a complete large Application in one Tool result. Studio persists the
-Session lifecycle for status, retry, permission, question, and Task
-sub-session progress; quiet model latency is not treated as a cancellation
-signal. Context-limit compaction is performed by the Runtime and shown in the
-TUI; `/compact` invokes the same Session compaction explicitly. `Esc` is the explicit manual interrupt. An interrupted unfinished turn is
-removed from future model context, while file changes already completed by its
-tools are retained; the next message therefore starts a new task instead of
-silently resuming the cancelled one.
+Tool and Diff cards are visible in the parent conversation. Task sub-Agent text
+remains visible until the next turn and can be selected and copied with
+`Ctrl+Y`. Quiet provider latency does not count as cancellation. `Esc` is the
+explicit interrupt.
 
-Runs pin the Application content hash in `manifest.json`. Later edits change the
-Working Revision but never hot-switch the Running Revision. A new/restarted Run
-is required to use new configuration.
+An interrupted unfinished turn is removed from future model context. File
+changes already completed by tools remain on disk, so the next message starts a
+new task against the actual project state instead of silently resuming cancelled
+reasoning.
 
-Studio and Application Agents share the project-root `config/llm.yaml` as their
-only model catalog, Provider, authentication, and default source. The Studio
-maps those profiles into the bundled Studio runtime; Application Agents keep
-resolving them through Python and YAML `model_type`. Selecting a Studio model
-with `/models` or `Ctrl+X` never changes an Application model. Missing or invalid
-configuration is an explicit startup error, not an ambient default fallback.
+## Permissions
+
+`Application Only` is the default:
+
+- reads may inspect the project;
+- direct writes inside the selected Application are allowed;
+- Shell, global files, other Applications, and unknown new-Application paths
+  require a permission card.
+
+Permission cards offer `1` once, `2` for this Session, and `3` reject. `Full
+Access` is one explicit toggle under `Ctrl+X`. It can be set before selecting an
+Application, remains active when switching targets, and resets when the TUI
+exits.
+
+Agent question requests use decision cards. Select a visible choice or type a
+custom answer. Separate answers to multiple questions with `|`; `Esc` rejects
+the request.
+
+## Sessions and models
+
+Choosing another Application retargets the current Studio Session and preserves
+conversation memory. A switch is blocked while the Agent Loop is active so an
+old turn cannot finish against a new target.
+
+- `/new` starts a blank conversation while retaining durable Application
+  history for later Agent retrieval.
+- `/compact` compresses current context in place, preserving Session identity,
+  durable history, and completed file changes.
+- Runtime-initiated context compaction appears in the TUI and follows the same
+  continuity contract.
+
+Studio and Application Agents share project-root `config/llm.yaml` as their only
+model catalog, Provider configuration, and authentication source. `/models`
+changes the Studio model for the current Session; it never changes an
+Application Agent's YAML `model_type`. Missing or invalid configuration is an
+explicit startup error, not a fallback to ambient credentials.
+
+## Revisions, Runs, and Goals
+
+Every Run pins the Application content hash in `manifest.json`. Editing YAML
+changes the Working Revision; an active Run continues using its Running Revision.
+A restart or new Run is required to execute new configuration.
+
+Recent Runs are secondary navigation. Their default view is a bounded,
+decision-ready summary rather than a raw event dump. Problem Runs expose an
+`a` action that asks Studio to diagnose the stored evidence.
+
+Goal-aware Run details display:
+
+- `active`, `complete`, or `budget_limited` state;
+- objective and completion evidence;
+- cumulative and remaining token budget;
+- resume eligibility and the current task identifier.
+
+While a Run is active, the bridge reads canonical checkpoint `goal.json`.
+Terminal Runs use the manifest and audit copy. This keeps the TUI aligned with
+CLI JSON/JSONL and Python `ApplicationRunResult` instead of deriving state from
+terminal output.
 
 ## Navigation
 
 | Action | Key / command |
 |---|---|
 | Send a Studio message | `Enter` |
-| Start a blank conversation while retaining Application history | `/new` |
-| Compact the current Session without starting over | `/compact` |
+| Start a blank conversation | `/new` |
+| Compact the current Session | `/compact` |
 | Search commands and global entities | `Ctrl+X` |
-| Select a Studio model from `config/llm.yaml` | `/models` or `Ctrl+X` |
-| Re-index project state | `/refresh` |
-| Scroll chat or the focused detail | `PgUp` / `PgDn`; mouse wheel scrolls the pointed region |
-| Diagnose a selected failed Run | `a` |
-| Close detail / reject permission or question / interrupt active loop | `Esc` |
+| Select a Studio model | `/models` or `Ctrl+X` |
+| Re-index the project | `/refresh` |
+| Scroll focused chat or detail | `PgUp` / `PgDn` or mouse wheel |
+| Copy selected text through OSC52 | `Ctrl+Y` |
+| Diagnose a selected problem Run | `a` |
+| Close detail, reject a decision, or interrupt the loop | `Esc` |
 | Exit | `Ctrl+C` |
 
-There is intentionally no global `?` binding. Discoverability lives in the
-visible footer, `/help`, and the `Ctrl+X` command descriptions.
+There is no global `?` binding. The footer, `/help`, and `Ctrl+X` descriptions
+carry command discovery.
 
-Schedules remain a separate foreground service:
+Set `AGENTLOOM_REDUCED_MOTION=1` for static status symbols. Dumb and CI terminals
+select reduced motion automatically.
+
+## Schedules
+
+The TUI creates and manages durable schedules. Automatic firing is a separate
+foreground service:
 
 ```bash
 agentloom schedules --project /path/to/project serve
 ```
+
+Closing the TUI therefore does not leave a hidden scheduler daemon. The workspace
+shows whether the service is running, while scheduled Runs use the same Run,
+Goal, checkpoint, and evidence contracts as manually started Runs.
 
 ## Architecture
 
@@ -136,8 +202,12 @@ agentloom_domain
        └─ run.start / stop / resume / restart / detail
 ```
 
-Third-party provenance and license notices for the presentation and runtime
-adaptations are maintained under [`upstream/`](upstream/README.md).
+The TypeScript layer owns presentation and the Studio Session. The Python bridge
+owns AgentLoom domain truth. Model-facing Application detail is deduplicated and
+paginated rather than placing a complete large topology in one Tool result.
+
+Third-party provenance and license notices for presentation and runtime
+adaptations live under [`upstream/`](upstream/README.md).
 
 ## Development
 

--- a/agentloom-tui/package.json
+++ b/agentloom-tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@agentloom/tui",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "license": "UNLICENSED",

--- a/agentloom-tui/script/build.ts
+++ b/agentloom-tui/script/build.ts
@@ -5,8 +5,10 @@ import { dirname, resolve } from "node:path"
 import { createSolidTransformPlugin } from "@opentui/solid/bun-plugin"
 
 const packageRoot = resolve(import.meta.dir, "..")
+const repositoryRoot = resolve(packageRoot, "..")
 const outfile = resolve(packageRoot, readOutfile(process.argv.slice(2)) ?? "dist/agentloom")
 const target = `bun-${process.platform === "win32" ? "windows" : process.platform}-${process.arch}`
+const version = await readProjectVersion(resolve(repositoryRoot, "pyproject.toml"))
 
 await mkdir(dirname(outfile), { recursive: true })
 process.chdir(packageRoot)
@@ -28,6 +30,7 @@ const result = await Bun.build({
     outfile,
   },
   entrypoints: ["./src/cli/standalone.ts"],
+  define: { "process.env.AGENTLOOM_VERSION": JSON.stringify(version) },
 })
 
 if (!result.success) {
@@ -59,4 +62,12 @@ function readOutfile(argv: readonly string[]) {
     throw new Error(`Unknown build option: ${argument}`)
   }
   return undefined
+}
+
+async function readProjectVersion(path: string) {
+  const source = await Bun.file(path).text()
+  const project = source.match(/^\[project\]\s*$([\s\S]*?)(?=^\[|(?![\s\S]))/m)?.[1]
+  const version = project?.match(/^version\s*=\s*"([^"]+)"\s*$/m)?.[1]
+  if (!version) throw new Error(`Unable to read [project].version from ${path}`)
+  return version
 }

--- a/agentloom-tui/src/cli/main.ts
+++ b/agentloom-tui/src/cli/main.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises"
 import { BridgeClient, PythonTransport } from "../bridge"
 import { formatSnapshot, parseCliArgs } from "./args"
 
-export const VERSION = "0.1.0"
+export const VERSION = process.env.AGENTLOOM_VERSION ?? "1.0.1"
 const MAX_BRIDGE_DIAGNOSTIC_CHARS = 4_000
 
 export const HELP = `AgentLoom Application Studio — create, inspect, modify, validate and run Applications

--- a/applications/test_demo/test_recall_skill_bash_command.py
+++ b/applications/test_demo/test_recall_skill_bash_command.py
@@ -73,10 +73,12 @@ class TestAgentRecallSkillRepoAdaptation(unittest.TestCase):
         self.assertNotIn("CODEX_SKILL_ROOT", content)
         self.assertNotIn("session-catchup.py", content)
         self.assertNotIn("/clear", content)
-        self.assertNotIn("hooks:", content)
+        frontmatter = content.split("---", 2)[1]
+        self.assertNotIn("hooks:", frontmatter)
         self.assertNotIn("python ./scripts/", content)
-        self.assertIn("skills/agent-recall-with-files", content)
         self.assertIn("hooks/agent-recall-with-files", content)
+        self.assertIn("references/examples.md", content)
+        self.assertIn("references/reference.md", content)
         self.assertTrue(HOOK_MANIFEST.exists())
         manifest = HOOK_MANIFEST.read_text(encoding="utf-8")
         self.assertIn("name: agent-recall-with-files", manifest)
@@ -84,13 +86,14 @@ class TestAgentRecallSkillRepoAdaptation(unittest.TestCase):
         self.assertNotIn("task_plan.md", content)
         self.assertNotIn(".planning/", content)
 
-    def test_workflow_uses_canonical_skill_path(self):
+    def test_workflow_activates_discovered_skill_by_name(self):
         self.assertTrue(WORKFLOW_PATH.exists(), f"Workflow file not found: {WORKFLOW_PATH}")
         content = WORKFLOW_PATH.read_text(encoding="utf-8")
-        self.assertIn('path: "skills/agent-recall-with-files"', content)
+        self.assertIn('skill(name="agent-recall-with-files")', content)
+        self.assertNotIn('path: "skills/agent-recall-with-files"', content)
         self.assertTrue(SKILL_DIR.exists(), f"Canonical skill directory not found: {SKILL_DIR}")
 
-    def test_task_start_script_bootstraps_runtime_and_cleans_legacy(self):
+    def test_task_start_script_bootstraps_runtime_without_deleting_project_files(self):
         self.assertTrue(TASK_START_SCRIPT.exists(), f"TaskCreated script not found: {TASK_START_SCRIPT}")
 
         with tempfile.TemporaryDirectory(prefix="recall-task-start-") as tmp:
@@ -136,10 +139,10 @@ class TestAgentRecallSkillRepoAdaptation(unittest.TestCase):
             insights_content = Path(agent_root, "insights.md").read_text(encoding="utf-8").replace("\r\n", "\n")
             trace_content = Path(runtime_dir, "trace.md").read_text(encoding="utf-8").replace("\r\n", "\n")
             context_content = Path(runtime_dir, "context.md").read_text(encoding="utf-8").replace("\r\n", "\n")
-            self.assertFalse(Path(tmp, ".planning").exists())
-            self.assertFalse(Path(tmp, "task_plan.md").exists())
-            self.assertFalse(Path(tmp, "findings.md").exists())
-            self.assertFalse(Path(tmp, "progress.md").exists())
+            self.assertTrue(Path(tmp, ".planning", "old_agent", "task_plan.md").is_file())
+            self.assertEqual(Path(tmp, "task_plan.md").read_text(encoding="utf-8"), "legacy root plan\n")
+            self.assertEqual(Path(tmp, "findings.md").read_text(encoding="utf-8"), "legacy root findings\n")
+            self.assertEqual(Path(tmp, "progress.md").read_text(encoding="utf-8"), "legacy root progress\n")
             self.assertEqual(
                 INSIGHTS_TEMPLATE.read_text(encoding="utf-8").replace("\r\n", "\n").strip(),
                 insights_content.strip(),

--- a/docs/assets/agentloom-studio.svg
+++ b/docs/assets/agentloom-studio.svg
@@ -1,0 +1,267 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1296" height="792" viewBox="0 0 1296 792" role="img" aria-labelledby="title desc">
+<title id="title">AgentLoom Application Studio</title>
+<desc id="desc">A real AgentLoom terminal session showing the Studio workspace, an application, run status, and command input.</desc>
+<rect width="100%" height="100%" fill="#080808"/>
+<style>text{font-family:Menlo,Monaco,Consolas,"Liberation Mono",monospace;font-size:14px;font-variant-ligatures:none}</style>
+<rect x="925.2" y="18.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="32.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="18.0" width="344.4" height="18" fill="#121212"/>
+<text x="34.8" y="50.0" fill="#ffaf87" font-weight="400">▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █░░ █▀█ █▀█ █▀▄▀█</text>
+<rect x="925.2" y="36.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="50.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="36.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="36.0" width="151.2" height="18" fill="#121212"/>
+<text x="950.4" y="50.0" fill="#eeeeee" font-weight="700">Application Studio</text>
+<rect x="1101.6" y="36.0" width="176.4" height="18" fill="#121212"/>
+<text x="34.8" y="68.0" fill="#ffaf87" font-weight="400">█▀█ █▄█ ██▄ █░▀█ ░█░ █▄▄ █▄█ █▄█ █░▀░█</text>
+<rect x="925.2" y="54.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="68.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="54.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="54.0" width="235.2" height="18" fill="#121212"/>
+<text x="950.4" y="68.0" fill="#7f7f7f" font-weight="400">agentloom-readme-demo.SIHeVj</text>
+<rect x="1185.6" y="54.0" width="92.4" height="18" fill="#121212"/>
+<rect x="925.2" y="72.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="86.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="72.0" width="344.4" height="18" fill="#121212"/>
+<text x="34.8" y="104.0" fill="#eeeeee" font-weight="700">agentloom-readme-demo.SIHeVj</text>
+<text x="648.0" y="104.0" fill="#7f7f7f" font-weight="400">Studio: config/llm.yaml default</text>
+<rect x="925.2" y="90.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="104.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="90.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="90.0" width="100.8" height="18" fill="#121212"/>
+<text x="950.4" y="104.0" fill="#ffaf87" font-weight="700">Applications</text>
+<rect x="1051.2" y="90.0" width="226.8" height="18" fill="#121212"/>
+<rect x="925.2" y="108.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="122.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="108.0" width="344.4" height="18" fill="#121212"/>
+<text x="34.8" y="140.0" fill="#eeeeee" font-weight="700">AgentLoom Application Studio</text>
+<text x="572.4" y="140.0" fill="#7f7f7f" font-weight="400">Choose an Application · Application Only</text>
+<rect x="925.2" y="126.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="140.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="126.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="126.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="140.0" fill="#ffaf87" font-weight="400">│</text>
+<rect x="958.8" y="126.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="126.0" width="260.4" height="18" fill="#121212"/>
+<text x="967.2" y="140.0" fill="#eeeeee" font-weight="400">1 Application · 0 Global Skills</text>
+<rect x="1227.6" y="126.0" width="50.4" height="18" fill="#121212"/>
+<rect x="925.2" y="144.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="158.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="144.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="144.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="158.0" fill="#ffaf87" font-weight="400">│</text>
+<rect x="958.8" y="144.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="144.0" width="142.8" height="18" fill="#121212"/>
+<text x="967.2" y="158.0" fill="#ffaf87" font-weight="700">+ New Application</text>
+<rect x="1110.0" y="144.0" width="168.0" height="18" fill="#121212"/>
+<text x="34.8" y="176.0" fill="#7f7f7f" font-weight="400">创 建  · 修 改  · 验 证  · 运 行   ·  Studio: config/llm.yaml default</text>
+<rect x="925.2" y="162.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="176.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="162.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="180.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="194.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="180.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="180.0" width="168.0" height="18" fill="#121212"/>
+<text x="950.4" y="194.0" fill="#eeeeee" font-weight="400">goal_mode_validation</text>
+<rect x="1118.4" y="180.0" width="159.6" height="18" fill="#121212"/>
+<text x="34.8" y="212.0" fill="#5fafff" font-weight="400">│</text>
+<rect x="925.2" y="198.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="212.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="198.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="198.0" width="252.0" height="18" fill="#121212"/>
+<text x="950.4" y="212.0" fill="#7f7f7f" font-weight="400">配 置 有 效  · 尚 未 运 行  · 点 击 打 开 </text>
+<rect x="1202.4" y="198.0" width="75.6" height="18" fill="#121212"/>
+<text x="34.8" y="230.0" fill="#5fafff" font-weight="400">│</text>
+<text x="51.6" y="230.0" fill="#5fafff" font-weight="700">AgentLoom</text>
+<rect x="925.2" y="216.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="230.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="216.0" width="344.4" height="18" fill="#121212"/>
+<text x="34.8" y="248.0" fill="#5fafff" font-weight="400">│</text>
+<text x="51.6" y="248.0" fill="#eeeeee" font-weight="400">我 是  AgentLoom Studio Agent。 请 新 建 或 选 择 一 个  Application； 之 后 可 以 直 接 让 我 检 查 、 修 改 、 验 证 和 运 行 它 。 </text>
+<rect x="925.2" y="234.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="248.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="234.0" width="344.4" height="18" fill="#121212"/>
+<text x="34.8" y="266.0" fill="#5fafff" font-weight="400">│</text>
+<rect x="925.2" y="252.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="266.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="252.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="252.0" width="67.2" height="18" fill="#121212"/>
+<text x="950.4" y="266.0" fill="#ffaf87" font-weight="700">运 行 记 录 </text>
+<rect x="1017.6" y="252.0" width="260.4" height="18" fill="#121212"/>
+<rect x="925.2" y="270.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="284.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="270.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="288.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="302.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="288.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="288.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="302.0" fill="#ffaf87" font-weight="400">│</text>
+<rect x="958.8" y="288.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="288.0" width="184.8" height="18" fill="#121212"/>
+<text x="967.2" y="302.0" fill="#eeeeee" font-weight="400">0 次  · 0 成 功  · 0 失 败 </text>
+<rect x="1152.0" y="288.0" width="126.0" height="18" fill="#121212"/>
+<rect x="925.2" y="306.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="320.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="306.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="306.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="320.0" fill="#ffaf87" font-weight="400">│</text>
+<rect x="958.8" y="306.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="306.0" width="277.2" height="18" fill="#121212"/>
+<text x="967.2" y="320.0" fill="#eeeeee" font-weight="400">0 预 算 受 限  · 0 崩 溃  · 0 中 断  · 0 </text>
+<rect x="1244.4" y="306.0" width="33.6" height="18" fill="#121212"/>
+<rect x="925.2" y="324.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="338.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="324.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="324.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="338.0" fill="#ffaf87" font-weight="400">│</text>
+<rect x="958.8" y="324.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="324.0" width="50.4" height="18" fill="#121212"/>
+<text x="967.2" y="338.0" fill="#eeeeee" font-weight="400">运 行 中 </text>
+<rect x="1017.6" y="324.0" width="260.4" height="18" fill="#121212"/>
+<rect x="925.2" y="342.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="356.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="342.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="342.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="356.0" fill="#ffaf87" font-weight="400">│</text>
+<rect x="958.8" y="342.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="342.0" width="134.4" height="18" fill="#121212"/>
+<text x="967.2" y="356.0" fill="#7f7f7f" font-weight="400">调 度 服 务 : 未 启 动 </text>
+<rect x="1101.6" y="342.0" width="176.4" height="18" fill="#121212"/>
+<rect x="925.2" y="360.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="374.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="360.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="378.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="392.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="378.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="378.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="392.0" fill="#ffaf5f" font-weight="400">│</text>
+<rect x="958.8" y="378.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="378.0" width="176.4" height="18" fill="#121212"/>
+<text x="967.2" y="392.0" fill="#ffaf5f" font-weight="400">Worker 状 态 索 引 不 完 整 </text>
+<rect x="1143.6" y="378.0" width="134.4" height="18" fill="#121212"/>
+<rect x="925.2" y="396.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="410.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="396.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="396.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="410.0" fill="#ffaf5f" font-weight="400">│</text>
+<rect x="958.8" y="396.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="396.0" width="285.6" height="18" fill="#121212"/>
+<text x="967.2" y="410.0" fill="#7f7f7f" font-weight="400">部 分 历 史 调 用 无 法 确 认 ； 不 会 把 它 们 误 </text>
+<rect x="1252.8" y="396.0" width="25.2" height="18" fill="#121212"/>
+<rect x="925.2" y="414.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="428.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="414.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="414.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="428.0" fill="#ffaf5f" font-weight="400">│</text>
+<rect x="958.8" y="414.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="414.0" width="134.4" height="18" fill="#121212"/>
+<text x="967.2" y="428.0" fill="#7f7f7f" font-weight="400">报 为  Never run。 </text>
+<rect x="1101.6" y="414.0" width="176.4" height="18" fill="#121212"/>
+<rect x="925.2" y="432.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="446.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="432.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="450.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="464.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="450.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="450.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="464.0" fill="#ffaf5f" font-weight="400">│</text>
+<rect x="958.8" y="450.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="450.0" width="168.0" height="18" fill="#121212"/>
+<text x="967.2" y="464.0" fill="#ffaf5f" font-weight="400">Run 状 态 索 引 正 在 收 敛 </text>
+<rect x="1135.2" y="450.0" width="142.8" height="18" fill="#121212"/>
+<rect x="925.2" y="468.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="482.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="468.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="468.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="482.0" fill="#ffaf5f" font-weight="400">│</text>
+<rect x="958.8" y="468.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="468.0" width="285.6" height="18" fill="#121212"/>
+<text x="967.2" y="482.0" fill="#7f7f7f" font-weight="400">当 前 是 有 界 增 量 窗 口 ； 后 续 刷 新 会 继 续 </text>
+<rect x="1252.8" y="468.0" width="25.2" height="18" fill="#121212"/>
+<rect x="925.2" y="486.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="500.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="486.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="486.0" width="8.4" height="18" fill="#121212"/>
+<text x="950.4" y="500.0" fill="#ffaf5f" font-weight="400">│</text>
+<rect x="958.8" y="486.0" width="8.4" height="18" fill="#121212"/>
+<rect x="967.2" y="486.0" width="134.4" height="18" fill="#121212"/>
+<text x="967.2" y="500.0" fill="#7f7f7f" font-weight="400">对 账 新 增 与 删 除 。 </text>
+<rect x="1101.6" y="486.0" width="176.4" height="18" fill="#121212"/>
+<rect x="925.2" y="504.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="518.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="504.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="522.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="536.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="522.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="522.0" width="67.2" height="18" fill="#121212"/>
+<text x="950.4" y="536.0" fill="#ffaf87" font-weight="700">最 近 执 行 </text>
+<rect x="1017.6" y="522.0" width="260.4" height="18" fill="#121212"/>
+<rect x="925.2" y="540.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="554.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="540.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="558.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="572.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="558.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="558.0" width="100.8" height="18" fill="#121212"/>
+<text x="950.4" y="572.0" fill="#7f7f7f" font-weight="400">暂 无 运 行 记 录 </text>
+<rect x="1051.2" y="558.0" width="226.8" height="18" fill="#121212"/>
+<rect x="925.2" y="576.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="590.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="576.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="594.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="608.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="594.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="612.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="626.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="612.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="630.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="644.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="630.0" width="344.4" height="18" fill="#121212"/>
+<rect x="34.8" y="648.0" width="873.6" height="18" fill="#1c1c1c"/>
+<text x="34.8" y="662.0" fill="#5f5f5f" font-weight="400">┌──────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<rect x="925.2" y="648.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="662.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="648.0" width="344.4" height="18" fill="#121212"/>
+<rect x="34.8" y="666.0" width="8.4" height="18" fill="#1c1c1c"/>
+<text x="34.8" y="680.0" fill="#5f5f5f" font-weight="400">│</text>
+<rect x="43.2" y="666.0" width="8.4" height="18" fill="#1c1c1c"/>
+<rect x="51.6" y="666.0" width="445.2" height="18" fill="#1c1c1c"/>
+<text x="51.6" y="680.0" fill="#7f7f7f" font-weight="400">描 述 你 要 创 建 或 修 改 的  Application； 输 入  /help 查 看 命 令 </text>
+<rect x="496.8" y="666.0" width="403.2" height="18" fill="#1c1c1c"/>
+<rect x="900.0" y="666.0" width="8.4" height="18" fill="#1c1c1c"/>
+<text x="900.0" y="680.0" fill="#5f5f5f" font-weight="400">│</text>
+<rect x="925.2" y="666.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="680.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="666.0" width="344.4" height="18" fill="#121212"/>
+<rect x="34.8" y="684.0" width="873.6" height="18" fill="#1c1c1c"/>
+<text x="34.8" y="698.0" fill="#5f5f5f" font-weight="400">└──────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<rect x="925.2" y="684.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="698.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="684.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="702.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="716.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="702.0" width="344.4" height="18" fill="#121212"/>
+<text x="34.8" y="734.0" fill="#ffaf87" font-weight="700">[ Enter 发 送  ]</text>
+<text x="169.2" y="734.0" fill="#7f7f7f" font-weight="400">Ctrl+X Commands</text>
+<text x="312.0" y="734.0" fill="#7f7f7f" font-weight="400">Ctrl+Y 复 制 选 中 </text>
+<text x="454.8" y="734.0" fill="#7f7f7f" font-weight="400">/help 帮 助 </text>
+<rect x="925.2" y="720.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="734.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="720.0" width="344.4" height="18" fill="#121212"/>
+<rect x="925.2" y="738.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="752.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="738.0" width="16.8" height="18" fill="#121212"/>
+<rect x="950.4" y="738.0" width="218.4" height="18" fill="#121212"/>
+<text x="950.4" y="752.0" fill="#7f7f7f" font-weight="400">Ctrl+X Commands · Esc 返 回 </text>
+<rect x="1168.8" y="738.0" width="109.2" height="18" fill="#121212"/>
+<rect x="18.0" y="756.0" width="16.8" height="18" fill="#121212"/>
+<rect x="34.8" y="756.0" width="378.0" height="18" fill="#121212"/>
+<text x="34.8" y="770.0" fill="#7f7f7f" font-weight="400">AgentLoom · 全 局 运 行 状 态 自 动 刷 新  · r 重 新 索 引 </text>
+<rect x="412.8" y="756.0" width="252.0" height="18" fill="#121212"/>
+<rect x="664.8" y="756.0" width="243.6" height="18" fill="#121212"/>
+<text x="664.8" y="770.0" fill="#7f7f7f" font-weight="400">Ctrl+Y 复 制 选 中  · Ctrl-C 退 出 </text>
+<rect x="908.4" y="756.0" width="16.8" height="18" fill="#121212"/>
+<rect x="925.2" y="756.0" width="8.4" height="18" fill="#121212"/>
+<text x="925.2" y="770.0" fill="#444444" font-weight="400">│</text>
+<rect x="933.6" y="756.0" width="344.4" height="18" fill="#121212"/>
+</svg>

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -5,26 +5,71 @@
 <h1 align="center">AgentLoom</h1>
 
 <p align="center">
-  <strong>创建、运行并查看由 YAML 定义的多 Agent 应用。</strong>
+  <strong>用 YAML 构建多 Agent 应用，并通过可追溯证据的终端 Studio 运行和维护。</strong>
 </p>
 
 <p align="center">
-  使用 Application Studio 创建、修改、校验、运行并查看 AgentLoom Application。
+  类型化 Worker、权限确认、断点恢复、Goal 预算和经审核的记忆，都以同一套运行时权威状态为准。
 </p>
 
 <p align="center">
   <a href="https://github.com/linora-u/AgentLoom/actions/workflows/tests.yml"><img alt="tests" src="https://github.com/linora-u/AgentLoom/actions/workflows/tests.yml/badge.svg"></a>
   <a href="https://www.python.org/downloads/"><img alt="python >=3.12" src="https://img.shields.io/badge/python-%3E%3D3.12-3776AB?logo=python&logoColor=white"></a>
-  <a href="https://github.com/linora-u/AgentLoom/releases/tag/v1.0.1"><img alt="release v1.0.1" src="https://img.shields.io/badge/release-v1.0.1-007EC6"></a>
+  <img alt="version 1.0.1" src="https://img.shields.io/badge/version-1.0.1-007EC6">
 </p>
 
 <p align="center">
-  <img alt="AgentLoom application flow" src="../assets/agentloom-application-flow.svg">
+  <img alt="真实终端中运行的 AgentLoom Application Studio" src="../assets/agentloom-studio.svg">
 </p>
 
-## 安装
+<p align="center"><sub>开启 reduced-motion 后录制的真实终端会话。Studio 从当前项目读取 Application、Skill、校验状态、Run 和命令。</sub></p>
 
-推荐从源码安装脚本开始。它会同时准备 TUI、Python Runtime 和所需依赖，不需要手工搭建多套环境。
+AgentLoom 把多 Agent 系统当成一个**有执行契约的 Application**。YAML 定义
+Supervisor、类型化 Worker、模型、Tool、Skill、Hook、权限和 Runtime 策略。
+Application Studio 可以修改这份契约、展示 Diff、为副作用请求授权、发起运行、
+读取结构化证据，并根据失败证据继续修复。
+
+## 核心价值
+
+### Worker 会成为类型化工具
+
+Worker 通过 `agent_function_schema` 声明接口，Runtime 将它转换成 Supervisor
+可调用、带参数校验的工具。不同 Worker 可以使用不同模型和工具、并发执行，同时保持
+稳定的输入输出契约，不依赖提示词里的口头约定。
+
+### Run 产出证据，不靠解析终端猜状态
+
+每个已分配存储的 Run 都有独立的 `run_id`、manifest 和带版本的生命周期事件；
+启用文件日志时还会生成有界日志，并保留审计记录和产物。逻辑任务使用稳定的
+`task_id` 恢复。TUI、CLI JSON/JSONL 和 Python API 读取同一份权威状态。预检
+拒绝发生在 Run 及其存储分配之前。
+
+### 长任务有明确的完成责任人
+
+Goal Mode 让根 Supervisor 跨 continuation 和 Worker 调用持续推进同一个目标。
+只有根 Supervisor 能携带证据完成 Goal。可选 token 预算覆盖整棵 Agent 树；启用
+checkpoint 时，达到预算后进入 `budget_limited` 并保留恢复状态。
+
+### 记忆有审核边界
+
+AgentLoom 把两类需求分开处理：
+
+- [`agent-recall-with-files`](../../skills/agent-recall-with-files/SKILL.md)
+  使用运行时约定的工作区文件保存轻量的任务恢复信息和 Agent 局部经验。可选
+  Hook Bundle 会注入最近记录，并按新鲜度提醒更新。
+- [Self-Learning v6](self_learning.md) 分开保存可搜索历史和经过证据门禁的记忆。
+  Fact 和 Experience 候选需通过证据门禁及作用域审批策略；提升到 Project
+  级别必须由人工发起。
+
+### 扩展不会隐式获得权限
+
+Skill 是按需加载的模型上下文包。Hook 是独立显式授权的 Runtime 代码。内置 Tool
+的元数据可以在不导入实现的情况下发现；真正的 Tool、文件、Shell 和 MCP 权限
+仍由 Agent 配置与权限策略决定。
+
+## 快速开始
+
+源码安装器会针对当前代码版本构建 TUI，并准备锁定依赖的 Python 环境：
 
 ```bash
 git clone https://github.com/linora-u/AgentLoom.git
@@ -32,47 +77,19 @@ cd AgentLoom
 ./install
 ```
 
-安装完成后打开一个新终端，在仓库根目录验证命令：
+目前支持 macOS 和 Linux Shell，需要 Git 与 Bash。安装器会通过官方安装器补齐
+`uv` 和 Bun，再把配套运行环境安装到 `~/.agentloom`。打开新终端后验证：
 
 ```bash
 agentloom --version
 agentloom --snapshot
 ```
 
-安装脚本会：
-
-- 通过官方安装器补齐缺少的 `uv` 和 Bun；
-- 在 `~/.agentloom/venv` 创建锁定的 Python 环境；
-- 构建当前平台的 TypeScript/OpenTUI 原生程序；
-- 将 `agentloom` 和 `agentloom-tui` 安装到 `~/.agentloom/bin`；
-- 在存在可写 Shell 配置时，把该目录加入 `PATH`。
-
-源码安装脚本目前面向 macOS 和 Linux Shell。它需要 Git 和 Bash；仅在缺少 `uv` 或 Bun 时需要 `curl`。
-
-源码更新只需在仓库中重新运行 `./install`。首次安装后也可执行
-`agentloom update`，它会从安装时记录的可信源码目录重新构建。参数
-`--no-modify-path` 仅表示“不修改 Shell PATH 配置”，不是更新必需参数。
-
-安装版 TUI 会在后台检查这个可信源码目录。如果与产品相关的源码比当前安装
-更新，`Ctrl+X` 会提供“整体更新并安全重启”。它不会擅自执行 Git 拉取，也不
-会在活跃 Session 中静默替换程序。
-
-需要自定义安装目录或不修改 `PATH` 时，可以使用：
-
-```bash
-AGENTLOOM_INSTALL_DIR="$HOME/tools/agentloom" ./install
-./install --no-modify-path
-```
-
-### 配置 Application 模型
-
-使用 TUI 对话或运行 Agent 前，先复制模型配置模板：
+创建本地模型配置：
 
 ```bash
 cp config/llm.example.yaml config/llm.yaml
 ```
-
-编辑 `config/llm.yaml` 并替换占位内容。不要提交这个文件；它包含凭证，已经被 Git 忽略。
 
 ```yaml
 model:
@@ -80,188 +97,78 @@ model:
   powerful:
     model: "openai/<model-id>"
     api_key: "<api-key>"
-    base_url: "https://<openai-compatible-endpoint>"  # OpenAI 官方端点可省略
+    base_url: "https://<openai-compatible-endpoint>"  # OpenAI 可省略
+    tool_choice: "auto"
+  fast:
+    model: "openai/<fast-model-id>"
+    api_key: "<api-key>"
+    base_url: "https://<openai-compatible-endpoint>"
     tool_choice: "auto"
 ```
 
-这份文件是 Studio 与 Application Agent 唯一共享的模型配置源。
-
-## Goal Mode
-
-顶层 Supervisor 可以通过 `goal: true` 或
-`goal: {enabled: true, token_budget: 120000}` 开启长期目标模式。它会在普通 final
-或 `max_steps` 后继续使用同一 runtime 和记忆，Worker 用量计入同一预算，并且只有
-根 Supervisor 的 `update_goal(complete, evidence)` 能完成。预算耗尽时 run 进入
-`budget_limited`，提高或移除预算后用同一个 `task_id` resume。完整的配置、状态、
-checkpoint、CLI/JSONL/TUI 和调度说明见 [Goal Mode](goal_mode.md)。
-
-文档导航：
-
-- [配置体系总览](config-overview.md)：配置层级、overlay 与运行时目录；
-- [Agent YAML](agent_config.md)：Supervisor/Worker 的全部字段与严格校验；
-- [Goal Mode](goal_mode.md)：continuation、显式完成、预算、resume 与可观测性；
-- [Checkpoint](checkpoint.md)：task/run 身份、持久化布局和恢复；
-- [Run 可观测性](run_observability.md)：Python receipt、typed outcome 与 JSONL；
-- [系统配置](system_config.md)、[内置 Tool Catalog](tool_catalog.md)、[模型配置](llm_config.md)、[Skills](skills_config.md)、[Hooks](hooks.md) 和 [自学习](self_learning.md)。
-Application Agent 由 Python Runtime 按 YAML `model_type` 解析；TypeScript
-Studio 适配器把同一批 Profile、端点、凭证和兼容请求参数安全映射给内置
-Studio Runtime。`/models` 或 `Ctrl+X` 只切换当前 Studio Session 使用的
-`llm.yaml` 模型类型，不修改任何 Application YAML 的 `model_type`。配置缺失
-或无效时 Studio 会明确启动失败，不会回退到未配置的环境默认模型。
-
-## 从 TUI 开始
-
-在需要查看的项目中运行 `agentloom`，也可以显式指定项目：
+`config/llm.yaml` 已被 Git 忽略，是 Studio 和 Application Agent 共用的唯一模型
+目录。在任意 AgentLoom 项目中启动 Studio：
 
 ```bash
-cd /path/to/AgentLoom
 agentloom
 
-# 查看另一个 AgentLoom 项目
+# 或查看另一个项目
 agentloom --project /path/to/project
 ```
 
-TUI 是 Applications-first 控制面。独立的 Studio Agent 可以读取项目、
-直接修改当前 Application、展示 Tool 与 Diff、校验配置、请求
-真实运行授权、读取结构化 Run 证据，并在失败后继续修复。
-
-### 1. 新建或选择 Application
-
-按 `Enter` 发送需求。一个有效的初始描述应写清应用、角色、输入、输出和验收标准：
+可以从一条包含角色和验收条件的需求开始：
 
 ```text
-创建一个名为 release_review 的应用。
-使用一个 Supervisor 和两个 Worker，分别负责 API 审查和测试审查。
-模型类型从 config/llm.yaml 中选择。
-校验完成后，在首次真实运行前向我申请权限。
+创建一个名为 release_review 的 Application。
+使用一个 Supervisor，以及负责 API 审查和测试审查的两个 Worker。
+模型类型只能从 config/llm.yaml 选择。
+完成校验后，在第一次真实 Run 前向我确认。
 ```
 
-Studio 在授权范围内直接改文件，并显示产生的 Diff。自治 Loop 会检查
-Effective Config、YAML/引用、Tools、Skills、权限、拓扑与相关测试；行为
-变化还会在获准后真实冒烟运行。未获运行授权时只能报告“配置已验证，
-尚未运行”，不能宣称完全完成。
+Studio 直接修改当前 Application，并展示每次 Diff。它按照下面的闭环工作：
 
-大型 Application 的模型侧详情会去重并按每页最多 10 个 Agent 返回，避免
-把完整配置塞进一次 Tool 输出。Studio 会持久化 Session 的状态、重试、
-权限、问题和 Task 子会话事件；模型安静思考不会被误判成需要自动中止。需要立即
-中止时按 `Esc`。
+```text
+检查 → 修改 → 校验 → 请求 Run 权限 → 执行 → 检查证据 → 修复
+```
 
-### 2. 首页数字与详情
+如果用户没有批准执行，Studio 会明确报告“配置已校验，未运行”，不会把静态校验
+包装成运行成功。
 
-首页只统计 `applications/` 下的 Application 数量，不统计展开后的
-Supervisor/Worker YAML 数量。`Global Skills` 只统计根目录运行时全局
-Skills；Application 私有 Skills 在对应 Application 和 Agent 详情中查看。
-Studio 使用的框架 Skill 不计入业务 Application Skills。
+## Application Studio
 
-`Ctrl+X` 搜索命令、权限、Application、主 Supervisor Agent、Skill、
-Schedule 和 Run。Worker 子 Agent 只在所属 Application 和主 Agent 详情中
-展示，不作为独立的全局搜索条目。Application 详情展示带来源的 Effective Config，包括
-模型、Tools、Skills、子 Agent、权限、Hooks、MCP、配置文件、校验、
-Working Revision 和 Running Revision。Run 默认只展示可行动摘要，不铺开
-原始 Events 和完整日志。
+TUI 是围绕 Application 设计的控制面，不是简单的日志查看器。
 
-### 3. 权限与 Revision
+- **Application 工作区：**查看 Effective Config、Supervisor/Worker 拓扑、配置
+  来源、模型、Tool、Skill、Hook、MCP、权限和校验结果。
+- **Agent Loop：**检查项目、修改当前 Application、展示 Tool 与 Diff 卡片、提出
+  业务问题、执行冒烟运行，并诊断失败 Run。
+- **权限边界：**默认 `Application Only` 允许读取项目、写入当前 Application。
+  Shell、全局文件、其他 Application 和未知新路径需要可见的权限确认。
+  `Full Access` 是显式 Session 开关，退出后自动重置。
+- **Session 连续性：**切换 Application 会保留 Studio 对话记忆；`/new` 开始新
+  对话，`/compact` 在保留已完成文件修改和持久历史的前提下压缩当前上下文。
+- **Revision 安全：**每个 Run 固定 Application 内容哈希。后续修改只改变
+  Working Revision，不会热切换正在执行的 Running Revision。
+- **Run 诊断：**摘要展示终态、Goal 进度、token 用量、完成证据和恢复操作，默认
+  不展示全部底层事件。
 
-默认 `Application Only`：可读整个项目，可直接写当前 Application；Shell、
-全局文件、其他 Application 和新建时未知目录由 Studio 弹出权限卡。
-按 `1` 仅本次、`2` 本次会话、`3` 拒绝。`Ctrl+X` 中的 Full Access 是同一个
-开关：未选择 Application 时也可预设，切换 Application 后继续生效，退出 TUI
-后恢复默认。切换 Application 会保留当前 Studio 对话记忆，只有 `/new` 才开始
-不带旧记忆的新 Session；`/compact` 使用当前 Studio 模型压缩当前 Session，保留
-任务连续性、持久历史和已经完成的文件修改。上下文接近上限时，Runtime 的自动压缩
-也会在 TUI 中显示。Agent Loop 运行时不能切换目标；等待完成或先按 `Esc`
-中止，避免旧回合污染新 Application。子 Agent 执行文本会保留到下一回合，选中
-TUI 文本后按 `Ctrl+Y` 可复制。
-Studio Agent 需要业务决定时，可点击选项或在输入框回答；一次出现多个问题时
-用 `|` 分隔答案。
-
-Run 启动时把 Application 内容哈希写入 manifest。之后继续修改只会改变
-Working Revision，不会热切换正在运行的 Agent；新配置需新 Run 或重启。
-
-| 操作 | 命令 / 按键 |
+| 操作 | 按键 / 命令 |
 |---|---|
-| 发送对话 | `Enter` |
-| 开始新的 Studio 对话 | `/new` |
-| 不开新会话，压缩当前对话上下文 | `/compact` |
-| 复制选中的 TUI 文本 | `Ctrl+Y` |
-| 搜索命令和全局实体 | `Ctrl+X` |
-| 从 `config/llm.yaml` 选择 Studio 模型 | `/models` 或 `Ctrl+X` |
-| 刷新完整索引 | `/refresh` 或在详情页按 `r` |
-| 分析选中的失败 Run | `a` |
-| 关闭详情、拒绝权限/问题或中止当前 Loop | `Esc` |
+| 发送 Studio 消息 | `Enter` |
+| 搜索 Application、Agent、Skill、Run、模型、权限和命令 | `Ctrl+X` |
+| 开始新对话 | `/new` |
+| 压缩当前对话 | `/compact` |
+| 选择 Studio 模型 | `/models` |
+| 刷新项目索引 | `/refresh` |
+| 诊断当前选中的失败 Run | `a` |
+| 关闭详情、拒绝决策或中断 Agent Loop | `Esc` |
 
-TUI 架构与开发说明见 [agentloom-tui/README.md](../../agentloom-tui/README.md)。
+界面行为、架构、更新、调度和开发命令见
+[Application Studio](../../agentloom-tui/README.md)。
 
-### 5. 显式运行调度服务
+## 定义 Application
 
-TUI 可以创建和管理持久化 Schedule。自动触发由独立的前台服务负责，因此关闭 TUI 后不会留下隐藏 daemon。
-
-```bash
-agentloom schedules --project /path/to/project serve
-```
-
-## 运行已有 Agent
-
-如果想先验证框架而不创建新应用，可以运行仓库自带的代码审查示例：
-
-```bash
-uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
-```
-
-一次运行会在 `.agentloom/runs/<application_id>/<run_id>/` 下生成 receipt。开启 checkpoint 后，可恢复状态位于 `.agentloom/checkpoints/<application_id>/<task_id>/`。
-
-`run_id` 标识一次 attempt，resume 后会改变；`task_id` 标识逻辑任务，resume 时保持不变。
-
-## AgentLoom 如何工作
-
-AgentLoom 把多 Agent 系统视为一个应用，而不是一组松散的 Prompt。
-
-| 概念 | 职责 |
-|---|---|
-| Supervisor | 拆解应用任务，并协调 Worker 和工具。 |
-| Worker | 负责一个专门角色，并暴露 typed callable contract。 |
-| Agent YAML | 定义角色、工作流、模型类型、工具、Skill、Worker 和运行策略。 |
-| Python Runtime | 负责模型路由、Worker 工具生成、并发、日志、checkpoint 和产物。 |
-
-编排逻辑可以复用，确定性的前处理、校验、缓存和结果写入仍然由普通 Python 代码完成。
-
-### 核心能力
-
-| 需求 | AgentLoom 提供 |
-|---|---|
-| 从配置构建应用 | 使用 `loom run` 直接执行 YAML，并可生成 Python 入口。 |
-| 为不同角色选择模型 | 每个 Agent 设置 `model_type`，凭证隔离在 `config/llm.yaml`。 |
-| 像工具一样调用 Agent | Worker 的 `agent_function_schema` 会转换成带校验的 callable function。 |
-| 处理重复输入 | 固定或自动 Worker 并发，并支持 `.batch(tasks)`。 |
-| 扩展 Agent | 内置工具、本地 Python 函数、MCP Server、Claude-style Skill 和显式 Hook。 |
-| 跟踪复杂执行 | Agent 私有的 Todo 快照，支持自主 `auto`、强提示 `on` 和权威关闭 `off`。 |
-| 恢复并检查任务 | Run receipt、有界日志、Shell audit、checkpoint resume、结构化事件、Web UI、dashboard 和 TUI。 |
-
-### 当前任务 Todo 跟踪
-
-Todo 是当前 task、当前 Agent 的执行状态，不是长期项目管理器。它可以在全局、
-Application 或 Agent 层配置，更具体的层级优先：
-
-```yaml
-todo:
-  mode: "auto"  # auto | on | off
-```
-
-- `auto` 是默认值：工具可用，由模型自主判断有意义的多步骤任务是否值得跟踪。
-- `on` 强提示非简单 Agent 在实质执行前建立完整 Todo 快照；Runtime 不插入隐藏的
-  planning 轮次，也不阻止最终回答。
-- `off` 完全移除工具、策略与上下文状态；即使通用工具列表包含 `todo_write` 也以
-  `off` 为准。
-
-每次 `todo_write` 都会原子替换完整有序列表。开启 checkpoint 时，按 Agent path
-隔离的权威快照位于当前 task checkpoint 的 `todos.json`，共用 resume、锁、保留
-与清理生命周期；关闭 checkpoint 时只存在于本次 run 的内存中。
-`planning_interval` 仍可控制周期 replanning，但不再控制 Todo。完整说明见
-[Agent 配置参考](agent_config.md#311-todomode--任务跟踪)。
-
-## 手工创建应用
-
-一个应用把 Supervisor、Worker、Prompt、可选工具和输出放在一起：
+Application 将 Supervisor、Worker、提示词、可选 Tool 和输出放在一起：
 
 ```text
 applications/release_review/
@@ -270,12 +177,12 @@ applications/release_review/
 │   └── worker_agents/
 │       ├── api_reviewer.yaml
 │       └── test_reviewer.yaml
-├── config/system.yaml          # 可选的应用级覆盖
-├── sysprompt/                  # 可选 Prompt 模板
-└── README.md
+├── config/system.yaml          # 可选的 Application 覆盖配置
+├── skills/                     # 可选的私有 Skill
+└── sysprompt/                  # 可选的提示词模板
 ```
 
-最小 Supervisor 会引用 Worker YAML：
+Supervisor 引用 Worker 定义：
 
 ```yaml
 name: "release_review"
@@ -292,9 +199,12 @@ workflow: |
 
 tools: []
 max_steps: 12
+goal:
+  enabled: true
+  token_budget: 120000
 ```
 
-每个 Worker 定义 Supervisor 可见的调用契约：
+每个 Worker 声明 Supervisor 看到的接口：
 
 ```yaml
 name: "api_reviewer"
@@ -319,113 +229,116 @@ worker_agents: []
 max_steps: 8
 ```
 
-确认真实 `model_type` 存在于 `config/llm.yaml`，然后运行 Supervisor：
+直接运行 Supervisor：
 
 ```bash
 uv run loom run applications/release_review/workflows/release_review_agent.yaml
 ```
 
-完整字段见 [Agent 配置参考](agent_config.md)。
+也可以让支持 Skill 的编程助手先读取
+[`agentloom-framework-skill/SKILL.md`](../../agentloom-framework-skill/SKILL.md)，
+再创建文件、校验配置、运行 Application，并检查 `.agentloom` 证据。
 
-## 使用编程助手创建应用
-
-仓库提供 `agentloom-framework-skill/`，供 Codex、Claude Code 和其他支持 Skill 的编程助手使用。
-
-创建文件前，先要求助手读取该 Skill：
-
-```text
-先读取 agentloom-framework-skill/SKILL.md。
-
-为下面目标创建一个名为 <app_name> 的 AgentLoom 应用：
-<任务、输入、输出和验收标准>
-
-在 applications/<app_name>/ 下创建一个 Supervisor 和必要的 Worker。
-只使用 config/llm.yaml 中存在的模型类型。
-用 agent_function_schema 定义每个 Worker 的输入和输出。
-校验 YAML、运行应用、检查 .agentloom 证据，
-并报告通过、失败和仍有限制的内容。
-```
-
-Framework Skill 是提供给编程助手的开发说明。它不是 Runtime Skill，也不会被 Agent 应用自动加载。
-
-## 架构
+## Runtime 模型
 
 <p align="center">
-  <img alt="AgentLoom runtime architecture" src="../assets/agentloom-runtime-architecture.svg">
+  <img alt="AgentLoom Runtime 架构" src="../assets/agentloom-runtime-architecture.svg">
 </p>
 
-Worker Agent 会转换成生成的工具。Supervisor 可以同时调用 Worker，以及普通 Python、MCP、文件、Shell、搜索、Git、Codex 或 Skill 工具。
+Python Runtime 负责模型路由、Worker Tool 生成、并发、权限、Hook、checkpoint 和
+证据。确定性的预处理、校验、缓存和输出仍然使用普通 Python 代码。
 
-Runtime 负责执行身份和证据。TUI 与其他观察端读取这套标准状态，而不是根据进程输出猜测结果。
+Runtime 存储将执行尝试和可恢复任务分开：
 
-## 示例应用
-
-| 应用 | 展示能力 |
-|---|---|
-| `ai_quality_analysis` | 十二个专门 Worker 协作完成分阶段代码审查。 |
-| `unit_test_studio` | 使用自定义 Python 入口的严格 pytest 生成流水线。 |
-| `repo_map` | 确定性前处理、Bottom-Up Agent 分析、批处理和进度持久化。 |
-| `codex_exec_demo` | 将本地 `codex exec` 注册为带固定参数的普通 Agent 工具。 |
-
-```bash
-# 生成仓库架构地图
-uv run python applications/repo_map/repo_map_app.py /path/to/project \
-  --output_dir /tmp/repo-map-output
-
-# 为指定函数生成 pytest
-uv run python applications/unit_test_studio/studio_runner.py \
-  /path/to/project "src/utils.py:parse_config" \
-  --output_dir tests/generated
-
-# 本地 Codex 工具示例
-uv run loom run applications/codex_exec_demo/workflows/use_codex_exec_demo.yaml
+```text
+.agentloom/
+├── runs/<application_id>/<run_id>/
+│   ├── manifest.json
+│   ├── logs/runtime.log
+│   ├── audit/
+│   └── artifacts/
+├── checkpoints/<application_id>/<task_id>/
+│   ├── checkpoint.json
+│   ├── workers/<worker>/calls/<index>/checkpoint.json
+│   ├── todos.json
+│   ├── goal.json
+│   ├── context_store/
+│   └── file-history/
+└── workspaces/agents/<application_id>/<agent_path>/
+    ├── insights.md
+    └── tasks/<task_id>/{context.md,trace.md}
 ```
 
-## CLI 参考
+Goal、Todo、context-store、file-history 和 Recall 文件只会在对应能力已配置或被使用
+时出现。
 
-| 命令 | 用途 |
+## 运行与集成
+
+无需新建 Application，即可运行仓库内置的代码审查 Application：
+
+```bash
+uv run loom run applications/ai_quality_analysis/workflows/code_review_agent.yaml
+```
+
+其他程序负责调度时，使用机器可读的生命周期事件：
+
+```bash
+uv run loom run <workflow> --output-format json
+uv run loom run <workflow> --output-format jsonl
+```
+
+在 Python 中调用 `execute_app()`，会返回包含输出、时间、结构化 Goal 状态和
+`RunInfo` receipt 的 `ApplicationRunResult`：
+
+```python
+from src.runner import execute_app
+
+result = execute_app("applications/release_review/workflows/release_review_agent.yaml")
+print(result.output, result.run.run_id)
+```
+
+存储分配后的失败携带同一 receipt；若预检阶段拒绝运行，会在分配运行存储前发出
+`run.rejected` 事件。详见[结构化 Run API](run_observability.md)。
+
+持久化 Schedule 复用相同的 Application 契约与 Run 生命周期。自动触发由单独的
+前台服务负责，关闭 TUI 不会留下隐藏 daemon：
+
+```bash
+agentloom schedules --project /path/to/project serve
+```
+
+## 示例 Application
+
+| Application | 展示能力 |
 |---|---|
-| `uv run loom run <workflow>` | 运行应用。 |
-| `uv run loom run <workflow> --output-format json` | 输出一个带版本的终态生命周期事件。 |
-| `uv run loom run <workflow> --output-format jsonl` | 输出带版本的生命周期事件流。 |
-| `uv run loom create <workflow>` | 生成 Python 入口。 |
-| `uv run loom list-tasks` | 列出可恢复任务。 |
-| `uv run loom dashboard` | 打开终端任务 dashboard。 |
-| `uv run loom ui` | 打开 Web 可视化面板。 |
-| `uv run loom schedules ...` | 管理持久化 Schedule。 |
-| `uv run loom sessions ...` | 搜索和维护执行历史。 |
-| `uv run loom learn review ...` | 触发 Application 或 Project review。 |
-| `uv run loom reviews ...` | 查看、应用或回滚 review decision。 |
-| `uv run loom memory ...` | 管理 Curated Memory。 |
-| `uv run loom feedback submit <run_id> ...` | 为 Run 添加结果反馈。 |
-| `uv run loom clean-tasks` | 删除保留的 checkpoint 任务。 |
-| `uv run loom clean-runtime` | 执行已配置的 Run 和 artifact retention。 |
-| `uv run loom migrate-runtime --dry-run\|--apply` | 预览或执行旧 Runtime 迁移。 |
-
-使用 `uv run loom <command> --help` 查看完整命令契约。
+| `ai_quality_analysis` | 十二个专业 Worker 协作完成分阶段代码审查 |
+| `unit_test_studio` | 通过确定性 Python 入口执行严格的 pytest 生成流程 |
+| `repo_map` | 确定性预处理、自底向上 Agent 分析、批处理和进度持久化 |
+| `codex_exec_demo` | 将本地 `codex exec` 作为带固定参数的普通 Agent Tool |
+| `goal_mode_validation` | Goal 显式完成、预算统计和可恢复终态 |
+| `self_learning_smoke` | Session 历史、记忆提案、证据和审核边界 |
 
 ## 文档
 
 | 文档 | 内容 |
 |---|---|
-| [配置体系总览](config-overview.md) | 配置层级、合并和隔离。 |
-| [Agent 配置](agent_config.md) | Supervisor 和 Worker YAML 字段。 |
-| [LLM 配置](llm_config.md) | 模型类型、Provider、重试和缓存。 |
-| [系统配置](system_config.md) | Runtime、权限、执行环境和工具。 |
-| [Skill 配置](skills_config.md) | Skill 包、加载方式和策略。 |
-| [Hook 参考](hooks.md) | 直接 Hook、Bundle、事件和执行方式。 |
-| [Goal Mode](goal_mode.md) | Supervisor continuation、显式完成、预算、resume、调度、CLI 与 TUI。 |
-| [Checkpoint 恢复](checkpoint.md) | Run 证据、checkpoint 布局和恢复。 |
-| [Self-learning v6](self_learning.md) | History、candidate、review、审批和 promotion。 |
-| [结构化 Run API](run_observability.md) | Python receipt、typed error、event sink、JSON 和 JSONL。 |
+| [配置总览](config-overview.md) | 配置分层、合并与隔离 |
+| [Agent 配置](agent_config.md) | Supervisor 和 Worker YAML 字段 |
+| [Tool Catalog](tool_catalog.md) | 延迟实现加载、Toolset、元数据和扩展规则 |
+| [Skills](skills_config.md) | 发现、按需激活与权限边界 |
+| [Hooks](hooks.md) | 显式授权、事件、输入转换和失败语义 |
+| [Goal Mode](goal_mode.md) | continuation、完成责任、预算、恢复与调度 |
+| [Checkpoint 与 Runtime 存储](checkpoint.md) | Run/task 身份、证据、恢复和保留策略 |
+| [Self-Learning v6](self_learning.md) | 历史、候选、审核、审批与提升 |
+| [结构化 Run API](run_observability.md) | Python receipt、类型化失败、JSON 与 JSONL |
 
 ## 开发与支持
 
 ```bash
-# Framework 测试
+# Framework
 uv run pytest tests -q
 
-# TUI 测试
+# TUI
 cd agentloom-tui
 bun test
 bun run typecheck
@@ -433,6 +346,7 @@ bun run typecheck
 
 - Issue：[github.com/linora-u/AgentLoom/issues](https://github.com/linora-u/AgentLoom/issues)
 - 联系方式：[raine_walker@163.com](mailto:raine_walker@163.com?subject=AgentLoom%20Collaboration)
-- TUI 上游来源与许可证：[agentloom-tui/upstream/README.md](../../agentloom-tui/upstream/README.md)
+- TUI 来源与声明：[agentloom-tui/upstream/README.md](../../agentloom-tui/upstream/README.md)
 
-如果 AgentLoom 对你的项目有帮助，欢迎 Star 仓库，或贡献一个范围明确的示例、修复或文档改进。
+如果 AgentLoom 对你的项目有帮助，欢迎 Star，或贡献一个边界清晰的 Application、
+修复或验证用例。

--- a/hooks/agent-recall-with-files/scripts/common.py
+++ b/hooks/agent-recall-with-files/scripts/common.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -16,15 +16,6 @@ from typing import Any
 CONTEXT_FILE = "context.md"
 TRACE_FILE = "trace.md"
 INSIGHTS_FILE = "insights.md"
-
-LEGACY_ROOT_FILES = (
-    "task_plan.md",
-    "findings.md",
-    "progress.md",
-    "trace.md",
-    "insights.md",
-    "context.md",
-)
 
 # How many tail lines to inject into agent_context during PreToolUse.
 PRE_TOOL_TRACE_LINES = 20
@@ -83,16 +74,6 @@ def read_template(name: str, title: str) -> str:
     return f"# {title}\n"
 
 
-def remove_path(path: Path) -> None:
-    """Safely delete a file or directory."""
-    if not path.exists():
-        return
-    if path.is_dir() and not path.is_symlink():
-        shutil.rmtree(path)
-    else:
-        path.unlink()
-
-
 # ---------------------------------------------------------------------------
 # File reading helpers
 # ---------------------------------------------------------------------------
@@ -119,14 +100,14 @@ def read_full(path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 def summarize_insights(path: Path) -> None:
-    """Compress *insights.md* when it exceeds ``MAX_INSIGHTS_LINES``.
+    """Bound *insights.md* when it exceeds ``MAX_INSIGHTS_LINES``.
 
     Strategy:
     - Keep the header block (lines before the first ``## `` section or
       the first tagged entry ``- [``).
-    - Split remaining entries into archive (older) and recent (newest).
-    - Deduplicate archive entries (exact match).
-    - Write back with ``## Archive`` and ``## Recent`` sections.
+    - Keep the newest entries verbatim.
+    - Replace older entries with a deterministic archive summary grouped by tag.
+    - Keep the final file under the configured line bound.
     """
     if not path.exists():
         return
@@ -165,23 +146,30 @@ def summarize_insights(path: Path) -> None:
     if len(pure_entries) <= INSIGHTS_RECENT_KEEP:
         return  # Not enough to warrant splitting.
 
-    # Split into archive and recent.
+    # Split into archive and recent. Archive details are intentionally replaced
+    # by a bounded index: old entries remain countable by type while recent,
+    # actionable knowledge stays verbatim.
     archive = pure_entries[:-INSIGHTS_RECENT_KEEP]
     recent = pure_entries[-INSIGHTS_RECENT_KEEP:]
 
-    # Deduplicate archive (preserve order, keep last occurrence).
-    seen: set[str] = set()
-    deduped_archive: list[str] = []
-    for line in reversed(archive):
-        key = line.strip()
-        if key not in seen:
-            seen.add(key)
-            deduped_archive.append(line)
-    deduped_archive.reverse()
+    tag_counts: Counter[str] = Counter()
+    for line in archive:
+        tag = "untagged"
+        for candidate in ("pitfall", "decision", "fact", "dependency", "perf", "config"):
+            if f"[{candidate}]" in line:
+                tag = candidate
+                break
+        tag_counts[tag] += 1
+
+    archive_summary = [
+        f"- Older entries compacted: {len(archive)} total; "
+        + ", ".join(f"{tag}={tag_counts[tag]}" for tag in sorted(tag_counts))
+        + "."
+    ]
 
     # Reassemble.
     result_lines = header_lines + ["", "## Archive", ""]
-    result_lines.extend(deduped_archive)
+    result_lines.extend(archive_summary)
     result_lines += ["", "## Recent", ""]
     result_lines.extend(recent)
     result_lines.append("")  # Trailing newline.

--- a/hooks/agent-recall-with-files/scripts/on_task_start.py
+++ b/hooks/agent-recall-with-files/scripts/on_task_start.py
@@ -5,20 +5,17 @@ Core behaviour:
 - ``context.md`` and ``trace.md`` are isolated by task id and created when missing.
 - ``insights.md`` is **preserved** if it already exists (cross-session experience).
   Only created from template when missing.
-- Old insights are compressed via ``summarize_insights`` when the file is too long.
+- Old insights are compacted via ``summarize_insights`` when the file is too long.
 """
 
 from common import (
     CONTEXT_FILE,
     HOOK_TAG,
     INSIGHTS_FILE,
-    LEGACY_ROOT_FILES,
     TRACE_FILE,
     output,
     persistent_insights_path,
-    project_root_dir,
     read_template,
-    remove_path,
     summarize_insights,
     task_workspace_dir,
 )
@@ -26,20 +23,8 @@ from common import (
 
 def main() -> None:
     workspace = task_workspace_dir()
-    project_root = project_root_dir()
-
-    # Clean up legacy artifacts from workspace root.
-    remove_path(project_root / ".planning")
-    for name in LEGACY_ROOT_FILES:
-        remove_path(project_root / name)
-
-    # Clean up legacy files with old names inside the runtime dir.
-    for old_name in ("progress.md", "findings.md"):
-        old_path = workspace / old_name
-        if old_path.exists():
-            remove_path(old_path)
-
-    # Ensure runtime directory exists (do NOT delete it — insights must survive).
+    # Runtime owns only this canonical workspace. Repository-root files may have
+    # the same names and must never be treated as disposable migration state.
     workspace.mkdir(parents=True, exist_ok=True)
 
     # Task files are fresh for a new task id and preserved on resume.
@@ -59,7 +44,7 @@ def main() -> None:
             read_template(INSIGHTS_FILE, "Insights"), encoding="utf-8",
         )
 
-    # Compress insights if they have grown too long.
+    # Compact insights if they have grown too long.
     if has_prior_insights:
         summarize_insights(persistent_insights)
 

--- a/hooks/agent-recall-with-files/templates/context.md
+++ b/hooks/agent-recall-with-files/templates/context.md
@@ -1,6 +1,6 @@
 # Context
 
-Current task state snapshot. Updated as the task progresses. Cleared on each new run.
+Current task state snapshot. Preserved on resume; a new task gets a new file.
 
 ## Goal
 

--- a/hooks/agent-recall-with-files/templates/trace.md
+++ b/hooks/agent-recall-with-files/templates/trace.md
@@ -1,6 +1,6 @@
 # Trace
 
-Ephemeral execution log for the current task. Cleared on each new run.
+Execution log for the current task. Preserved on resume; a new task gets a new file.
 
 ## Log
 - [YYYY-MM-DD HH:MM:SS] Task started.

--- a/skills/agent-recall-with-files/SKILL.md
+++ b/skills/agent-recall-with-files/SKILL.md
@@ -1,156 +1,93 @@
 ---
 name: agent-recall-with-files
-description: Cross-session experience recall via file-based memory. Agents accumulate insights (pitfalls, decisions, facts) that persist across runs, plus ephemeral context and trace files for the current task.
+description: Maintain task recovery notes and durable, cross-task Agent experience in canonical AgentLoom workspace files. Use for multi-step work that may resume after interruption, or when later tasks should reuse verified pitfalls, decisions, dependencies, and configuration facts. Skip one-shot answers and short lookups where recording would cost more than recovery.
 ---
 
 # Agent Recall With Files
 
-File-based memory instructions that let agents recall experience from previous sessions.
+Maintain three small Markdown files with different lifecycles:
 
-This Skill only teaches the recording workflow. The separately configured
-`agent-recall-with-files` Hook Bundle can bootstrap files, inject exact paths, and
-surface recent context, but loading this Skill never executes Hook code.
+| File | Lifecycle | Question answered |
+|---|---|---|
+| `tasks/<task_id>/context.md` | Current task; preserved on resume | What is the goal and current state? |
+| `tasks/<task_id>/trace.md` | Current task; preserved on resume | What meaningful actions just happened? |
+| `insights.md` | Same Application and Agent across tasks | What verified knowledge should future tasks reuse? |
 
-## When to Use
+Use the exact paths supplied in AgentLoom runtime context. Do not reconstruct the
+project root or invent Agent aliases such as `supervisor` and `worker`.
 
-Use this skill when:
+## Activation boundary
 
-- The task has multiple steps or phases and can drift out of short-term context.
-- You want agents to learn from past runs — avoid repeated pitfalls, remember key decisions.
-- The agent might be interrupted or restarted mid-task and needs fast context recovery.
-- You need a durable execution trace in the canonical AgentLoom workspace.
+Loading this Skill adds instructions only. It does not execute scripts or grant
+file access. AgentLoom discovers root and Application Skills automatically; the
+model activates this body with `skill(name="agent-recall-with-files")` when the
+task matches.
 
-Skip this skill when:
+The Hook Bundle is optional and separately authorized:
 
-- The task is a one-shot answer or quick lookup.
-- The work is so small that runtime bookkeeping would outweigh the task itself.
-
-## Runtime Files
-
-Files are split by lifecycle under `.agentloom/workspaces/agents/<application_id>/<agent_path>/`:
-
-| File | Lifecycle | Purpose |
-|------|-----------|---------|
-| `tasks/<task_id>/context.md` | Per task | Task goal, current status snapshot, remaining items. Preserved on resume. |
-| `tasks/<task_id>/trace.md` | Per task | Chronological action log. Preserved on resume. |
-| `insights.md` | **Cross-task** | Application/agent-scoped experience: pitfalls, decisions, facts. Never cleared automatically. |
-
-The framework injects the exact canonical workspace paths into hook processes. Skill code never discovers a project root or creates a second runtime root.
-
-In this repository the Skill lives at `AgentLoom/skills/agent-recall-with-files/`.
-
-Inside AgentLoom workflows it is referenced as `skills/agent-recall-with-files`.
-The optional Hook Bundle is independently referenced as
-`hooks/agent-recall-with-files`; neither interface enables the other.
-
-## Core Principle
-
-`context.md` answers: **what is my current task and where am I?**
-
-`trace.md` answers: **what did I just do?**
-
-`insights.md` answers: **what stable knowledge should survive across sessions?**
-
-Manual runtime recording is part of task execution, not cleanup to postpone until the end.
-
-## Insights Tag System
-
-Every entry in `insights.md` should follow this format:
-
-```
-- [YYYY-MM-DD] [tag] Specific, actionable description.
+```yaml
+hooks:
+  bundles:
+    agent-recall-with-files:
+      path: hooks/agent-recall-with-files
 ```
 
-Available tags:
+Enable the Bundle when the Agent should receive canonical paths, prior notes,
+and stale-record reminders automatically. Without it, use this workflow only
+when the task already exposes the three canonical paths and authorized file
+tools.
 
-| Tag | When to use |
-|-----|-------------|
-| `[pitfall]` | A mistake or trap that wasted time. Future agents should avoid it. |
-| `[decision]` | A deliberate choice with reasoning. Future agents should respect it. |
-| `[fact]` | A verified truth about the codebase, environment, or tooling. |
-| `[dependency]` | A version, library, or system requirement that matters. |
-| `[perf]` | A performance-related observation or optimization. |
-| `[config]` | A configuration detail that is easy to get wrong. |
+## Recording workflow
 
-## Required Routine
+1. Read existing `insights.md` before planning. Check `[pitfall]` entries first.
+2. Replace placeholders in `context.md` with the goal, current state, remaining
+   work, and key files. Add the task start to `trace.md`.
+3. Append to `trace.md` after a meaningful action: a completed scan, file change,
+   failed approach, or finished subtask.
+4. Refresh `context.md` when the current state or remaining work changes.
+5. Add to `insights.md` only after knowledge is verified and likely to matter in
+   another task. Do not add a “no new insights” entry.
+6. Before finishing, make `context.md` and `trace.md` reflect the final state.
 
-Follow this routine every time you use this skill:
+Use this format for durable entries:
 
-1. **Start with context and trace**
-   - Replace template placeholders in `context.md` with the actual task goal and scope.
-   - Add the first real entry to `trace.md`.
+```text
+- [YYYY-MM-DD] [tag] Specific fact, consequence, and reuse guidance.
+```
 
-2. **Review insights from previous sessions**
-   - If `insights.md` has content from prior runs, read it before planning your approach.
-   - Pay special attention to `[pitfall]` entries.
+| Tag | Durable knowledge |
+|---|---|
+| `[pitfall]` | A reproducible trap and how to avoid it |
+| `[decision]` | A choice plus the constraint or evidence behind it |
+| `[fact]` | A verified property of the codebase or environment |
+| `[dependency]` | A version or system requirement |
+| `[perf]` | A measured performance finding |
+| `[config]` | A configuration detail that is easy to misuse |
 
-3. **After each meaningful action, update `trace.md`**
-   - Meaningful actions: creating/updating files, finishing a scan, changing approach after an error, completing a subtask step.
+Keep entries short. Include concrete paths, commands, identifiers, or observed
+results when they make the knowledge reusable.
 
-4. **When task state changes, update `context.md`**
-   - Update the Current Status and Remaining sections.
-   - This is your recovery snapshot — keep it fresh.
+## Hook Bundle behavior
 
-5. **When something becomes durable, update `insights.md`**
-   - Durable items: confirmed pitfalls, stable decisions, verified facts, dependency constraints.
-   - Use the tag format. Be specific.
+When enabled, the Bundle:
 
-6. **Before finishing, self-check all three files**
-   - `context.md` must show task-specific content, not the template.
-   - `trace.md` must show task-specific actions.
-   - `insights.md` must contain either task-specific entries or an explicit note.
+- creates missing task files without overwriting resume state;
+- preserves Application/Agent-scoped `insights.md` across tasks;
+- injects full context, the latest 20 trace lines, and the latest 30 insight lines
+  before matched file, Shell, and search tools;
+- waits through steps 1–3, then reminds only when context or trace becomes stale;
+- compacts older insight entries into a bounded tag summary after 80 lines while
+  retaining the newest 30 entries verbatim;
+- leaves `Stop` default-allow, so recording never traps an Agent in a completion
+  loop;
+- never deletes similarly named files from the project root.
 
-## If You Have No Insights
-
-Do not leave `insights.md` untouched just because no insights emerged yet.
-
-Write an explicit note such as:
-
-- `- [YYYY-MM-DD] [fact] No new insights this session; task was straightforward.`
-
-That tells the next session the file was reviewed intentionally rather than forgotten.
-
-## Optional Hook Bundle Behavior
-
-When separately enabled, the Hook Bundle bootstrap:
-
-1. Removes legacy planning artifacts from the workspace root.
-2. Ensures the current `tasks/<task_id>/` workspace exists.
-3. Creates `context.md` and `trace.md` only when missing, so resume keeps task state.
-4. **Preserves `insights.md`** if it already has content (cross-task persistence).
-5. If `insights.md` exceeds the line threshold, compresses it via summarization.
-
-- `TaskCreated` creates ephemeral files and preserves insights. Returns prior-session notice if applicable.
-- `SubagentStart` bootstraps the runtime directory and template files for sub-agents (creates context.md, trace.md, insights.md if missing), then returns a progress-recording reminder. Existing files are never overwritten.
-- `SubagentStop` returns a reminder; it does not backfill agent-authored records.
-- `TaskCompleted` and `StopFailure` only return reminders. They do not write runtime files.
-- `PreToolUse` injects the full `context.md`, tail of `trace.md` (20 lines), and tail of `insights.md` (30 lines) into agent context. Empty-template files produce a brief "(no notes yet)" marker instead of the full template text.
-- `PostToolUse` uses a **freshness-driven reminder engine**: it tracks file modification times and only reminds when files become stale (not updated for N steps). Steps 1-3 are silent (grace period). Reminders have a cooldown to prevent spamming. The agent's current `step_number` arrives in versioned Hook stdin.
-- `Stop` is default-allow. This skill relies on agent discipline, not hard gating.
-- Hook `agent_context` is wrapped in `<system-reminder>` tags when it enters the next model turn.
-
-## Operating Rules
-
-- Keep entries short and concrete.
-- Update `trace.md` after meaningful execution steps.
-- Update `context.md` when task state changes (new goal, status shift, items completed).
-- Update `insights.md` only when you learn something worth keeping across sessions.
-- Use the tag format in `insights.md`.
-- Always use the exact current agent name in the runtime path.
-- Do not invent alias directories such as `supervisor` or `worker`.
-
-## Red Flags
-
-If you catch yourself thinking any of the following, stop and update runtime first:
-
-- "I'll finish the main task and backfill runtime later."
-- "The optional Hook Bundle already reminded me, so I can ignore it for now."
-- "There is no new insight, so `insights.md` can stay as the template."
-- "I saw a pitfall but it's too minor to record."
-
-These are the common ways runtime recording gets silently dropped.
+The Bundle does not observe every possible tool. MCP, Worker, and custom tool
+calls may require an explicit trace update before the next matched tool.
 
 ## References
 
-- [references/reference.md](references/reference.md)
-- [references/examples.md](references/examples.md)
+- Read [references/examples.md](references/examples.md) when you need concrete
+  examples of context, trace, and durable insight entries.
+- Read [references/reference.md](references/reference.md) when debugging file
+  lifecycle, template detection, compaction, or Hook coverage.

--- a/skills/agent-recall-with-files/references/examples.md
+++ b/skills/agent-recall-with-files/references/examples.md
@@ -86,12 +86,5 @@ The agent immediately knows to check thread-safety in the test setup, and avoids
 
 ## Example 5: No New Insights
 
-```md
-# Insights
-
-## Log
-- [2026-03-12] [pitfall] `TokenManager` is a singleton but not thread-safe...
-- [2026-03-13] [fact] No new insights this session; task was a straightforward test fix using the existing lock pattern.
-```
-
-Do not leave `insights.md` untouched. An explicit "no new insights" entry confirms the file was reviewed.
+Leave `insights.md` unchanged. Record task completion in `trace.md`; the durable
+file should contain only knowledge that another task can reuse.

--- a/skills/agent-recall-with-files/references/reference.md
+++ b/skills/agent-recall-with-files/references/reference.md
@@ -1,62 +1,48 @@
-# Reference
+# Runtime reference
 
-## Intent
+## Canonical layout
 
-This skill gives each agent a small, durable workspace under `.agentloom/workspaces/agents/<application_id>/<agent_path>/`.
-
-It enables cross-session experience recall — agents learn from past pitfalls and decisions.
-
-## File Roles
-
-| File | Lifecycle | Role |
-|------|-----------|------|
-| `tasks/<task_id>/context.md` | Per task | Task goal, current status, remaining items. Recovery snapshot. |
-| `tasks/<task_id>/trace.md` | Per task | Chronological execution log. Preserved when the task resumes. |
-| `insights.md` | **Cross-task** | Application/agent-scoped experience: pitfalls, decisions, facts. Tagged and dated. |
-
-## Template State Does Not Count
-
-If any file still looks like the original template, treat it as not updated yet.
-
-Examples of template state:
-
-- `trace.md` still contains only the placeholder timestamp line.
-- `context.md` still has `(What is this task trying to achieve?)` placeholders.
-- `insights.md` still contains only generic guidance bullets and no dated entries.
-
-## Insights Entry Format
-
-```
-- [YYYY-MM-DD] [tag] Specific, actionable description.
+```text
+.agentloom/workspaces/agents/<application_id>/<agent_path>/
+├── insights.md
+└── tasks/<task_id>/
+    ├── context.md
+    ├── trace.md
+    └── .write_tracker.json
 ```
 
-Tags: `[pitfall]` `[decision]` `[fact]` `[dependency]` `[perf]` `[config]`
+`context.md` and `trace.md` belong to one logical `task_id`. A resume preserves
+them. A new task receives new files. `insights.md` belongs to one Application and
+runtime Agent path and survives across tasks.
 
-## Recommended Entry Style
+## Template detection
 
-- Prefer short bullets.
-- Include concrete paths, commands, and identifiers.
-- Record failures once with the `[pitfall]` tag, then change approach.
-- Always tag insights — untagged entries are harder to scan.
+A missing, empty, or unchanged template file counts as unwritten. The Hook emits
+a short marker instead of injecting placeholder text. Task completion remains
+default-allow even when a file is stale.
 
-## Cross-Session Behaviour
+## Reminder thresholds
 
-- `insights.md` is **never automatically cleared**. It accumulates across task runs.
-- When it exceeds the line threshold (80 lines), `TaskCreated` compresses older entries into an `## Archive` section and keeps recent entries under `## Recent`.
-- `context.md` and `trace.md` are recreated from templates on each new task.
+- Steps 1–3: no PostToolUse reminder.
+- `trace.md`: gentle after 4 stale steps, urgent after 7.
+- `context.md`: gentle after 6 stale steps, urgent after 10.
+- Reminder cooldown: 3 steps.
+- `insights.md`: no staleness reminder; write only durable knowledge.
 
-## Minimum Self-Check Before Finishing
+PreToolUse and PostToolUse match the built-in file, Shell, and search tools named
+in `HOOK.yaml`. They do not intercept arbitrary MCP, Worker, Skill, or custom
+tools.
 
-- `context.md` contains task-specific content (not just template placeholders).
-- `trace.md` contains at least one task-specific action entry.
-- `trace.md` mentions the latest meaningful step or produced artifact.
-- `insights.md` contains either a dated insight entry or an explicit "no new insights" note.
-- All files use the exact canonical paths injected by the framework.
+## Insight compaction
 
-## Hook Summary
+At TaskCreated, a file over 80 lines keeps its newest 30 non-empty entries under
+`## Recent`. Older entries are replaced by one deterministic count grouped by
+tag under `## Archive`. This is lossy bounding, not model-generated synthesis.
 
-- `TaskCreated` bootstraps missing task files and preserves `insights.md` plus resume state.
-- `PreToolUse` injects full `context.md`, recent `trace.md` (20 lines), recent `insights.md` (30 lines).
-- `PostToolUse` reminds the agent to record meaningful changes.
-- `SubagentStop` on failure emphasises logging pitfalls in `insights.md`.
-- `Stop` always allows; the skill depends on manual compliance rather than a hard gate.
+## Concurrency boundary
+
+Different runtime Agent paths have separate `insights.md` files. Concurrent
+tasks using the same Application and Agent path share one file. Serialize those
+tasks: both manual edits and automatic TaskCreated compaction use unlocked
+read/write cycles, so overlapping writers can lose entries. Safe concurrency
+requires a future lock or atomic merge implementation.

--- a/skills/agent-recall-with-files/templates/context.md
+++ b/skills/agent-recall-with-files/templates/context.md
@@ -1,6 +1,6 @@
 # Context
 
-Current task state snapshot. Updated as the task progresses. Cleared on each new run.
+Current task state snapshot. Preserved on resume; a new task gets a new file.
 
 ## Goal
 

--- a/skills/agent-recall-with-files/templates/trace.md
+++ b/skills/agent-recall-with-files/templates/trace.md
@@ -1,6 +1,6 @@
 # Trace
 
-Ephemeral execution log for the current task. Cleared on each new run.
+Execution log for the current task. Preserved on resume; a new task gets a new file.
 
 ## Log
 - [YYYY-MM-DD HH:MM:SS] Task started.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,7 +6,7 @@ from src.encoding.terminal import configure_terminal_encoding
 
 configure_terminal_encoding()
 
-__version__ = "0.1.0"
+__version__ = "1.0.1"
 
 _LAZY_EXPORTS = {
     "C": ("src.lib.config", "C"),

--- a/tests/skills_test/test_state_aware_reminder.py
+++ b/tests/skills_test/test_state_aware_reminder.py
@@ -33,6 +33,7 @@ from common import (  # noqa: E402
     is_template_only,
     load_write_tracker,
     save_write_tracker,
+    summarize_insights,
 )
 
 
@@ -224,6 +225,30 @@ class TestWriteTracker(unittest.TestCase):
             self.tmpdir, tracker, step=9, persistent_insights=self.tmpdir / INSIGHTS_FILE
         )
         self.assertEqual(staleness[TRACE_FILE], 0)  # Fresh again.
+
+
+class TestInsightCompaction(unittest.TestCase):
+    def test_old_entries_are_replaced_by_bounded_tag_summary(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / INSIGHTS_FILE
+            entries = [
+                f"- [2026-08-12] [fact] Durable fact {index}."
+                for index in range(100)
+            ]
+            path.write_text(
+                "# Insights\n\n## Log\n" + "\n".join(entries) + "\n",
+                encoding="utf-8",
+            )
+
+            summarize_insights(path)
+
+            compacted = path.read_text(encoding="utf-8")
+            self.assertLessEqual(len(compacted.splitlines()), 80)
+            self.assertIn("Older entries compacted: 70 total; fact=70.", compacted)
+            self.assertNotIn("Durable fact 0.", compacted)
+            self.assertIn("Durable fact 99.", compacted)
 
 
 class TestPostToolUseBehavior(unittest.TestCase):


### PR DESCRIPTION
## Why

The landing documentation buried AgentLoom's differentiators, gave the Studio little visual or operational coverage, and let the English and Chinese guides drift. The Recall package also described behavior that did not match its runtime and its TaskCreated hook could delete unrelated project-root files.

## What changed

- Rewrite the English and Chinese landing READMEs around the execution contract, typed Workers, canonical Run evidence, Goal ownership, memory review boundaries, and explicit extension authority.
- Add a real reduced-motion Application Studio terminal capture and expand the TUI guide with workspace, Agent Loop, permissions, sessions, models, revisions, Runs, Goals, navigation, schedules, and architecture.
- Clarify the Recall Skill/Hook activation boundary, canonical file lifecycles, Hook coverage, lossy compaction, and same-Agent-path concurrency limit.
- Stop Recall TaskCreated from deleting similarly named project files, and replace unbounded archive rewriting with deterministic bounded compaction that keeps the newest 30 insights.
- Align Python, TUI package, and compiled CLI versions at `1.0.1`; the TUI build now reads the canonical version from `pyproject.toml`.
- Update regression tests for discovered Skills, non-destructive bootstrap, and bounded insight compaction.

## Review

Two independent review agents audited the final documentation:

- English technical accuracy and open-source first impression: **ready to merge** after fixes.
- Chinese accuracy, terminology, and naturalness: **ready to merge** after fixes.

Their findings prompted concrete corrections to checkpoint prerequisites, optional runtime files, preflight Run semantics, Self-Learning approval policy, model-profile examples, `execute_app()` naming, and Recall concurrency guidance.

## Validation

- `uv run pytest -q tests/skills_test/test_visualization_skill.py tests/skills_test/test_state_aware_reminder.py applications/test_demo/test_recall_skill_bash_command.py` — 40 passed
- `uv run pytest -q tests/tui_bridge_test` — 190 passed
- `cd agentloom-tui && bun run test` — 199 passed
- `cd agentloom-tui && bun run typecheck`
- `cd agentloom-tui && bun run build --outfile /tmp/agentloom-pr-final` — standalone smoke reports `1.0.1`
- `uv run ruff check ...` for changed Python files
- `quick_validate.py skills/agent-recall-with-files` — valid
- Local Markdown link check and `git diff --check`

## Maintainer decisions / follow-ups

- The repository has no root `LICENSE`, while `agentloom-tui/package.json` says `UNLICENSED`. This materially limits external adoption, but this PR does not choose legal terms on the maintainers' behalf.
- The PR adds a real static Studio capture. A short GIF/WebM showing the complete inspect → Diff → permission → Run → evidence → repair loop would be a stronger follow-up asset.
